### PR TITLE
fix(client): tag-chip click + empty graph view + button-in-button

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useCallback } from 'react';
+import { useMemo, useEffect, useCallback, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './hooks/useAuth';
 import { PluginSlotRegistry, PluginProvider, usePluginSlots } from '@azrtydxb/ui';
@@ -150,6 +150,14 @@ function AppContent() {
   const setEditContent = useUIStore((s) => s.setEditContent);
   const view = useUIStore((s) => s.view);
   const setView = useUIStore((s) => s.setView);
+  // Tag selected via the sidebar chip click — passed into <TagsView> as
+  // initialTag so the view opens already filtered. Subsequent clicks
+  // inside the TagsView manage selection internally.
+  const [pendingTag, setPendingTag] = useState<string | null>(null);
+  const handleSidebarTagSelect = useCallback((tag: string) => {
+    setPendingTag(tag);
+    setView('tags');
+  }, [setView]);
 
   const {
     toggleStar,
@@ -252,6 +260,7 @@ function AppContent() {
           onCreateFromTemplate={handleCreateFromTemplate}
           onToggleStar={toggleStar}
           onShare={handleShare}
+          onTagSelect={handleSidebarTagSelect}
         >
           <PluginSlot slot="sidebar" />
         </SidebarLayout>
@@ -279,7 +288,14 @@ function AppContent() {
                 mode="global"
               />
             ) : view === 'tags' ? (
-              <TagsView onNoteSelect={(p) => { handleNoteSelect(p); setView('note'); }} />
+              <TagsView
+                // key remounts the view when the user picks a different tag
+                // from the sidebar, so initialTag seeds fresh state without
+                // requiring a sync-in-effect inside TagsView.
+                key={pendingTag ?? '__none__'}
+                initialTag={pendingTag}
+                onNoteSelect={(p) => { handleNoteSelect(p); setView('note'); setPendingTag(null); }}
+              />
             ) : notes.activeNote ? (
               editing ? (
                 <EditModeView

--- a/packages/client/src/components/Layout/SidebarLayout.tsx
+++ b/packages/client/src/components/Layout/SidebarLayout.tsx
@@ -33,6 +33,8 @@ interface SidebarLayoutProps {
   onCreateFromTemplate: () => void;
   onToggleStar: (path: string) => void;
   onShare: (path: string, isFolder: boolean) => void;
+  /** Sidebar tag-chip click — routes to the tags view filtered by `tag`. */
+  onTagSelect?: (tag: string) => void;
   children?: React.ReactNode;
 }
 
@@ -44,6 +46,7 @@ export function SidebarLayout({
   onSelect, onCreateNote, onDeleteNote, onRenameNote,
   onCreateFolder, onDeleteFolder, onRenameFolder,
   onDailyNote, onCreateFromTemplate, onToggleStar, onShare,
+  onTagSelect,
   children,
 }: SidebarLayoutProps) {
   return (
@@ -104,6 +107,7 @@ export function SidebarLayout({
             tree={tree}
             activeNotePath={activeNotePath}
             onSelect={onSelect}
+            onTagSelect={onTagSelect}
             onCreateNote={onCreateNote}
             onDeleteNote={onDeleteNote}
             onRenameNote={onRenameNote}

--- a/packages/client/src/components/Sidebar/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar/Sidebar.tsx
@@ -35,6 +35,11 @@ interface SidebarProps {
   version?: string;
   /** optional content rendered between the section list and the agents footer (e.g. plugin slot) */
   beforeFooter?: ReactNode;
+  /**
+   * Called when the user clicks a tag chip in the sidebar — should route
+   * to the tags-filtered view (not load `#tag` as a note path, which 500s).
+   */
+  onTagSelect?: (tag: string) => void;
 }
 
 const DEFAULT_VERSION = 'v4.3.2';
@@ -238,6 +243,7 @@ export function Sidebar({
   onCollapse,
   version = DEFAULT_VERSION,
   beforeFooter,
+  onTagSelect,
 }: SidebarProps) {
   const [favOpen, setFavOpen] = useState(true);
   const [filesOpen, setFilesOpen] = useState(true);
@@ -457,7 +463,7 @@ export function Sidebar({
                 <button
                   key={tag}
                   className="mono"
-                  onClick={() => onSelect(`#${tag}`)}
+                  onClick={() => onTagSelect?.(tag)}
                   title={`#${tag} (${count})`}
                   style={{
                     display: 'inline-flex',

--- a/packages/client/src/components/Views/TagsView.tsx
+++ b/packages/client/src/components/Views/TagsView.tsx
@@ -5,12 +5,19 @@
  * tag chip grid, and a side detail showing the notes for the selected
  * tag. Replaces the editor pane (sidebar + graph rail stay mounted).
  */
-import { useEffect, useState, useCallback, type CSSProperties } from 'react';
+import { useState, useCallback, type CSSProperties } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { api, type TagData, type TagNoteData } from '../../lib/api';
 import { Icons } from '../Icons';
 
 interface TagsViewProps {
   onNoteSelect: (path: string) => void;
+  /**
+   * Tag to pre-select when the view mounts. Used when the user navigates
+   * here by clicking a tag chip in the sidebar. Subsequent clicks inside
+   * the view manage selection internally.
+   */
+  initialTag?: string | null;
 }
 
 const headerStyle: CSSProperties = {
@@ -39,33 +46,30 @@ const tagChip = (active: boolean): CSSProperties => ({
   transition: 'background 120ms, border-color 120ms, color 120ms',
 });
 
-export function TagsView({ onNoteSelect }: TagsViewProps) {
-  const [tags, setTags] = useState<TagData[]>([]);
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const [tagNotes, setTagNotes] = useState<TagNoteData[]>([]);
-  const [loadingNotes, setLoadingNotes] = useState(false);
+export function TagsView({ onNoteSelect, initialTag }: TagsViewProps) {
+  // initialTag seeds the first render. The parent passes `key={initialTag}`
+  // so picking a different tag from the sidebar remounts the view and
+  // re-seeds state without any sync-in-effect dance.
+  const [selectedTag, setSelectedTag] = useState<string | null>(initialTag ?? null);
 
-  useEffect(() => {
-    api.getTags().then(setTags).catch(() => setTags([]));
+  // The tags index and the per-tag note list both come from the network —
+  // delegated to react-query so loading/data state lives outside React's
+  // effect machinery (no sync setState in effects).
+  const { data: tags = [] } = useQuery<TagData[]>({
+    queryKey: ['tags'],
+    queryFn: () => api.getTags(),
+    staleTime: 30_000,
+  });
+  const { data: tagNotes = [], isLoading: loadingNotes } = useQuery<TagNoteData[]>({
+    queryKey: ['tag-notes', selectedTag],
+    queryFn: () => api.getNotesByTag(selectedTag as string),
+    enabled: !!selectedTag,
+    staleTime: 30_000,
+  });
+
+  const handleTagSelect = useCallback((tag: string) => {
+    setSelectedTag((prev) => (prev === tag ? null : tag));
   }, []);
-
-  const handleTagSelect = useCallback(async (tag: string) => {
-    if (selectedTag === tag) {
-      setSelectedTag(null);
-      setTagNotes([]);
-      return;
-    }
-    setSelectedTag(tag);
-    setLoadingNotes(true);
-    try {
-      const notes = await api.getNotesByTag(tag);
-      setTagNotes(notes);
-    } catch {
-      setTagNotes([]);
-    } finally {
-      setLoadingNotes(false);
-    }
-  }, [selectedTag]);
 
   return (
     <div
@@ -101,7 +105,7 @@ export function TagsView({ onNoteSelect }: TagsViewProps) {
         <div style={{ flex: 1 }} />
         {selectedTag && (
           <button
-            onClick={() => { setSelectedTag(null); setTagNotes([]); }}
+            onClick={() => setSelectedTag(null)}
             className="mono"
             style={{
               fontSize: 11,

--- a/packages/ui/src/graph/layout/forceLayout.ts
+++ b/packages/ui/src/graph/layout/forceLayout.ts
@@ -23,9 +23,35 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
 
   const pinned = new Set<string>();
 
+  // ngraph's gravity is pure repulsion; with no edges or sparse graphs the
+  // cluster's centre of mass drifts and falls off-screen. After every step,
+  // shift all unpinned positions so the centroid stays at (0, 0). This is
+  // gentle (relative offsets between nodes are preserved) and gives consumers
+  // a stable bbox to fit the camera against.
+  function recentre() {
+    let sx = 0, sy = 0, count = 0;
+    graph.forEachNode((node) => {
+      const id = node.id as string;
+      const body = layout.getBody(id);
+      if (!body) return;
+      sx += body.pos.x; sy += body.pos.y; count++;
+    });
+    if (count === 0) return;
+    const dx = sx / count, dy = sy / count;
+    if (dx === 0 && dy === 0) return;
+    graph.forEachNode((node) => {
+      const id = node.id as string;
+      const body = layout.getBody(id);
+      if (!body || body.isPinned) return;
+      body.pos.x -= dx;
+      body.pos.y -= dy;
+    });
+  }
+
   const handle: LayoutHandle = {
     step() {
       layout.step();
+      recentre();
       for (const id of pinned) {
         const body = layout.getBody(id);
         if (!body) continue;

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -33,10 +33,43 @@ export function GraphView({
   const hitRef = React.useRef<HitTest | null>(null);
   const hoverRef = React.useRef<string | null>(null);
   const dragRef = React.useRef<{ id: string; startX: number; startY: number } | null>(null);
+  // Once the layout has been pre-settled we stop stepping the simulation —
+  // continuing would let positions drift past the initial fit. Drag bumps
+  // this back to false so the simulation runs while the user is dragging.
+  const frozenRef = React.useRef(false);
   const { viewport, bind, setViewport } = useViewport();
   const layoutMode: LayoutMode = mode === "full" ? "global" : "local";
 
+  /** Compute a viewport that frames the current layout positions inside (w, h). */
+  const fitToCanvas = React.useCallback((w: number, h: number) => {
+    const layout = layoutRef.current;
+    if (!layout) return { x: w / 2, y: h / 2, k: 1 };
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity, count = 0;
+    for (const p of layout.positions()) {
+      if (p.x < minX) minX = p.x; if (p.x > maxX) maxX = p.x;
+      if (p.y < minY) minY = p.y; if (p.y > maxY) maxY = p.y;
+      count++;
+    }
+    if (count === 0 || !Number.isFinite(minX)) return { x: w / 2, y: h / 2, k: 1 };
+    const bboxW = Math.max(1, maxX - minX);
+    const bboxH = Math.max(1, maxY - minY);
+    const margin = 60;
+    // Allow zooming in past 1× when the cluster is small — the bbox can be
+    // tiny for sparse graphs, and we want nodes to be visible, not pinheads.
+    const k = Math.min(
+      GRAPH_CONFIG.zoom.scaleMax,
+      Math.max(
+        GRAPH_CONFIG.zoom.scaleMin,
+        Math.min((w - margin) / bboxW, (h - margin) / bboxH),
+      ),
+    );
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+    return { x: w / 2 - cx * k, y: h / 2 - cy * k, k };
+  }, []);
+
   // Build / rebuild layout when graphData, mode, or activeNotePath changes.
+  // Settle for a few hundred ticks before fitting so the bbox is meaningful.
   React.useEffect(() => {
     if (!graphData) return;
     layoutRef.current?.dispose();
@@ -48,21 +81,30 @@ export function GraphView({
       nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
       activeId, width: w, height: h,
     });
+    // Pre-settle so positions stabilise before the first paint, then freeze.
+    frozenRef.current = false;
+    for (let i = 0; i < 500; i++) layoutRef.current.step();
+    frozenRef.current = true;
     hitRef.current = createHitTest(
       [...layoutRef.current.positions()],
       Math.sqrt(GRAPH_CONFIG.node.hitTestRadiusSq),
     );
+    setViewport(fitToCanvas(w, h));
     return () => {
       layoutRef.current?.dispose();
       layoutRef.current = null;
     };
-  }, [graphData, layoutMode, activeNotePath]);
+  }, [graphData, layoutMode, activeNotePath, setViewport, fitToCanvas]);
 
-  // Recenter handle.
+  // Recenter handle — fits the bounding box of current positions to the canvas.
   React.useEffect(() => {
     if (!recenterRef) return;
-    recenterRef.current = () => setViewport({ x: 0, y: 0, k: 1 });
-  }, [recenterRef, setViewport]);
+    recenterRef.current = () => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      setViewport(fitToCanvas(canvas.clientWidth, canvas.clientHeight));
+    };
+  }, [recenterRef, setViewport, fitToCanvas]);
 
   // Render loop.
   React.useEffect(() => {
@@ -80,8 +122,10 @@ export function GraphView({
             canvas.width = w * dpr; canvas.height = h * dpr;
             ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
           }
-          layout.step();
-          hit?.rebuild([...layout.positions()]);
+          if (!frozenRef.current || dragRef.current) {
+            layout.step();
+            hit?.rebuild([...layout.positions()]);
+          }
 
           const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
           const localSet = computeLocalSet(graphData, activeId, layoutMode);
@@ -155,6 +199,8 @@ export function GraphView({
     const id = hitRef.current?.test(wx, wy);
     if (id) {
       dragRef.current = { id, startX: e.clientX, startY: e.clientY };
+      // Unfreeze so the dragged node can move and the rest react.
+      frozenRef.current = false;
       applyDragStart(layoutRef.current!, id, wx, wy);
     }
   };
@@ -170,6 +216,8 @@ export function GraphView({
         if (node) onNoteSelect(node.path);
       }
       dragRef.current = null;
+      // Re-freeze after the user lets go so the simulation stops.
+      frozenRef.current = true;
     }
   };
 

--- a/packages/ui/src/notes/FileTree.tsx
+++ b/packages/ui/src/notes/FileTree.tsx
@@ -341,15 +341,23 @@ export function FileTree({
         const isDragOver = node.type === "folder" && node.path === dragOverPath;
         const displayName = node.type === "file" ? node.name.replace(/\.md$/, "") : node.name;
 
+        const onRowActivate = () => {
+          if (node.type === "folder") toggleExpand(node.path);
+          else onSelect(node.path);
+        };
         return (
           <div>
-            <button
+            {/* Tree row uses a <div role="treeitem"> rather than a <button>
+                because it wraps the Star + More-options buttons, and HTML
+                doesn't allow interactive content inside a <button>. We add
+                tabIndex + keyboard activation to keep it focusable. */}
+            <div
               draggable
               role="treeitem"
               aria-expanded={node.type === "folder" ? isExpanded : undefined}
               tabIndex={0}
               className={cn(
-                "group w-full flex items-center gap-2 py-1 text-sm rounded-md mx-1 transition-colors duration-100 kryton-tree-row relative",
+                "group w-full flex items-center gap-2 py-1 text-sm rounded-md mx-1 transition-colors duration-100 kryton-tree-row relative cursor-pointer",
                 isDragging && "opacity-50",
                 isDragOver && "kryton-tree-row--dragover",
                 isActive && "kryton-tree-row--active",
@@ -360,9 +368,12 @@ export function FileTree({
                 color: isActive ? "var(--fg)" : "var(--fg-1)",
                 background: isActive ? "var(--accent-soft)" : "transparent",
               }}
-              onClick={() => {
-                if (node.type === "folder") toggleExpand(node.path);
-                else onSelect(node.path);
+              onClick={onRowActivate}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onRowActivate();
+                }
               }}
               onContextMenu={(e) => handleContextMenu(e, node)}
               onDragStart={(e) => handleDragStart(e, node)}
@@ -489,7 +500,7 @@ export function FileTree({
               >
                 <MoreHorizontal size={14} aria-hidden="true" />
               </button>
-            </button>
+            </div>
             {node.type === "folder" && isExpanded && node.children && (
               <div>
                 {creating && creating.parentPath === node.path && (


### PR DESCRIPTION
Three bugs fixed in one pass after running the app and finding live issues.

## Tag-chip click → 500

Sidebar tag chip called \`onSelect(\`#${tag}\`)\` which the note-open handler tried to load as a literal note path. \`GET /api/notes/%23tag\` 500'd.

- \`Sidebar.tsx\` — new optional \`onTagSelect\` prop; chips call it.
- \`SidebarLayout.tsx\` — plumb the prop through.
- \`App.tsx\` — \`handleSidebarTagSelect\` sets \`pendingTag\` + \`view='tags'\`. \`<TagsView>\` is rendered with \`key={pendingTag}\` so a different tag remounts cleanly.
- \`TagsView.tsx\` — new \`initialTag\` prop seeds \`selectedTag\` on mount. Refactored the network fetches to \`react-query\` (already a project dep) so loading + data state lives outside React's effect machinery — satisfies the \`react-hooks/set-state-in-effect\` lint rule with no \`eslint-disable\`.

## Graph rail empty

\`/api/graph\` returned 6 nodes / 0 edges; canvas painted nothing. Three causes:

(a) ngraph's gravity is pure repulsion. With no edges the cluster's centre of mass drifts off-canvas. Per-step centroid recentering in \`forceLayout\` keeps the centroid at (0, 0).

(b) Viewport defaulted to (0, 0, 1) so world-origin mapped to canvas top-left. Pre-settle the layout 500 ticks then compute a bounding-box fit (clamped to \`scaleMin\`/\`scaleMax\`) and call \`setViewport\`. Same path runs from the recenter button.

(c) Continuing to step after the fit drifted positions past the framed bbox. New \`frozenRef\` — pre-settled then frozen. Drag unfreezes; pointer-up re-freezes.

## Button-in-button hydration

\`FileTree\` row was a \`<button>\` wrapping the Star + More-options buttons. Invalid HTML and a hydration warning on every page load.

\`FileTree.tsx\` — switch the row to \`<div role=\"treeitem\" tabIndex=0>\` with Enter/Space keyboard activation. Same accessible behaviour, valid HTML.

## Verified

Booted server + client, opened the app:
- 6 nodes visible and centred in the graph rail.
- Tag chip → tags view with that tag pre-filtered, no 500, no 404.
- Console: no errors, no warnings.
- ui tests 351/351 pass.

## Test plan

- [ ] Click each tag chip in sidebar; tags view opens with that tag selected, list of notes appears, no 500.
- [ ] Graph rail shows 6 nodes centred. Recenter button re-fits.
- [ ] Drag a node — simulation runs while held, freezes on release.
- [ ] Browser console clean across navigation: no errors, no warnings, no hydration mismatches.