### PR TITLE
fix(graph): keep dragged nodes pinned where dropped

### DIFF
--- a/packages/client/src/components/Graph/useD3Graph.ts
+++ b/packages/client/src/components/Graph/useD3Graph.ts
@@ -407,11 +407,7 @@ export function useD3Graph(
 
     const handleMouseUp = () => {
       if (dragNode) {
-        // Don't unpin active node in local mode
-        if (!(useLocalLayout && dragNode.path === activeNotePath)) {
-          dragNode.fx = null;
-          dragNode.fy = null;
-        }
+        // Keep node pinned where user dropped it (fx/fy stay set)
         dragNode = null;
         simulation.alphaTarget(0);
         d3Canvas.call(zoom);


### PR DESCRIPTION
Nodes now stay where you drop them instead of snapping back. The fx/fy pin is kept after mouseup so simulation forces don't pull the node back to its natural position.