### PR TITLE
style(editor): line-number gutter + colour pass per prototype editor.jsx

### DIFF
--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -52,26 +52,40 @@
   @apply btn text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 active:bg-red-100 dark:active:bg-red-900/30;
 }
 
-/* In-house editor (EditorView.web.tsx) — spans carry data-kind=… and one of
-   the .ed-* classes from KIND_CLASS in EditorView.web.tsx. The container
-   itself uses [data-editor-root]. Aligned to the design doc:
-     edit body  — monospace, 1.7 line-height, padding 24px 32px
-     wikilinks  — dashed underline in --link
-     inline code — mono 0.88em, --code-bg/--code-fg, 1px 6px, 4px radius
-     code block — mono, --bg-2, 12px padding, 6px radius
-     blockquote — 2px left border in --accent, italic --fg-2
+/* In-house editor (EditorView.web.tsx) — outer .ed-shell is a 2-column grid
+   (52px gutter + content). The contenteditable surface is the right cell,
+   reachable via [data-editor-root]; spans inside carry data-kind and one of
+   the .ed-* classes from KIND_CLASS. Aligned to
+   design_handoff_kryton_redesign/prototype/app/editor.jsx (EditorBody):
+     mono 13.5px / 22px line-height, padding 20px 0 200px
+     gutter: mono 11.5px, --fg-4, right-aligned, paddingRight 14
 */
