### PR TITLE
style(editor): syntax-highlight markdown marks (#, -, >, link)

### DIFF
--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -152,6 +152,22 @@
 .ed-task-unchecked { color: var(--fg-1); }
 .ed-hr { color: var(--fg-4); }
 
+/* Syntax marks per editor.jsx MdLine: heading `#`s in cyan, list bullet
+   in violet, quote `>` dimmed, emphasis/code/link marks de-emphasised so
+   the content reads first; the URL inside an inline link gets the link
+   colour. The deeper-wins logic in projectDom guarantees these win over
+   their enclosing decoration on the mark range. */
+.ed-mark-header { color: var(--accent-2); font-weight: 600; }
+.ed-mark-list { color: var(--accent); }
+.ed-mark-quote { color: var(--fg-3); }
+.ed-mark-link { color: var(--fg-4); }
+.ed-mark-link-url {
+  color: var(--link);
+  text-decoration: underline;
+  text-decoration-style: dashed;
+  text-underline-offset: 3px;
+}
+
 /* Markdown preview styling — token-driven. The .kryton-md wrapper in
    Preview.tsx provides additional scoped overrides per the design spec. */
 .markdown-preview {

--- a/packages/ui/src/editor/state/decorations.ts
+++ b/packages/ui/src/editor/state/decorations.ts
@@ -21,6 +21,22 @@ const KIND_BY_NODE: Record<string, DecorationKind> = {
   HorizontalRule: "horizontal-rule",
 };
 
+// Lezer mark nodes: structural delimiters that should get a distinct
+// colour while leaving the construct's content alone. Per the prototype
+// (editor.jsx MdLine) the heading `#`, list `-`, and quote `>` are
+// highlighted as separate spans. Emphasis (`**`) and inline-code
+// backticks are intentionally NOT split out — those tokens render with
+// the same colour as the bold / italic / code content so the whole
+// marker-plus-text reads as one unit. WikiLinkMark also stays inside the
+// surrounding wikilink span for the same reason.
+const MARK_BY_NODE: Record<string, DecorationKind> = {
+  HeaderMark: "mark-header",
+  ListMark: "mark-list",
+  QuoteMark: "mark-quote",
+  LinkMark: "mark-link",
+  URL: "mark-link-url",
+};
+
 export function emitDecorations(text: string, tree: Tree): DecorationSpec[] {
   const out: DecorationSpec[] = [];
   tree.iterate({
@@ -28,6 +44,11 @@ export function emitDecorations(text: string, tree: Tree): DecorationSpec[] {
       const kind = KIND_BY_NODE[node.name];
       if (kind) {
         out.push({ from: node.from, to: node.to, kind });
+        return;
+      }
+      const mark = MARK_BY_NODE[node.name];
+      if (mark) {
+        out.push({ from: node.from, to: node.to, kind: mark });
         return;
       }
       if (node.name === "WikiLink") {

--- a/packages/ui/src/editor/state/types.ts
+++ b/packages/ui/src/editor/state/types.ts
@@ -14,7 +14,13 @@ export type DecorationKind =
   | "heading-1" | "heading-2" | "heading-3" | "heading-4" | "heading-5" | "heading-6"
   | "bold" | "italic" | "strikethrough" | "code-inline" | "code-block"
   | "link" | "wikilink" | "tag" | "blockquote" | "list-item" | "task-checked" | "task-unchecked"
-  | "horizontal-rule";
+  | "horizontal-rule"
+  // Mark-level decorations: the syntax tokens that delimit a construct (the
+  // `#` of a heading, the `-` of a list, etc.). Emitted as separate spans
+  // with their own colour so raw markdown reads as a syntax-highlighted
+  // surface in edit mode.
+  | "mark-header" | "mark-list" | "mark-quote"
+  | "mark-link" | "mark-link-url";
 
 export interface DecorationSpec {
   from: Offset;

--- a/packages/ui/src/editor/view/web/EditorView.web.tsx
+++ b/packages/ui/src/editor/view/web/EditorView.web.tsx
@@ -37,6 +37,11 @@ const KIND_CLASS: Record<string, string> = {
   blockquote: "ed-blockquote", "list-item": "ed-li",
   "task-checked": "ed-task-checked", "task-unchecked": "ed-task-unchecked",
   "horizontal-rule": "ed-hr",
+  "mark-header": "ed-mark-header",
+  "mark-list": "ed-mark-list",
+  "mark-quote": "ed-mark-quote",
+  "mark-link": "ed-mark-link",
+  "mark-link-url": "ed-mark-link-url",
 };
 
 export function EditorView({


### PR DESCRIPTION
Closes the gap reported after #103: heading hash, list bullet, blockquote arrow, and link brackets all inherited their parent construct's colour. The prototype (\`design_handoff_kryton_redesign/prototype/app/editor.jsx\`) renders them as distinctly coloured spans.

## What changed

\`state/types.ts\` — adds five new \`DecorationKind\` variants: \`mark-header\`, \`mark-list\`, \`mark-quote\`, \`mark-link\`, \`mark-link-url\`.

\`state/decorations.ts\` — new \`MARK_BY_NODE\` table mapping Lezer \`HeaderMark\` / \`ListMark\` / \`QuoteMark\` / \`LinkMark\` / \`URL\` to the new kinds. Emitted as smaller-range decorations so \`projectDom\`'s deeper-wins logic gives them precedence over the enclosing construct on the mark span.

Deliberately NOT split out: \`EmphasisMark\` and \`CodeMark\`. The prototype paints \`**bold**\`, \`*italic*\`, and \`\` \`code\` \`\` as single tokens (markers + content sharing one colour); emitting separate marks would visually fragment them. \`WikiLinkMark\` follows the same rule — \`[[\` \`]]\` stay inside the wikilink span.

\`EditorView.web.tsx\` — registers the new kinds in \`KIND_CLASS\` so the projection emits \`.ed-mark-*\` classes.

\`globals.css\`:
- \`.ed-mark-header\` — \`--accent-2\` (cyan), weight 600.
- \`.ed-mark-list\` — \`--accent\` (violet).
- \`.ed-mark-quote\` — \`--fg-3\`.
- \`.ed-mark-link\` — \`--fg-4\` for \`[\`/\`]\`/\`(\`/\`)\` brackets.
- \`.ed-mark-link-url\` — \`--link\` with dashed underline.

## Test plan

- [ ] Edit-mode rendering of \`## Heading\` shows \`##\` cyan, the rest in heading display font.
- [ ] \`- bullet\` shows \`-\` violet, content in fg-1.
- [ ] \`> quote\` shows \`>\` dimmed, content italic.
- [ ] \`[text](url)\` shows brackets/parens dimmed, URL in link colour with dashed underline.
- [ ] \`**bold**\`, \`*italic*\`, \`\` \`code\` \`\` still render as single contiguous coloured tokens (no marker/content colour split).
- [ ] \`[[Wikilink]]\` still renders as a single dashed-underline link token.

ui tests: 351/351 pass.