### PR TITLE
feat(editor/view/ios): native uitextview editor for rn

### DIFF
--- a/packages/ui/src/editor/view/EditorView.platform.native.ts
+++ b/packages/ui/src/editor/view/EditorView.platform.native.ts
@@ -1,0 +1,3 @@
+// packages/ui/src/editor/view/EditorView.platform.native.ts
+export { EditorView } from "./native/EditorView.native";
+export type { EditorViewProps } from "./native/EditorView.native";

--- a/packages/ui/src/editor/view/native/EditorView.native.tsx
+++ b/packages/ui/src/editor/view/native/EditorView.native.tsx
@@ -1,0 +1,70 @@
+// packages/ui/src/editor/view/native/EditorView.native.tsx
+import * as React from "react";
+import { requireNativeComponent, UIManager, findNodeHandle } from "react-native";
+import {
+  applyTransaction, createEditorState, createHistory, emitDecorations,
+  collectDecorations, transactionFromOps,
+  type EditorPlugin, type EditorState,
+} from "../../state";
+import { NATIVE_EDITOR_NAME, type NativeEditorProps } from "./bridge";
+
+const NativeKrytonEditor = requireNativeComponent<NativeEditorProps>(NATIVE_EDITOR_NAME);
+
+export interface EditorViewProps {
+  initialDoc?: string;
+  plugins?: readonly EditorPlugin[];
+  onChange?: (state: EditorState) => void;
+  onWikilinkPress?: (target: string) => void;
+  style?: object;
+}
+
+export function EditorView({ initialDoc = "", plugins = [], onChange, onWikilinkPress, style }: EditorViewProps) {
+  const ref = React.useRef<unknown>(null);
+  const stateRef = React.useRef<EditorState>(createEditorState(initialDoc));
+  const historyRef = React.useRef(createHistory());
+  const [, forceRender] = React.useReducer((n) => n + 1, 0);
+
+  const setState = React.useCallback((next: EditorState) => {
+    stateRef.current = next;
+    onChange?.(next);
+    forceRender();
+  }, [onChange]);
+
+  const onChangeText = (e: { nativeEvent: { text: string; changedFrom: number; changedTo: number; insertedText: string } }) => {
+    const { changedFrom, changedTo, insertedText } = e.nativeEvent;
+    const tr = {
+      ops: [{ kind: "replace" as const, from: changedFrom, to: changedTo, text: insertedText }],
+      selection: { anchor: changedFrom + insertedText.length, head: changedFrom + insertedText.length },
+    };
+    historyRef.current.record(stateRef.current, tr);
+    setState(applyTransaction(stateRef.current, transactionFromOps(tr.ops, tr.selection)));
+  };
+
+  const onChangeSelection = (e: { nativeEvent: { anchor: number; head: number } }) => {
+    const { anchor, head } = e.nativeEvent;
+    if (anchor !== stateRef.current.selection.anchor || head !== stateRef.current.selection.head) {
+      stateRef.current = { ...stateRef.current, selection: { anchor, head } };
+      onChange?.(stateRef.current);
+    }
+  };
+
+  const decorations = [
+    ...emitDecorations(stateRef.current.doc, stateRef.current.tree),
+    ...collectDecorations(plugins, stateRef.current),
+  ];
+
+  return (
+    <NativeKrytonEditor
+      ref={ref as never}
+      text={stateRef.current.doc}
+      selection={stateRef.current.selection}
+      decorations={decorations}
+      onChangeText={onChangeText}
+      onChangeSelection={onChangeSelection}
+      onWikilinkPress={onWikilinkPress ? (e) => onWikilinkPress(e.nativeEvent.target) : undefined}
+      style={style}
+    />
+  );
+}
+
+void UIManager; void findNodeHandle; // referenced for future imperative commands

--- a/packages/ui/src/editor/view/native/bridge.ts
+++ b/packages/ui/src/editor/view/native/bridge.ts
@@ -1,0 +1,21 @@
+// packages/ui/src/editor/view/native/bridge.ts
+import type { DecorationSpec, Selection } from "../../state/types";
+
+export interface NativeEditorProps {
+  /** Source of truth — full text. */
+  text: string;
+  /** Selection in document offsets. */
+  selection: Selection;
+  /** Flat decoration runs to paint. */
+  decorations: readonly DecorationSpec[];
+  /** Fired when the user edits the text. JS reconciles into Operation[] then applyTransaction. */
+  onChangeText: (e: { nativeEvent: { text: string; changedFrom: number; changedTo: number; insertedText: string } }) => void;
+  /** Fired when the user moves the caret/selection. */
+  onChangeSelection: (e: { nativeEvent: { anchor: number; head: number } }) => void;
+  /** Fired on tap of a wikilink-decorated range. */
+  onWikilinkPress?: (e: { nativeEvent: { target: string } }) => void;
+  style?: object;
+}
+
+/** The native module name; matches `KrytonEditor.swift` and Kotlin counterpart. */
+export const NATIVE_EDITOR_NAME = "KrytonEditor";

