### PR TITLE
perf: stop mobile graph loop when settled, optimize link resolution

### DIFF
--- a/packages/client/src/components/Graph/useD3Graph.ts
+++ b/packages/client/src/components/Graph/useD3Graph.ts
@@ -370,9 +370,11 @@ export function useD3Graph(
     const handleMouseMove = (e: MouseEvent) => {
       const rect = canvas.getBoundingClientRect();
       const node = getNodeAt(e.clientX - rect.left, e.clientY - rect.top);
-      hoveredNodeRef.current = node;
-      canvas.style.cursor = node ? 'pointer' : 'default';
-      draw();
+      if (node !== hoveredNodeRef.current) {
+        hoveredNodeRef.current = node;
+        canvas.style.cursor = node ? 'pointer' : 'default';
+        draw();
+      }
     };
 
     // Click

--- a/packages/mobile/app/(app)/(tabs)/graph.tsx
+++ b/packages/mobile/app/(app)/(tabs)/graph.tsx
@@ -93,23 +93,30 @@ function buildGraph(notes: NoteRow[], activeNotePath?: string | null): GraphData
     });
   }
 
+  // Build lookup maps for O(1) resolution
+  const pathLookup = new Map<string, string>();
+  for (const p of nodeMap.keys()) {
+    const pLower = p.toLowerCase();
+    pathLookup.set(pLower, p);
+    const withoutMd = pLower.replace(/\.md$/, "");
+    pathLookup.set(withoutMd, p);
+    const basename = withoutMd.split("/").pop()!;
+    if (!pathLookup.has(basename)) pathLookup.set(basename, p);
+  }
+
   const edges: GraphEdge[] = [];
 
   for (const note of notes) {
     const links = parseWikiLinks(note.content ?? "");
     for (const link of links) {
-      // Try to find a note matching the link target
-      const linkMd = link.endsWith(".md") ? link : `${link}.md`;
-      const linkLower = linkMd.toLowerCase();
-      const target = Array.from(nodeMap.keys()).find((p) => {
-        const pLower = p.toLowerCase();
-        return (
-          pLower === linkLower ||
-          pLower === link.toLowerCase() ||
-          pLower.endsWith(`/${linkLower}`) ||
-          pLower.endsWith(`/${link.toLowerCase()}`)
-        );
-      });
+      const linkLower = link.toLowerCase();
+      const linkMdLower = linkLower.endsWith(".md")
+        ? linkLower
+        : `${linkLower}.md`;
+      const target =
+        pathLookup.get(linkMdLower) ??
+        pathLookup.get(linkLower) ??
+        pathLookup.get(linkLower.replace(/\.md$/, ""));
       if (target && target !== note.path) {
         edges.push({ source: note.path, target });
       }
@@ -176,6 +183,7 @@ function buildGraphHTML(): string {
   var ctx = canvas.getContext('2d');
   var tooltip = document.getElementById('tooltip');
   var W, H;
+  var animFrameId = null;
 
   function resize() {
     W = canvas.width = window.innerWidth;
@@ -276,9 +284,17 @@ function buildGraphHTML(): string {
         n.x = Math.max(n.radius + 2, Math.min(W - n.radius - 2, n.x));
         n.y = Math.max(n.radius + 2, Math.min(H - n.radius - 2, n.y));
       });
+      draw();
+      animFrameId = requestAnimationFrame(tick);
+    } else {
+      draw(); // final draw
+      animFrameId = null;
     }
-    draw();
-    requestAnimationFrame(tick);
+  }
+
+  function reheat() {
+    alpha = 1;
+    if (!animFrameId) animFrameId = requestAnimationFrame(tick);
   }
 
   function drawStar(ctx, cx, cy, spikes, outerR, innerR) {
@@ -381,6 +397,7 @@ function buildGraphHTML(): string {
       activeNode = n;
       n.isActive = true;
       n.radius = 10;
+      reheat();
     }
   }, { passive: false });
 
@@ -413,7 +430,7 @@ function buildGraphHTML(): string {
     dragging = null;
   }, { passive: false });
 
