### PR TITLE
feat(editor/state): yjs binding + cursor awareness

### DIFF
--- a/packages/ui/src/editor/state/__tests__/awareness.test.ts
+++ b/packages/ui/src/editor/state/__tests__/awareness.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import * as Y from "yjs";
+import { Awareness } from "y-protocols/awareness";
+import { createCursorAwareness } from "../awareness";
+
+describe("cursor awareness", () => {
+  it("publishes local cursor selection to awareness", () => {
+    const ydoc = new Y.Doc();
+    const aware = new Awareness(ydoc);
+    const ca = createCursorAwareness(aware, "user-1", "Pascal", "#aabbcc");
+    ca.publish({ anchor: 5, head: 7 });
+    const states = aware.getStates();
+    const local = states.get(aware.clientID)!;
+    expect(local.cursor).toEqual({ anchor: 5, head: 7 });
+    expect(local.user).toEqual({ id: "user-1", name: "Pascal", color: "#aabbcc" });
+    ca.dispose();
+  });
+
+  it("collects remote cursors from awareness state", () => {
+    const ydoc = new Y.Doc();
+    const aware = new Awareness(ydoc);
+    aware.setLocalState({ user: { id: "u1", name: "A", color: "#111" }, cursor: { anchor: 1, head: 1 } });
+    // Simulate a remote client by setting a state under a different clientID
+    aware.states.set(999, { user: { id: "u2", name: "B", color: "#222" }, cursor: { anchor: 3, head: 5 } });
+    const ca = createCursorAwareness(aware, "u1", "A", "#111");
+    const remotes = ca.remotes();
+    expect(remotes).toContainEqual({
+      clientId: 999, user: { id: "u2", name: "B", color: "#222" }, cursor: { anchor: 3, head: 5 },
+    });
+    ca.dispose();
+  });
+});

--- a/packages/ui/src/editor/state/__tests__/yjsBinding.test.ts
+++ b/packages/ui/src/editor/state/__tests__/yjsBinding.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import * as Y from "yjs";
+import { createEditorState } from "../transaction";
+import { createYjsBinding } from "../yjsBinding";
+
+describe("yjs binding", () => {
+  it("local insert is reflected into Y.Text", () => {
+    const ydoc = new Y.Doc();
+    const ytext = ydoc.getText("body");
+    let state = createEditorState("");
+    const binding = createYjsBinding(ytext, () => state, (s) => { state = s; });
+
+    binding.applyLocal({ ops: [{ kind: "insert", at: 0, text: "hello" }], selection: { anchor: 5, head: 5 } });
+    expect(ytext.toString()).toBe("hello");
+    expect(state.doc).toBe("hello");
+    binding.dispose();
+  });
+
+  it("remote Y.Text op is reflected into a Transaction on local state", () => {
+    const ydoc1 = new Y.Doc();
+    const ytext1 = ydoc1.getText("body");
+    let state1 = createEditorState("");
+    const binding1 = createYjsBinding(ytext1, () => state1, (s) => { state1 = s; });
+
+    const ydoc2 = new Y.Doc();
+    const ytext2 = ydoc2.getText("body");
+    let state2 = createEditorState("");
+    const binding2 = createYjsBinding(ytext2, () => state2, (s) => { state2 = s; });
+
+    // Wire two docs together via update messages.
+    ydoc1.on("update", (u: Uint8Array) => Y.applyUpdate(ydoc2, u));
+    ydoc2.on("update", (u: Uint8Array) => Y.applyUpdate(ydoc1, u));
+
+    binding1.applyLocal({ ops: [{ kind: "insert", at: 0, text: "from-1" }], selection: { anchor: 6, head: 6 } });
+    expect(state2.doc).toBe("from-1");
+
+    binding2.applyLocal({ ops: [{ kind: "insert", at: 6, text: "/2" }], selection: { anchor: 8, head: 8 } });
+    expect(state1.doc).toBe("from-1/2");
+
+    binding1.dispose();
+    binding2.dispose();
+  });
+
+  it("offsets shift correctly when a remote insert lands before the local caret", () => {
+    const ydoc1 = new Y.Doc();
+    const ytext1 = ydoc1.getText("body");
+    let state1 = createEditorState("hello", { anchor: 5, head: 5 });
+    const binding1 = createYjsBinding(ytext1, () => state1, (s) => { state1 = s; });
+    ytext1.insert(0, "[1]"); // simulate a remote applyUpdate path
+
+    expect(state1.doc).toBe("[1]hello");
+    expect(state1.selection).toEqual({ anchor: 8, head: 8 });
+    binding1.dispose();
+  });
+
+  it("dispose unsubscribes Y.Text observer", () => {
+    const ydoc = new Y.Doc();
+    const ytext = ydoc.getText("body");
+    let state = createEditorState("");
+    const binding = createYjsBinding(ytext, () => state, (s) => { state = s; });
+    binding.dispose();
+    ytext.insert(0, "ignored");
+    expect(state.doc).toBe(""); // observer was removed before insert
+  });
+});