-[data-editor-root] {
-  font-family: var(--font-mono);
-  font-size: 14px;
-  line-height: 1.7;
-  padding: 24px 32px;
-  color: var(--fg-1);
+[data-editor-shell] {
+  display: grid;
+  grid-template-columns: 52px 1fr;
+  height: 100%;
+  overflow-y: auto;
   background: var(--bg);
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  line-height: 22px;
+}
+.ed-gutter {
+  text-align: right;
+  padding: 20px 14px 200px 0;
+  color: var(--fg-4);
+  font-size: 11.5px;
+  line-height: 22px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.ed-ln { display: block; }
+[data-editor-root] {
+  padding: 20px 28px 200px 0;
+  color: var(--fg-1);
   outline: none;
   white-space: pre-wrap;
-  overflow-y: auto;
-  height: 100%;
+  word-break: break-word;
   caret-color: var(--accent);
 }
 [data-editor-root]:focus { outline: none; }
@@ -88,21 +102,19 @@
 .ed-h5 { font-family: var(--font-display); font-size: 14px; font-weight: 600; color: var(--fg); }
 .ed-h6 { font-family: var(--font-display); font-size: 13px; font-weight: 600; color: var(--fg-2); }
 
-.ed-bold { font-weight: 700; color: var(--fg); }
-.ed-italic { font-style: italic; }
-.ed-strike { text-decoration: line-through; text-decoration-color: var(--fg-3); }
+/* Bold uses --accent-warn (amber) per editor.jsx MdInline so emphasis pops
+   inside the mono surface; the body --fg already gives normal text contrast. */
+.ed-bold { font-weight: 600; color: var(--accent-warn); }
+.ed-italic { font-style: italic; color: var(--fg-1); }
+.ed-strike { text-decoration: line-through; text-decoration-color: var(--fg-3); color: var(--fg-3); }
 
 .ed-code-inline {
-  font-family: var(--font-mono);
-  font-size: 0.88em;
   background: var(--code-bg);
   color: var(--code-fg);
-  padding: 1px 6px;
-  border-radius: 4px;
+  padding: 0 4px;
+  border-radius: 3px;
 }
 .ed-code-block {
-  display: inline;
-  font-family: var(--font-mono);
   background: var(--bg-2);
   color: var(--fg-1);
   border-radius: 6px;

--- a/packages/ui/src/editor/view/web/EditorView.web.tsx
+++ b/packages/ui/src/editor/view/web/EditorView.web.tsx
@@ -149,34 +149,41 @@ export function EditorView({
     ...collectDecorations(plugins, stateRef.current),
   ];
   const runs = projectDom(stateRef.current.doc, decos);
+  const lineCount = stateRef.current.doc.split("\n").length;
 
   return (
-    <div
-      ref={rootRef}
-      className={className ?? "ed-root"}
-      contentEditable
-      suppressContentEditableWarning
-      spellCheck
-      onCompositionStart={onCompositionStart}
-      onCompositionEnd={onCompositionEnd}
-      onPaste={onPaste}
-      onKeyDown={onKeyDown}
-      onSelect={onSelect}
-      onClick={onClick}
-      data-editor-root=""
-    >
-      {runs.map((run, i) => (
-        <span
-          key={i}
-          data-from={run.from}
-          data-to={run.to}
-          data-kind={run.kind ?? undefined}
-          data-target={run.attrs?.target}
-          className={run.kind ? KIND_CLASS[run.kind] : undefined}
-        >
-          {run.text}
-        </span>
-      ))}
+    <div className={className ?? "ed-shell"} data-editor-shell="">
+      <div className="ed-gutter" aria-hidden="true">
+        {Array.from({ length: lineCount }, (_, i) => (
+          <span key={i} className="ed-ln">{i + 1}</span>
+        ))}
+      </div>
+      <div
+        ref={rootRef}
+        contentEditable
+        suppressContentEditableWarning
+        spellCheck
+        onCompositionStart={onCompositionStart}
+        onCompositionEnd={onCompositionEnd}
+        onPaste={onPaste}
+        onKeyDown={onKeyDown}
+        onSelect={onSelect}
+        onClick={onClick}
+        data-editor-root=""
+      >
+        {runs.map((run, i) => (
+          <span
+            key={i}
+            data-from={run.from}
+            data-to={run.to}
+            data-kind={run.kind ?? undefined}
+            data-target={run.attrs?.target}
+            className={run.kind ? KIND_CLASS[run.kind] : undefined}
+          >
+            {run.text}
+          </span>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Continues the design-doc reapply work from #102. The previous CSS pass landed the basic decoration colours but missed the line-number gutter and used neutral hues for emphasis instead of the prototype's pop palette.

Reference: \`design_handoff_kryton_redesign/prototype/app/editor.jsx\` (\`EditorBody\` + \`MdInline\`).

## What changed

\`EditorView.web.tsx\`:
- Wraps the contenteditable in a 2-column grid: 52px gutter | 1fr content. Both columns share the same scroll context so the gutter scrolls in lockstep. The wrapper carries \`data-editor-shell\` for stable CSS targeting (consumer-supplied \`className\` cannot override).
- Renders one \`.ed-ln\` span per source line (split on \`\\n\`) with the 1-based index. Soft-wrapped visual lines do not get extra numbers — matches most code editors.

\`globals.css\`:
- \`[data-editor-shell]\`: 52px / 1fr grid, mono 13.5px, line-height 22px, scroll on the shell.
- \`.ed-gutter\`: right-aligned, paddingRight 14, mono 11.5px, \`--fg-4\`, \`user-select: none\`.
- \`[data-editor-root]\`: paddingRight 28, \`white-space: pre-wrap\`, \`word-break: break-word\`.
- \`.ed-bold\`: \`--accent-warn\` (amber) per MdInline.
- \`.ed-italic\`: explicit \`--fg-1\` so it doesn't inherit the dimmed blockquote colour when nested.
- \`.ed-strike\`: dims to \`--fg-3\` for "removed" feel.
- \`.ed-code-inline\`: drop redundant font-family / font-size (shell already mono); tighter \`0 4px / 3px radius\` matches prototype.
- \`.ed-code-block\`: drop \`display: inline\` override.

## Test plan

- [ ] Open a note in Edit mode. Line numbers count down the left, mono 11.5px in \`--fg-4\`.
- [ ] Type \`**bold**\`, \`*italic*\`, \`~~strike~~\`, \`\` \`code\` \`\`, \`[[Wikilink]]\`, \`> quote\`. Bold pops in amber; italic / strike / code-pill / wikilink-dashed / blockquote-italic all distinct.
- [ ] Long lines wrap inside the content column rather than scrolling horizontally; the gutter number stays put for the source line, regardless of wrap.
- [ ] Both gutter and content scroll together when the doc is taller than the viewport.

ui tests: 351/351 still pass.