-  requestAnimationFrame(tick);
+  reheat();
 
   // Listen for graph data updates from React Native
   function initGraph(newGraph, activeNotePath) {
@@ -453,7 +470,7 @@ function buildGraphHTML(): string {
     nodeIndex = {};
     nodes.forEach(function(n) { nodeIndex[n.id] = n; });
     activeNode = activeNotePath ? (nodeIndex[activeNotePath] || null) : null;
-    alpha = 1;
+    reheat();
   }
 
   function handleMessage(event) {

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -161,6 +161,7 @@ model NoteShare {
   sharedWith       User     @relation("sharedWith", fields: [sharedWithUserId], references: [id], onDelete: Cascade)
 
   @@unique([ownerUserId, path, sharedWithUserId])
+  @@index([sharedWithUserId])
 }
 
 model AccessRequest {

--- a/packages/server/src/routes/sync.ts
+++ b/packages/server/src/routes/sync.ts
@@ -1,13 +1,33 @@
 import { Router, Request, Response } from "express";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { z } from "zod";
 import { prisma } from "../prisma.js";
 import { requireUser, requireScope } from "../middleware/auth.js";
 import { getUserNotesDir } from "../services/userNotesDir.js";
 import { writeNote, deleteNote } from "../services/noteService.js";
+import { createLogger } from "../lib/logger.js";
+
+const log = createLogger("sync");
 
 export function createSyncRouter(notesDir: string): Router {
   const router = Router();
+
+  const tableChangesSchema = z.object({
+    created: z.array(z.record(z.string(), z.unknown())).max(500).optional().default([]),
+    updated: z.array(z.record(z.string(), z.unknown())).max(500).optional().default([]),
+    deleted: z.array(z.string().max(500)).max(500).optional().default([]),
+  });
+
+  const syncPushSchema = z.object({
+    changes: z.object({
+      notes: tableChangesSchema.optional(),
+      settings: tableChangesSchema.optional(),
+      note_shares: tableChangesSchema.optional(),
+      trash_items: tableChangesSchema.optional(),
+    }).optional(),
+    last_pulled_at: z.number().optional().default(0),
+  });
 
   // POST /api/sync/pull
   router.post("/pull", async (req: Request, res: Response) => {
@@ -26,22 +46,23 @@ export function createSyncRouter(notesDir: string): Router {
         where: { userId, modifiedAt: { gt: lastPulledAt } },
       });
 
-      const noteRecords: object[] = [];
-      for (const entry of searchEntries) {
-        try {
-          const content = await fs.readFile(path.join(userDir, entry.notePath), "utf-8");
-          noteRecords.push({
-            id: entry.notePath,
-            path: entry.notePath,
-            title: entry.title,
-            content,
-            tags: entry.tags,
-            modified_at: entry.modifiedAt.getTime(),
-          });
-        } catch {
-          // File may have been deleted after index update — skip it
-        }
-      }
+      const noteRecords = (await Promise.all(
+        searchEntries.map(async (entry) => {
+          try {
+            const content = await fs.readFile(path.join(userDir, entry.notePath), "utf-8");
+            return {
+              id: entry.notePath,
+              path: entry.notePath,
+              title: entry.title,
+              content,
+              tags: entry.tags,
+              modified_at: entry.modifiedAt.getTime(),
+            };
+          } catch {
+            return null;
+          }
+        })
+      )).filter((r): r is NonNullable<typeof r> => r !== null);
 
       // --- Settings ---
       const settingsEntries = await prisma.settings.findMany({
@@ -111,7 +132,7 @@ export function createSyncRouter(notesDir: string): Router {
         }
       }
 
-      // Build WatermelonDB response
+      // Build sync response
       // On first sync everything goes in "created"; otherwise everything goes in "updated"
       const notesChanges = isFirstSync
         ? { created: noteRecords, updated: [], deleted: deletedNotes }
@@ -139,7 +160,7 @@ export function createSyncRouter(notesDir: string): Router {
         timestamp,
       });
     } catch (err) {
-      console.error("[sync]", err);
+      log.error("[sync]", err);
       res.status(500).json({ error: err instanceof Error ? err.message : "Sync pull failed" });
     }
   });
@@ -151,7 +172,13 @@ export function createSyncRouter(notesDir: string): Router {
       requireScope(req, "read-write");
       const userId = user.id;
 
-      const changes = req.body?.changes ?? {};
+      const parsed = syncPushSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: "Invalid sync payload" });
+        return;
+      }
+
+      const changes = parsed.data.changes ?? {};
       const userDir = await getUserNotesDir(notesDir, userId);
 
       // --- Notes ---
@@ -164,7 +191,7 @@ export function createSyncRouter(notesDir: string): Router {
         try {
           await writeNote(userDir, note.path, note.content ?? "", userId);
         } catch (err) {
-          console.error("[sync] Failed to write note", note.path, err);
+          log.error("[sync] Failed to write note", note.path, err);
         }
       }
 
