### PR TITLE
fix(server): refresh openapi snapshot (drift on master)

### DIFF
--- a/packages/server/openapi.snapshot.json
+++ b/packages/server/openapi.snapshot.json
@@ -2456,7 +2456,7 @@
             "description": "Default Response"
           }
         },
-        "summary": "Delete an empty folder",
+        "summary": "Delete a folder (recursively trashes any notes inside)",
         "tags": [
           "notes"
         ]


### PR DESCRIPTION
Pre-existing snapshot drift on master — the folder DELETE summary was updated in 066bef9 but the OpenAPI snapshot wasn't refreshed at the time. Re-running `npm run openapi:dump` produces the corrected file.

Single-line diff: `Delete an empty folder` → `Delete a folder (recursively trashes any notes inside)`.

This fix unblocks CI for downstream PRs (#93 and #94 currently fail `OpenAPI snapshot drift check`).