### PR TITLE
fix: server security hardening and code cleanup

### DIFF
--- a/packages/server/src/mcp/mcpServer.ts
+++ b/packages/server/src/mcp/mcpServer.ts
@@ -149,6 +149,11 @@ function createMcpServerInstance(userId: string, keyScope: string, rawKey: strin
           fetchInit.body = JSON.stringify(args);
         }
 
+        const urlObj = new URL(url);
+        if (urlObj.hostname !== "localhost" && urlObj.hostname !== "127.0.0.1") {
+          throw new Error("Dynamic tool URLs must target localhost");
+        }
+
         const response = await fetch(url, fetchInit);
         const text = await response.text();
         if (!response.ok) {

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -102,6 +102,11 @@ export function createSettingsRouter(): Router {
       const user = requireUser(req);
       const key = req.params.key as string;
 
+      if (!/^[a-zA-Z0-9_.-]{1,100}$/.test(key)) {
+        res.status(400).json({ error: "Invalid setting key format" });
+        return;
+      }
+
       const ADMIN_ONLY_KEYS = ["registration_mode"];
       if (ADMIN_ONLY_KEYS.includes(key)) {
         res.status(403).json({ error: "This setting requires admin access" });

--- a/packages/server/src/routes/sync.ts
+++ b/packages/server/src/routes/sync.ts
@@ -1,13 +1,43 @@
 import { Router, Request, Response } from "express";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { z } from "zod";
 import { prisma } from "../prisma.js";
 import { requireUser, requireScope } from "../middleware/auth.js";
 import { getUserNotesDir } from "../services/userNotesDir.js";
 import { writeNote, deleteNote } from "../services/noteService.js";
+import { createLogger } from "../lib/logger.js";
+
+const log = createLogger("sync");
 
 export function createSyncRouter(notesDir: string): Router {
   const router = Router();
+
+  const syncPushSchema = z.object({
+    changes: z.object({
+      notes: z.object({
+        created: z.array(z.object({ path: z.string().min(1).max(500), content: z.string().max(5_000_000) })).max(500).default([]),
+        updated: z.array(z.object({ path: z.string().min(1).max(500), content: z.string().max(5_000_000) })).max(500).default([]),
+        deleted: z.array(z.string().max(500)).max(500).default([]),
+      }).default({}),
+      settings: z.object({
+        created: z.array(z.any()).max(100).default([]),
+        updated: z.array(z.any()).max(100).default([]),
+        deleted: z.array(z.string()).max(100).default([]),
+      }).default({}),
+      note_shares: z.object({
+        created: z.array(z.any()).max(100).default([]),
+        updated: z.array(z.any()).max(100).default([]),
+        deleted: z.array(z.string()).max(100).default([]),
+      }).default({}),
+      trash_items: z.object({
+        created: z.array(z.any()).max(100).default([]),
+        updated: z.array(z.any()).max(100).default([]),
+        deleted: z.array(z.string()).max(100).default([]),
+      }).default({}),
+    }).default({}),
+    last_pulled_at: z.number().default(0),
+  });
 
   // POST /api/sync/pull
   router.post("/pull", async (req: Request, res: Response) => {
@@ -111,7 +141,7 @@ export function createSyncRouter(notesDir: string): Router {
         }
       }
 
-      // Build WatermelonDB response
+      // Build sync response
       // On first sync everything goes in "created"; otherwise everything goes in "updated"
       const notesChanges = isFirstSync
         ? { created: noteRecords, updated: [], deleted: deletedNotes }
@@ -139,7 +169,7 @@ export function createSyncRouter(notesDir: string): Router {
         timestamp,
       });
     } catch (err) {
-      console.error("[sync]", err);
+      log.error(err);
       res.status(500).json({ error: err instanceof Error ? err.message : "Sync pull failed" });
     }
   });
@@ -151,7 +181,12 @@ export function createSyncRouter(notesDir: string): Router {
       requireScope(req, "read-write");
       const userId = user.id;
 
-      const changes = req.body?.changes ?? {};
+      const parsed = syncPushSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: "Invalid sync payload", details: parsed.error.issues });
+        return;
+      }
+      const { changes } = parsed.data;
       const userDir = await getUserNotesDir(notesDir, userId);
 
       // --- Notes ---
@@ -164,7 +199,7 @@ export function createSyncRouter(notesDir: string): Router {
         try {
           await writeNote(userDir, note.path, note.content ?? "", userId);
         } catch (err) {
-          console.error("[sync] Failed to write note", note.path, err);
+          log.error("Failed to write note", note.path, err);
         }
       }
 
@@ -172,7 +207,7 @@ export function createSyncRouter(notesDir: string): Router {
         try {
           await deleteNote(userDir, notePath, userId);
         } catch (err) {
-          console.error("[sync] Failed to delete note", notePath, err);
+          log.error("Failed to delete note", notePath, err);
         }
       }
 
@@ -189,7 +224,7 @@ export function createSyncRouter(notesDir: string): Router {
             create: { key: setting.key, userId, value: setting.value },
           });
         } catch (err) {
-          console.error("[sync] Failed to upsert setting", setting.key, err);
+          log.error("Failed to upsert setting", setting.key, err);
         }
       }
 
@@ -197,7 +232,7 @@ export function createSyncRouter(notesDir: string): Router {
 
       res.json({});
     } catch (err) {
-      console.error("[sync]", err);
+      log.error(err);
       res.status(500).json({ error: err instanceof Error ? err.message : "Sync push failed" });
     }
   });

--- a/packages/server/src/services/noteService.ts
+++ b/packages/server/src/services/noteService.ts
@@ -5,6 +5,8 @@ import { updateGraphCache, removeFromGraph, renameInGraph } from "./graphService
 import { moveToTrash } from "../routes/trash.js";
 import { saveHistorySnapshot } from "../routes/history.js";
 import type { PluginWebSocket } from "../plugins/PluginWebSocket.js";
+import { prisma } from "../prisma.js";
+import { createLogger } from "../lib/logger.js";
 
 // Optional WebSocket instance for broadcasting graph updates
 let pluginWs: PluginWebSocket | null = null;
@@ -16,8 +18,6 @@ let pluginWs: PluginWebSocket | null = null;
 export function setGraphWebSocket(ws: PluginWebSocket): void {
   pluginWs = ws;
 }
-import { prisma } from "../prisma.js";
-import { createLogger } from "../lib/logger.js";
 
 const log = createLogger("note-service");
 


### PR DESCRIPTION
## Security
- **S4**: Zod validation on sync push payload (size/count limits)
- **S5**: Settings key format validation (regex)
- **S6**: MCP dynamic tool loopback URL validation

## Code Cleanup
- **A8**: Structured logger in sync route (replaces console.error)
- **A10**: Removed stale WatermelonDB comment
- **A11**: Fixed import ordering in noteService.ts