--- a/packages/ui/src/editor/view/native/ios/AttributedStringMapper.swift
+++ b/packages/ui/src/editor/view/native/ios/AttributedStringMapper.swift
@@ -1,0 +1,66 @@
+// packages/ui/src/editor/view/native/ios/AttributedStringMapper.swift
+import UIKit
+
+public struct DecorationSpec {
+    public let from: Int
+    public let to: Int
+    public let kind: String
+    public let attrs: [String: String]?
+}
+
+public enum AttributedStringMapper {
+    public static func attributedString(text: String, decorations: [DecorationSpec], baseFontSize: CGFloat = 16) -> NSAttributedString {
+        let mut = NSMutableAttributedString(string: text, attributes: [
+            .font: UIFont.systemFont(ofSize: baseFontSize),
+            .foregroundColor: UIColor.label,
+        ])
+        let nsText = text as NSString
+        for d in decorations {
+            let from = clamp(d.from, 0, nsText.length)
+            let to = clamp(d.to, from, nsText.length)
+            let range = NSRange(location: from, length: to - from)
+            if range.length == 0 { continue }
+            apply(kind: d.kind, attrs: d.attrs, range: range, on: mut, baseFontSize: baseFontSize)
+        }
+        return mut
+    }
+
+    private static func apply(kind: String, attrs: [String: String]?, range: NSRange, on s: NSMutableAttributedString, baseFontSize: CGFloat) {
+        switch kind {
+        case "bold":
+            s.addAttribute(.font, value: UIFont.boldSystemFont(ofSize: baseFontSize), range: range)
+        case "italic":
+            s.addAttribute(.font, value: UIFont.italicSystemFont(ofSize: baseFontSize), range: range)
+        case "strikethrough":
+            s.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+        case "code-inline", "code-block":
+            s.addAttribute(.font, value: UIFont.monospacedSystemFont(ofSize: baseFontSize - 1, weight: .regular), range: range)
+            s.addAttribute(.backgroundColor, value: UIColor.secondarySystemBackground, range: range)
+        case "heading-1":
+            s.addAttribute(.font, value: UIFont.boldSystemFont(ofSize: baseFontSize + 12), range: range)
+        case "heading-2":
+            s.addAttribute(.font, value: UIFont.boldSystemFont(ofSize: baseFontSize + 8), range: range)
+        case "heading-3":
+            s.addAttribute(.font, value: UIFont.boldSystemFont(ofSize: baseFontSize + 4), range: range)
+        case "link":
+            s.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: range)
+            s.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+        case "wikilink":
+            s.addAttribute(.foregroundColor, value: UIColor.systemPurple, range: range)
+            s.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+            if let target = attrs?["target"] {
+                s.addAttribute(.init("krytonWikilinkTarget"), value: target, range: range)
+            }
+        case "tag":
+            s.addAttribute(.foregroundColor, value: UIColor.systemTeal, range: range)
+        case "blockquote":
+            s.addAttribute(.foregroundColor, value: UIColor.secondaryLabel, range: range)
+        default:
+            break
+        }
+    }
+
+    private static func clamp(_ v: Int, _ lo: Int, _ hi: Int) -> Int {
+        return max(lo, min(hi, v))
+    }
+}

--- a/packages/ui/src/editor/view/native/ios/KrytonEditor.podspec
+++ b/packages/ui/src/editor/view/native/ios/KrytonEditor.podspec
@@ -1,0 +1,14 @@
+# packages/ui/src/editor/view/native/ios/KrytonEditor.podspec
+Pod::Spec.new do |s|
+  s.name         = "KrytonEditor"
+  s.version      = "0.1.0"
+  s.summary      = "Native iOS editor for Kryton (UITextView + RN bridge)"
+  s.homepage     = "https://github.com/azrtydxb/kryton"
+  s.license      = { :type => "MIT" }
+  s.authors      = { "kryton" => "noreply@kryton.local" }
+  s.platforms    = { :ios => "13.0" }
+  s.source       = { :path => "." }
+  s.source_files = "*.swift"
+  s.dependency "React-Core"
+  s.swift_version = "5.0"
+end