--- a/packages/ui/src/editor/state/awareness.ts
+++ b/packages/ui/src/editor/state/awareness.ts
@@ -1,0 +1,50 @@
+// packages/ui/src/editor/state/awareness.ts
+import type { Awareness } from "y-protocols/awareness";
+import type { Selection } from "./types";
+
+export interface RemoteCursor {
+  clientId: number;
+  user: { id: string; name: string; color: string };
+  cursor: Selection;
+}
+
+export interface CursorAwareness {
+  publish(selection: Selection): void;
+  remotes(): RemoteCursor[];
+  onChange(cb: () => void): () => void;
+  dispose(): void;
+}
+
+export function createCursorAwareness(
+  awareness: Awareness, userId: string, userName: string, userColor: string,
+): CursorAwareness {
+  const localUser = { id: userId, name: userName, color: userColor };
+  awareness.setLocalStateField("user", localUser);
+
+  const subs = new Set<() => void>();
+  const onUpdate = () => subs.forEach((cb) => cb());
+  awareness.on("update", onUpdate);
+
+  return {
+    publish(selection) {
+      awareness.setLocalStateField("cursor", selection);
+    },
+    remotes() {
+      const out: RemoteCursor[] = [];
+      for (const [clientId, state] of awareness.getStates()) {
+        if (clientId === awareness.clientID) continue;
+        if (!state || !state.user || !state.cursor) continue;
+        out.push({ clientId, user: state.user, cursor: state.cursor });
+      }
+      return out;
+    },
+    onChange(cb) {
+      subs.add(cb);
+      return () => { subs.delete(cb); };
+    },
+    dispose() {
+      awareness.off("update", onUpdate);
+      subs.clear();
+    },
+  };
+}

--- a/packages/ui/src/editor/state/index.ts
+++ b/packages/ui/src/editor/state/index.ts
@@ -20,3 +20,8 @@ export {
   toggleBold, toggleItalic, toggleStrikethrough, toggleInlineCode,
   insertWikilink, insertHeading,
 } from "./commands";
+
+export type { YjsBinding } from "./yjsBinding";
+export { createYjsBinding } from "./yjsBinding";
+export type { CursorAwareness, RemoteCursor } from "./awareness";
+export { createCursorAwareness } from "./awareness";