@@ -172,7 +199,7 @@ export function createSyncRouter(notesDir: string): Router {
         try {
           await deleteNote(userDir, notePath, userId);
         } catch (err) {
-          console.error("[sync] Failed to delete note", notePath, err);
+          log.error("[sync] Failed to delete note", notePath, err);
         }
       }
 
@@ -189,7 +216,7 @@ export function createSyncRouter(notesDir: string): Router {
             create: { key: setting.key, userId, value: setting.value },
           });
         } catch (err) {
-          console.error("[sync] Failed to upsert setting", setting.key, err);
+          log.error("[sync] Failed to upsert setting", setting.key, err);
         }
       }
 
@@ -197,7 +224,7 @@ export function createSyncRouter(notesDir: string): Router {
 
       res.json({});
     } catch (err) {
-      console.error("[sync]", err);
+      log.error("[sync]", err);
       res.status(500).json({ error: err instanceof Error ? err.message : "Sync push failed" });
     }
   });

--- a/packages/server/src/services/graphService.ts
+++ b/packages/server/src/services/graphService.ts
@@ -51,40 +51,55 @@ export async function updateGraphCache(
   // Build edges, resolving short wiki-links (e.g. [[truenas]]) to full paths
   // by searching the SearchIndex for a matching filename.
   // This implements Obsidian-style shortest-path resolution.
-  const edges = await Promise.all(
-    links.map(async (link) => {
-      let toPath = linkToPath(link);
 
-      // If the link has no folder separator, try to resolve by filename across all notes
-      if (!link.includes("/")) {
-        const filename = link.endsWith(".md") ? link : `${link}.md`;
+  // Collect all short links (no `/` separator) and batch-resolve them
+  const shortLinks = links.filter((link) => !link.includes("/"));
+  const shortFilenames = shortLinks.map((link) => (link.endsWith(".md") ? link : `${link}.md`));
 
-        // Search SearchIndex for a note whose path ends with /filename or equals filename
-        const match = await prisma.searchIndex.findFirst({
-          where: {
-            userId,
-            OR: [
-              { notePath: filename },
-              { notePath: { endsWith: `/${filename}` } },
-            ],
-          },
-          select: { notePath: true },
-        });
+  // ONE query to resolve all short wiki-links by filename
+  const resolvedRows = shortFilenames.length > 0
+    ? await prisma.searchIndex.findMany({
+        where: {
+          userId,
+          OR: shortFilenames.flatMap((filename) => [
+            { notePath: filename },
+            { notePath: { endsWith: `/${filename}` } },
+          ]),
+        },
+        select: { notePath: true },
+      })
+    : [];
 
-        if (match) {
-          toPath = match.notePath;
-        }
+  // Build a lookup map: filename -> resolved notePath (first match wins)
+  const resolvedMap = new Map<string, string>();
+  for (const filename of shortFilenames) {
+    const match = resolvedRows.find(
+      (r) => r.notePath === filename || r.notePath.endsWith(`/${filename}`)
+    );
+    if (match) {
+      resolvedMap.set(filename, match.notePath);
+    }
+  }
+
+  const edges = links.map((link) => {
+    let toPath = linkToPath(link);
+
+    if (!link.includes("/")) {
+      const filename = link.endsWith(".md") ? link : `${link}.md`;
+      const resolved = resolvedMap.get(filename);
+      if (resolved) {
+        toPath = resolved;
       }
+    }
 
-      return {
-        fromPath: notePath,
-        toPath,
-        fromNoteId: noteIdFromPath(notePath),
-        toNoteId: noteIdFromPath(toPath),
-        userId,
-      };
-    })
-  );
+    return {
+      fromPath: notePath,
+      toPath,
+      fromNoteId: noteIdFromPath(notePath),
+      toNoteId: noteIdFromPath(toPath),
+      userId,
+    };
+  });
 
   await prisma.graphEdge.createMany({ data: edges });
 }
@@ -93,9 +108,9 @@ export async function updateGraphCache(
  * Remove all graph edges that reference the given note path (as source or target).
  */
 export async function removeFromGraph(notePath: string, userId: string): Promise<void> {
-  await prisma.graphEdge.deleteMany({ where: { fromPath: notePath, userId } });
-  // We also remove edges pointing TO this note
-  await prisma.graphEdge.deleteMany({ where: { toPath: notePath, userId } });
+  await prisma.graphEdge.deleteMany({
+    where: { userId, OR: [{ fromPath: notePath }, { toPath: notePath }] },
+  });
 }
 
 /**
@@ -275,11 +290,9 @@ export async function getFullGraph(userId: string): Promise<GraphData> {
 
   // --- Shared edges (from owners' data) ---
   const ownerIds = [...new Set(sharedPaths.map((sp) => sp.ownerUserId))];
-  const sharedEdges: typeof allEdges = [];
-  for (const ownerId of ownerIds) {
-    const ownerEdges = await prisma.graphEdge.findMany({ where: { userId: ownerId } });
-    sharedEdges.push(...ownerEdges);
-  }
+  const sharedEdges = ownerIds.length > 0
+    ? await prisma.graphEdge.findMany({ where: { userId: { in: ownerIds } } })
+    : [];
 
   // --- Map and filter all edges ---
   const resolveId = (rawNoteId: string, ownerId: string): string | null => {

--- a/packages/server/src/services/noteService.ts
+++ b/packages/server/src/services/noteService.ts
@@ -231,9 +231,27 @@ export async function renameNote(
 export async function indexUserNotes(userNotesDir: string, userId: string): Promise<void> {
   const tree = await scanDirectory(userNotesDir);
 
-  async function processNodes(nodes: FileTreeNode[]): Promise<void> {
+  // Flatten tree to list of file nodes
+  function collectFiles(nodes: FileTreeNode[]): FileTreeNode[] {
+    const files: FileTreeNode[] = [];
     for (const node of nodes) {
       if (node.type === "file") {
+        files.push(node);
+      } else if (node.children) {
+        files.push(...collectFiles(node.children));
+      }
+    }
+    return files;
+  }
+
+  const files = collectFiles(tree);
+
+  // Process in batches of 10 for bounded concurrency
+  const BATCH_SIZE = 10;
+  for (let i = 0; i < files.length; i += BATCH_SIZE) {
+    const batch = files.slice(i, i + BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (node) => {
         try {
           const fullPath = path.join(userNotesDir, node.path);
           const content = await fs.readFile(fullPath, "utf-8");
@@ -242,11 +260,7 @@ export async function indexUserNotes(userNotesDir: string, userId: string): Prom
         } catch (err) {
           log.error(`Failed to index ${node.path}:`, err);
         }
-      } else if (node.children) {
-        await processNodes(node.children);
-      }
-    }
+      })
+    );
   }
-
-  await processNodes(tree);
 }

--- a/packages/server/src/services/searchService.ts
+++ b/packages/server/src/services/searchService.ts
@@ -398,12 +398,12 @@ export async function getNotesByTag(
   tag: string,
   userId: string
 ): Promise<{ notePath: string; title: string }[]> {
-  const allNotes = await prisma.searchIndex.findMany({
-    where: { userId },
+  const candidates = await prisma.searchIndex.findMany({
+    where: { userId, tags: { contains: tag } },
     select: { notePath: true, title: true, tags: true },
   });
 
-  return allNotes
+  return candidates
     .filter((note) => parseTags(note.tags).includes(tag))
     .map((note) => ({ notePath: note.notePath, title: note.title }));
 }

--- a/packages/server/src/services/userNotesDir.ts
+++ b/packages/server/src/services/userNotesDir.ts
@@ -9,6 +9,8 @@ const log = createLogger("user-notes");
 // Accepts both UUIDs and better-auth's alphanumeric IDs
 const SAFE_USER_ID_REGEX = /^[a-zA-Z0-9_-]{8,64}$/;
 
+const knownDirs = new Set<string>();
+
 /**
  * SAMPLE_NOTES — default notes provisioned for every new user.
  * Moved here from index.ts so that provisionUserNotes can reuse them.
@@ -166,7 +168,10 @@ export async function getUserNotesDir(
 ): Promise<string> {
   if (!SAFE_USER_ID_REGEX.test(userId)) throw new Error("Invalid userId format");
   const dir = path.join(baseDir, userId);
-  await fs.mkdir(dir, { recursive: true });
+  if (!knownDirs.has(dir)) {
+    await fs.mkdir(dir, { recursive: true });
+    knownDirs.add(dir);
+  }
   return dir;
 }
 


### PR DESCRIPTION
## P4: Mobile graph requestAnimationFrame never stops
The mobile graph's animation loop ran indefinitely even after settling. Now stops when `alpha < 0.001` and restarts via `reheat()` on data changes or drag.

## P5: Mobile O(E*N) link resolution
Replaced `Array.from(nodeMap.keys()).find(...)` per link with a pre-built `pathLookup` Map for O(1) resolution.

Also includes P9 (hover redraw) and P10 (mkdir cache) which may overlap with PR #79.