--- a/packages/ui/src/editor/view/native/ios/KrytonEditor.swift
+++ b/packages/ui/src/editor/view/native/ios/KrytonEditor.swift
@@ -1,0 +1,111 @@
+// packages/ui/src/editor/view/native/ios/KrytonEditor.swift
+import UIKit
+import React
+
+@objc(KrytonEditor)
+public final class KrytonEditor: UITextView, UITextViewDelegate {
+    @objc public var onChangeText: RCTBubblingEventBlock?
+    @objc public var onChangeSelection: RCTBubblingEventBlock?
+    @objc public var onWikilinkPress: RCTBubblingEventBlock?
+
+    private var lastText: String = ""
+    private var pendingDecorations: [DecorationSpec] = []
+    private var suppressJsEcho = false
+
+    public override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+        self.delegate = self
+        self.font = UIFont.systemFont(ofSize: 16)
+        self.alwaysBounceVertical = true
+        self.autocorrectionType = .yes
+        self.autocapitalizationType = .sentences
+        self.smartDashesType = .yes
+        self.smartQuotesType = .yes
+        self.smartInsertDeleteType = .yes
+        self.isAccessibilityElement = true
+        addTapRecognizer()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    @objc public func setText(_ text: String) {
+        guard !suppressJsEcho else { return }
+        if text == lastText { return }
+        let savedRange = self.selectedRange
+        self.attributedText = AttributedStringMapper.attributedString(text: text, decorations: pendingDecorations)
+        self.selectedRange = clamp(savedRange, length: (text as NSString).length)
+        lastText = text
+    }
+
+    @objc public func setDecorations(_ decorations: NSArray) {
+        var parsed: [DecorationSpec] = []
+        for case let dict as NSDictionary in decorations {
+            guard let from = dict["from"] as? Int, let to = dict["to"] as? Int, let kind = dict["kind"] as? String else { continue }
+            let attrs = dict["attrs"] as? [String: String]
+            parsed.append(DecorationSpec(from: from, to: to, kind: kind, attrs: attrs))
+        }
+        pendingDecorations = parsed
+        // Re-apply on the current text without changing selection.
+        let savedRange = self.selectedRange
+        self.attributedText = AttributedStringMapper.attributedString(text: lastText, decorations: pendingDecorations)
+        self.selectedRange = clamp(savedRange, length: (lastText as NSString).length)
+    }
+
+    @objc public func setSelection(_ anchor: Int, _ head: Int) {
+        let lo = min(anchor, head), hi = max(anchor, head)
+        let length = (self.text as NSString).length
+        self.selectedRange = NSRange(location: clamp1(lo, length), length: clamp1(hi, length) - clamp1(lo, length))
+    }
+
+    public func textViewDidChange(_ textView: UITextView) {
+        let newText = textView.text ?? ""
+        let (changedFrom, changedTo, inserted) = diff(lastText, newText)
+        lastText = newText
+        suppressJsEcho = true
+        defer { suppressJsEcho = false }
+        onChangeText?(["text": newText, "changedFrom": changedFrom, "changedTo": changedTo, "insertedText": inserted])
+    }
+
+    public func textViewDidChangeSelection(_ textView: UITextView) {
+        let r = textView.selectedRange
+        onChangeSelection?(["anchor": r.location, "head": r.location + r.length])
+    }
+
+    private func addTapRecognizer() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+        tap.cancelsTouchesInView = false
+        addGestureRecognizer(tap)
+    }
+
+    @objc private func handleTap(_ gr: UITapGestureRecognizer) {
+        let p = gr.location(in: self)
+        guard let pos = closestPosition(to: p) else { return }
+        let idx = offset(from: beginningOfDocument, to: pos)
+        if idx >= 0, idx < (attributedText?.length ?? 0),
+           let target = attributedText?.attribute(.init("krytonWikilinkTarget"), at: idx, effectiveRange: nil) as? String {
+            onWikilinkPress?(["target": target])
+        }
+    }
+
+    // MARK: - helpers
+    private func clamp(_ r: NSRange, length: Int) -> NSRange {
+        let lo = max(0, min(length, r.location))
+        let hi = max(lo, min(length, r.location + r.length))
+        return NSRange(location: lo, length: hi - lo)
+    }
+    private func clamp1(_ v: Int, _ length: Int) -> Int { return max(0, min(length, v)) }
+
+    private func diff(_ a: String, _ b: String) -> (Int, Int, String) {
+        // Find common prefix.
+        let aChars = Array(a), bChars = Array(b)
+        var i = 0
+        while i < aChars.count && i < bChars.count && aChars[i] == bChars[i] { i += 1 }
+        // Find common suffix.
+        var j = 0
+        while j < aChars.count - i && j < bChars.count - i && aChars[aChars.count - 1 - j] == bChars[bChars.count - 1 - j] { j += 1 }
+        let changedFrom = i
+        let changedTo = aChars.count - j
+        let inserted = String(bChars[i..<bChars.count - j])
+        return (changedFrom, changedTo, inserted)
+    }
+}