--- a/packages/ui/src/editor/state/yjsBinding.ts
+++ b/packages/ui/src/editor/state/yjsBinding.ts
@@ -1,0 +1,108 @@
+// packages/ui/src/editor/state/yjsBinding.ts
+import * as Y from "yjs";
+import { applyTransaction, transactionFromOps, type EditorState, type Transaction } from "./transaction";
+import type { Operation } from "./operations";
+import type { Selection } from "./types";
+
+export interface YjsBinding {
+  /** Apply a local transaction; reflects ops into Y.Text inside a Y transaction. */
+  applyLocal(tr: Transaction): void;
+  /** Tear down the Y.Text observer. */
+  dispose(): void;
+}
+
+type SetState = (next: EditorState) => void;
+
+/**
+ * Wire a Y.Text to a getter/setter pair so the binding can read and replace
+ * the local EditorState as remote updates arrive.
+ */
+export function createYjsBinding(
+  ytext: Y.Text,
+  getState: () => EditorState,
+  setState: SetState,
+): YjsBinding {
+  let suppressObserver = false;
+  const ORIGIN = Symbol("kryton-editor");
+
+  function observer(event: Y.YTextEvent, transaction: Y.Transaction) {
+    if (suppressObserver) return;
+    if (transaction.origin === ORIGIN) return;
+    const ops: Operation[] = [];
+    let cursor = 0;
+    for (const delta of event.delta) {
+      if (typeof delta.retain === "number") {
+        cursor += delta.retain;
+      } else if (typeof delta.insert === "string") {
+        ops.push({ kind: "insert", at: cursor, text: delta.insert });
+        cursor += delta.insert.length;
+      } else if (typeof delta.delete === "number") {
+        ops.push({ kind: "delete", from: cursor, to: cursor + delta.delete });
+      }
+    }
+    if (ops.length === 0) return;
+    const before = getState();
+    const shiftedSelection = shiftSelection(before.selection, ops);
+    const next = applyTransaction(before, transactionFromOps(ops, shiftedSelection));
+    setState(next);
+  }
+
+  ytext.observe(observer);
+
+  return {
+    applyLocal(tr) {
+      const next = applyTransaction(getState(), tr);
+      setState(next);
+      suppressObserver = true;
+      try {
+        ytext.doc!.transact(() => {
+          for (const op of tr.ops) {
+            switch (op.kind) {
+              case "insert":
+                ytext.insert(op.at, op.text);
+                break;
+              case "delete":
+                ytext.delete(op.from, op.to - op.from);
+                break;
+              case "replace":
+                ytext.delete(op.from, op.to - op.from);
+                ytext.insert(op.from, op.text);
+                break;
+            }
+          }
+        }, ORIGIN);
+      } finally {
+        suppressObserver = false;
+      }
+    },
+    dispose() {
+      ytext.unobserve(observer);
+    },
+  };
+}
+
+/** Shift a Selection across a sequence of remote ops. */
+function shiftSelection(sel: Selection, ops: readonly Operation[]): Selection {
+  let { anchor, head } = sel;
+  for (const op of ops) {
+    if (op.kind === "insert") {
+      if (op.at <= anchor) anchor += op.text.length;
+      if (op.at <= head) head += op.text.length;
+    } else if (op.kind === "delete") {
+      const len = op.to - op.from;
+      if (op.to <= anchor) anchor -= len;
+      else if (op.from < anchor) anchor = op.from;
+      if (op.to <= head) head -= len;
+      else if (op.from < head) head = op.from;
+    } else if (op.kind === "replace") {
+      const oldLen = op.to - op.from;
+      const newLen = op.text.length;
+      const delta = newLen - oldLen;
+      if (op.to <= anchor) anchor += delta;
+      else if (op.from < anchor) anchor = op.from + newLen;
+      if (op.to <= head) head += delta;
+      else if (op.from < head) head = op.from + newLen;
+    }
+  }
+  return { anchor, head };
+}


### PR DESCRIPTION
Implements editor-yjs-binding sub-plan (depends on #94 state-core, now merged).

## Summary
- bidirectional Document ↔ Y.Text binding with selection shifting
- cursor awareness via y-protocols
- replaces y-codemirror.next at the state layer

## Test plan
- [ ] `cd packages/ui && npm test -- editor/state` shows 6 new tests PASS
- [ ] `grep -rn '@codemirror' packages/ui/src/editor/state/` returns empty (no CM6 imports)