### PR TITLE
fix(client): pixel-match design guide (round 4)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -59,8 +59,31 @@ export default function App() {
   );
 }
 
-function AppStatusBar({ notePath }: { notePath: string | null }) {
+function AppStatusBar({
+  notePath,
+  noteContent,
+}: {
+  notePath: string | null;
+  noteContent: string | null;
+}) {
   const cursorState = useUIStore((s) => s.cursorState);
+
+  // Derive outgoing-link and tag counts from the active note's content so the
+  // status bar tracks the live document, not just file metadata. Strip
+  // fenced code blocks first so wikilinks/hashtags inside snippets don't
+  // inflate the counts.
+  const { outgoing, tags, words } = useMemo(() => {
+    if (!noteContent) return { outgoing: 0, tags: 0, words: 0 };
+    const stripped = noteContent.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '');
+    const outgoingMatches = stripped.match(/\[\[[^\]]+\]\]/g) || [];
+    const tagMatches = stripped.match(/(^|\s)#[A-Za-z][\w-]*/g) || [];
+    const wordMatches = stripped.match(/\S+/g) || [];
+    return {
+      outgoing: outgoingMatches.length,
+      tags: tagMatches.length,
+      words: wordMatches.length,
+    };
+  }, [noteContent]);
 
   return (
     <div className="flex items-center">
@@ -69,7 +92,9 @@ function AppStatusBar({ notePath }: { notePath: string | null }) {
         notePath={notePath}
         line={cursorState.line}
         col={cursorState.col}
-        wordCount={cursorState.wordCount}
+        wordCount={cursorState.wordCount || words}
+        outgoingCount={outgoing}
+        tagsCount={tags}
       />
       <PluginSlot slot="statusbar-right" />
     </div>
@@ -342,10 +367,16 @@ function AppContent() {
           {/* EditorMeta — per prototype, the editor pane's own bottom rail
              (28px, bg-1) so it shares the baseline with the sidebar
              AgentsFooter and the graph legend. */}
-          <AppStatusBar notePath={notes.activeNote?.path ?? null} />
+          <AppStatusBar
+            notePath={notes.activeNote?.path ?? null}
+            noteContent={notes.activeNote?.content ?? null}
+          />
         </main>
 
-        {!editing && view === 'note' && (
+        {/* Graph rail is shown in every view except the fullscreen graph view
+            (matches prototype/app/main.jsx: graphPosition='right' && view!=='graph').
+            Previously hidden during edit mode — that broke the 3-pane layout. */}
+        {view !== 'graph' && view !== 'all' && view !== 'tags' && (
           <>
             <RightPanel
               rightPanelWidth={rightPanelWidth}

--- a/packages/client/src/components/Editor/Editor.tsx
+++ b/packages/client/src/components/Editor/Editor.tsx
@@ -239,18 +239,39 @@ export function EditorTabStrip({ activePath, activeTitle, dirty, onClose }: Edit
             return basename.endsWith('.md') ? basename : `${activeTitle}.md`;
           })()}
         </span>
-        {dirty && (
+        {/* Saved-status pill per prototype/app/editor.jsx EditorTabBar. The
+            dot pulses while dirty (mid-edit) and the label flips between
+            "saving" and "saved" — for now we always show "saved" since the
+            client autosaves on idle. */}
+        <span
+          className="mono"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            marginLeft: 4,
+            padding: '2px 6px',
+            borderRadius: 3,
+            background: 'var(--bg-1)',
+            border: '1px solid var(--line)',
+            fontSize: 10,
+            fontFamily: 'var(--font-mono)',
+            color: 'var(--fg-3)',
+          }}
+        >
           <span
-            className="dot pulse"
+            className={dirty ? 'dot pulse' : 'dot'}
             style={{
-              width: 6,
-              height: 6,
+              width: 5,
+              height: 5,
+              borderRadius: '50%',
+              background: dirty ? 'var(--accent)' : 'var(--accent-good)',
               boxShadow: 'none',
-              opacity: 1,
             }}
             aria-hidden
           />
-        )}
+          {dirty ? 'saving' : 'saved'}
+        </span>
         {hover && onClose && (
           <button
             onClick={onClose}

--- a/packages/client/src/components/Graph/GraphPanel.tsx
+++ b/packages/client/src/components/Graph/GraphPanel.tsx
@@ -101,7 +101,10 @@ export function GraphPanel({
   onModeChange,
   fullscreen = false,
 }: GraphPanelProps) {
-  const [internalMode, setInternalMode] = useState<'local' | 'global'>('local');
+  // Default to global so the rail always shows the whole graph at a glance.
+  // Local is the focus mode the user opts into to see "what's connected to
+  // this note"; global is the right idle state.
+  const [internalMode, setInternalMode] = useState<'local' | 'global'>('global');
   const mode = controlledMode ?? internalMode;
   const setMode = useCallback(
     (m: 'local' | 'global') => {

--- a/packages/client/src/components/Preview/Preview.tsx
+++ b/packages/client/src/components/Preview/Preview.tsx
@@ -11,6 +11,8 @@ interface PreviewProps {
   allNotes?: FileNode[];
   onCreateNote?: (name: string) => void;
   notePath?: string;
+  /** ISO timestamp of the note's last modification — surfaced in the meta header. */
+  modifiedAt?: string;
   /** Open a backlink note. When provided, the inline backlinks tail is clickable. */
   onNoteSelect?: (path: string) => void;
   getCodeFenceRenderer?: (language: string) => { component: React.ComponentType<{ content: string; notePath: string }> } | undefined;
@@ -29,16 +31,20 @@ interface PreviewProps {
 const MD_CSS = `
 .kryton-md .markdown-preview {
   font-family: var(--font-sans);
-  font-size: 14.5px;
+  /* prototype/app/editor.jsx PreviewBody: fontSize 15, lineHeight 1.7 */
+  font-size: 15px;
   line-height: 1.7;
   color: var(--fg-1);
-  padding: 28px 36px 80px;
+  /* Top padding handled by the meta-header row above; bottom keeps the
+     "scroll past content" feel from the prototype. */
+  padding: 8px 48px 80px;
   max-width: 760px;
   margin: 0 auto;
 }
 .kryton-md .markdown-preview h1 {
   font-family: var(--font-display);
-  font-size: 28px;
+  /* prototype: fontSize 32, letterSpacing -0.4 */
+  font-size: 32px;
   font-weight: 600;
   letter-spacing: -0.4px;
   color: var(--fg);
@@ -190,6 +196,7 @@ export function Preview({
   allNotes,
   onCreateNote,
   notePath = '',
+  modifiedAt,
   onNoteSelect,
   getCodeFenceRenderer,
 }: PreviewProps) {
@@ -240,6 +247,51 @@ export function Preview({
   return (
     <div className="kryton-md">
       <style>{MD_CSS}</style>
+      {/* Meta header per prototype/app/editor.jsx PreviewBody:
+          file-icon · path · words · updated <date>. Sits above the h1 in
+          mono 11.5px / --fg-3, matching the design tokens. */}
+      {notePath && (
+        <div
+          className="mono"
+          style={{
+            maxWidth: 760,
+            margin: '0 auto',
+            padding: '28px 48px 0',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 0,
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11.5,
+            color: 'var(--fg-3)',
+          }}
+        >
+          <Icons.FileText size={11} aria-hidden />
+          <span>/{notePath}</span>
+          {(() => {
+            const words = (content.replace(/`{1,3}.*?`{1,3}/gs, '').match(/\S+/g) || []).length;
+            return (
+              <>
+                <span aria-hidden>·</span>
+                <span>{words} words</span>
+              </>
+            );
+          })()}
+          {modifiedAt && (
+            <>
+              <span style={{ flex: 1 }} aria-hidden />
+              <span>
+                updated{' '}
+                {new Date(modifiedAt).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </span>
+            </>
+          )}
+        </div>
+      )}
       <NotePreviewReact
         content={processedContent}
         onLinkClick={onLinkClick}

--- a/packages/client/src/components/Sidebar/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar/Sidebar.tsx
@@ -361,6 +361,7 @@ export function Sidebar({
         <NavRow
           icon={<Icons.Hash size={14} />}
           label="Tags"
+          hint={tags.length || undefined}
           active={view === 'tags'}
           onClick={handleTagsClick}
         />

--- a/packages/client/src/components/Views/EditModeView.tsx
+++ b/packages/client/src/components/Views/EditModeView.tsx
@@ -2,7 +2,6 @@ import { ComponentType, useRef, useState, useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { FileNode } from '../../lib/api';
 import { Editor, type EditorCursorState, type EditorHandle, EditorTabStrip, ModePills } from '../Editor/Editor';
-import { EditorToolbar } from '../Editor/EditorToolbar';
 import { Preview } from '../Preview/Preview';
 // OutgoingLinksPanel intentionally removed to match design handoff: the
 // editor surface has only the tab strip + body + EditorMeta (28px). Outgoing
@@ -179,8 +178,10 @@ export function EditModeView({
         </div>
       </div>
 
-      {/* Toolbar (formatting) */}
-      {showEditor && <EditorToolbar editorRef={editorRef} />}
+      {/* Formatting toolbar removed per design guide — the prototype's editor
+          pane has only the tab strip + mode pills above the body, no separate
+          toolbar row. In-editor formatting goes through keyboard shortcuts;
+          plugin-supplied buttons live in the status bar via PluginSlot. */}
 
       {/* Body */}
       <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>

--- a/packages/client/src/components/Views/PreviewModeView.tsx
+++ b/packages/client/src/components/Views/PreviewModeView.tsx
@@ -10,7 +10,7 @@ import { Icons } from '../Icons';
 import { usePrefs, type EditorLayout } from '../../stores/prefsStore';
 
 interface PreviewModeViewProps {
-  activeNote: { path: string; title: string; content: string };
+  activeNote: { path: string; title: string; content: string; modifiedAt?: string };
   isStarred: boolean;
   allNotes: FileNode[];
   previewRef: MutableRefObject<HTMLDivElement | null>;
@@ -340,6 +340,7 @@ export function PreviewModeView({
             allNotes={allNotes}
             onCreateNote={onCreateNote}
             notePath={activeNote.path}
+            modifiedAt={activeNote.modifiedAt}
             onNoteSelect={onNoteSelect}
             getCodeFenceRenderer={getCodeFenceRenderer}
           />

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -54,10 +54,12 @@ export function GraphView({
     const bboxW = Math.max(1, maxX - minX);
     const bboxH = Math.max(1, maxY - minY);
     const margin = 60;
-    // Allow zooming in past 1× when the cluster is small — the bbox can be
-    // tiny for sparse graphs, and we want nodes to be visible, not pinheads.
+    // Auto-fit caps zoom-in at 1.5× so a sparse cluster doesn't blow up
+    // node radii to the size of the rail. User can still pinch / wheel up
+    // to scaleMax manually.
+    const AUTO_FIT_MAX_K = 1.5;
     const k = Math.min(
-      GRAPH_CONFIG.zoom.scaleMax,
+      AUTO_FIT_MAX_K,
       Math.max(
         GRAPH_CONFIG.zoom.scaleMin,
         Math.min((w - margin) / bboxW, (h - margin) / bboxH),


### PR DESCRIPTION
## Summary
- Status bar derives outgoing/tags/words from the active note's content (not just live editor cursor state)
- Preview meta header: `/path · N words` left, `updated <date>` right — matches `prototype/app/editor.jsx PreviewBody`
- Tab strip: always-visible `saved`/`saving` pulse pill (matches prototype line ~123-131)
- Sidebar: Tags primary-nav row shows tag count, mirroring `All notes 6`
- Default graph mode: `global` (was `local`)
- Removed standalone formatting toolbar — prototype has none
- Graph rail visible in all editor modes (was hidden during editing)
- Auto-fit zoom capped at 1.5× so a sparse cluster stays readable on first paint

## Test plan
- [x] tsc --noEmit clean
- [x] Manual: status bar shows data-derived counts (not zeros)
- [x] Manual: preview meta shows updated date right-aligned
- [x] Manual: graph rail visible in all modes