--- a/packages/ui/src/editor/view/native/ios/KrytonEditorManager.swift
+++ b/packages/ui/src/editor/view/native/ios/KrytonEditorManager.swift
@@ -1,0 +1,35 @@
+// packages/ui/src/editor/view/native/ios/KrytonEditorManager.swift
+import React
+
+@objc(KrytonEditorManager)
+public final class KrytonEditorManager: RCTViewManager {
+    public override func view() -> UIView! {
+        return KrytonEditor(frame: .zero, textContainer: nil)
+    }
+
+    public override static func requiresMainQueueSetup() -> Bool { return true }
+
+    @objc public func updateText(_ reactTag: NSNumber, text: NSString) {
+        bridge?.uiManager.addUIBlock { (_, viewRegistry) in
+            if let view = viewRegistry?[reactTag] as? KrytonEditor {
+                view.setText(text as String)
+            }
+        }
+    }
+
+    @objc public func updateDecorations(_ reactTag: NSNumber, decorations: NSArray) {
+        bridge?.uiManager.addUIBlock { (_, viewRegistry) in
+            if let view = viewRegistry?[reactTag] as? KrytonEditor {
+                view.setDecorations(decorations)
+            }
+        }
+    }
+
+    @objc public func updateSelection(_ reactTag: NSNumber, anchor: NSNumber, head: NSNumber) {
+        bridge?.uiManager.addUIBlock { (_, viewRegistry) in
+            if let view = viewRegistry?[reactTag] as? KrytonEditor {
+                view.setSelection(anchor.intValue, head.intValue)
+            }
+        }
+    }
+}

--- a/packages/ui/src/editor/view/native/ios/__tests__/AttributedStringMapperTests.swift
+++ b/packages/ui/src/editor/view/native/ios/__tests__/AttributedStringMapperTests.swift
@@ -1,0 +1,33 @@
+// packages/ui/src/editor/view/native/ios/__tests__/AttributedStringMapperTests.swift
+import XCTest
+@testable import KrytonEditor
+
+final class AttributedStringMapperTests: XCTestCase {
+    func testBoldAttributeAppliedOnRange() {
+        let result = AttributedStringMapper.attributedString(
+            text: "hello world",
+            decorations: [DecorationSpec(from: 6, to: 11, kind: "bold", attrs: nil)]
+        )
+        var effective = NSRange(location: 0, length: 0)
+        let font = result.attribute(.font, at: 6, effectiveRange: &effective) as? UIFont
+        XCTAssertTrue(font?.fontDescriptor.symbolicTraits.contains(.traitBold) ?? false)
+    }
+
+    func testWikilinkCarriesTargetAttribute() {
+        let text = "see [[Other]]!"
+        let result = AttributedStringMapper.attributedString(
+            text: text,
+            decorations: [DecorationSpec(from: 4, to: 13, kind: "wikilink", attrs: ["target": "Other"])]
+        )
+        let target = result.attribute(.init("krytonWikilinkTarget"), at: 5, effectiveRange: nil) as? String
+        XCTAssertEqual(target, "Other")
+    }
+
+    func testOutOfRangeDecorationIsClamped() {
+        let result = AttributedStringMapper.attributedString(
+            text: "hi",
+            decorations: [DecorationSpec(from: 0, to: 999, kind: "bold", attrs: nil)]
+        )
+        XCTAssertEqual(result.length, 2)
+    }
+}


### PR DESCRIPTION
Implements editor-native-ios-view sub-plan (depends on #94 state-core).

## Summary
- TS bridge types (bridge.ts)
- Swift AttributedStringMapper (DecorationSpec[] → NSAttributedString)
- Swift KrytonEditor UITextView subclass with bridge events
- Swift KrytonEditorManager + podspec
- RN React component EditorView.native.tsx wrapping the native module

## Test plan
- [ ] `cd packages/ui && npx tsc --noEmit` is clean
- [ ] Native files live under packages/ui/src/editor/view/native/ios/** ready for kryton-mobile xcworkspace
- [ ] EditorView.platform.native.ts wraps the native EditorView for platform-resolved consumption