### PR TITLE
fix(client): wire backlinks count into status bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ pgdata/
 
 # Installed plugins (downloaded from registry at runtime)
 packages/server/plugins/
+packages/server/data
 packages/server/data/
 *.db

--- a/package-lock.json
+++ b/package-lock.json
@@ -6755,7 +6755,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -13540,7 +13539,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -18268,6 +18266,7 @@
         "@prisma/client": "^7.5.0",
         "better-auth": "^1.5.6",
         "better-sqlite3": "^12.8.0",
+        "chokidar": "^4.0.3",
         "date-fns": "^4.1.0",
         "dotenv": "^16.6.1",
         "fastify": "^5.2.0",
@@ -18434,15 +18433,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "packages/ui/node_modules/lucide-react": {
-      "version": "0.460.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz",
-      "integrity": "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "packages/ui/node_modules/tough-cookie": {

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -41,6 +41,7 @@ import { EmptyStateView } from './components/Views/EmptyStateView';
 import { ModalsContainer } from './components/Modals/ModalsContainer';
 import { ErrorToast } from './components/Toast/ErrorToast';
 import { ToastContainer } from './components/Toast/ToastContainer';
+import { NoteHistoryPopover } from './components/NoteHistoryPopover/NoteHistoryPopover';
 import { StatusBar } from './components/StatusBar/StatusBar';
 import { api, FileNode } from './lib/api';
 import LoginPage from './pages/LoginPage';
@@ -471,6 +472,11 @@ function AppContent() {
       <ErrorToast message={notes.error} onDismiss={() => notes.setError(null)} />
 
       <ToastContainer />
+
+      <NoteHistoryPopover
+        activePath={notes.activeNote?.path ?? null}
+        onRestored={() => notes.activeNote && notes.openNote(notes.activeNote.path)}
+      />
 
       <AppModals
         noteTree={notes.tree}

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -67,6 +67,7 @@ function AppStatusBar({
   noteContent: string | null;
 }) {
   const cursorState = useUIStore((s) => s.cursorState);
+  const editing = useUIStore((s) => s.editing);
 
   // Backlinks count is server-derived (live indexer); cached so the bar
   // reflects current cross-references without forcing extra fetches.
@@ -78,16 +79,58 @@ function AppStatusBar({
   });
   const backlinksCount = backlinksQuery.data?.length ?? 0;
 
-  // Derive outgoing-link and tag counts from the active note's content so the
-  // status bar tracks the live document, not just file metadata. Strip
-  // fenced code blocks first so wikilinks/hashtags inside snippets don't
-  // inflate the counts.
+  // Derive outgoing-link, tag, and word counts from the active note's content
+  // so the status bar tracks the live document. For the word count we strip
+  // every markdown syntax marker that a reader wouldn't count as a word —
+  // headings, list bullets, blockquote arrows, bold/italic emphasis,
+  // strikethroughs, inline code, code fences, and wiki/markdown link wrappers
+  // — so '# Title' counts as one word ('Title'), '**bold**' as one ('bold'),
+  // and '[link](url)' as one ('link').
   const { outgoing, tags, words } = useMemo(() => {
     if (!noteContent) return { outgoing: 0, tags: 0, words: 0 };
-    const stripped = noteContent.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '');
-    const outgoingMatches = stripped.match(/\[\[[^\]]+\]\]/g) || [];
-    const tagMatches = stripped.match(/(^|\s)#[A-Za-z][\w-]*/g) || [];
-    const wordMatches = stripped.match(/\S+/g) || [];
+    // Count outgoing wikilinks and tags from the raw text (before stripping
+    // markdown) since those constructs ARE the thing being counted.
+    const outgoingMatches = noteContent.match(/\[\[[^\]]+\]\]/g) || [];
+    const tagMatches = noteContent.match(/(^|\s)#[A-Za-z][\w-]*/g) || [];
+
+    // Word count uses a markdown-aware strip so syntax tokens don't pollute
+    // the result. Order matters: remove fences first, then inline markers.
+    const cleaned = noteContent
+      // Front-matter
+      .replace(/^---[\s\S]*?---\n*/m, '')
+      // Fenced code blocks
+      .replace(/```[\s\S]*?```/g, ' ')
+      // Inline code
+      .replace(/`[^`]*`/g, ' ')
+      // Wikilinks: [[Target|Label]] or [[Target]] → keep the visible label
+      .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2')
+      .replace(/\[\[([^\]]+)\]\]/g, '$1')
+      // Markdown links: [text](url) → text; image alts dropped entirely
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+      // Reference-style link targets like '[1]: http://…'
+      .replace(/^\s*\[[^\]]+\]:\s.*$/gm, '')
+      // HTML tags
+      .replace(/<[^>]+>/g, ' ')
+      // Heading markers '# ' '## ' …, list bullets '- ', '* ', '+ ',
+      // ordered-list markers '1. ', blockquote arrows '> '
+      .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+      .replace(/^\s*[-*+]\s+/gm, '')
+      .replace(/^\s*\d+\.\s+/gm, '')
+      .replace(/^\s*>\s?/gm, '')
+      // Horizontal rules
+      .replace(/^\s*([-*_])\1{2,}\s*$/gm, ' ')
+      // Emphasis markers (keep inner text)
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/__([^_]+)__/g, '$1')
+      .replace(/\*([^*]+)\*/g, '$1')
+      .replace(/_([^_]+)_/g, '$1')
+      // Strikethrough
+      .replace(/~~([^~]+)~~/g, '$1')
+      // Task list markers
+      .replace(/^\s*[-*+]?\s*\[[ xX]\]\s+/gm, '');
+
+    const wordMatches = cleaned.match(/[A-Za-z0-9][A-Za-z0-9'_-]*/g) || [];
     return {
       outgoing: outgoingMatches.length,
       tags: tagMatches.length,
@@ -100,9 +143,13 @@ function AppStatusBar({
       <PluginSlot slot="statusbar-left" />
       <StatusBar
         notePath={notePath}
-        line={cursorState.line}
-        col={cursorState.col}
-        wordCount={cursorState.wordCount || words}
+        // Ln/Col is only meaningful in edit mode (no cursor in preview).
+        line={editing ? cursorState.line : null}
+        col={editing ? cursorState.col : null}
+        // Editor's reported word count uses raw doc.split — prefer the
+        // preview-rendered count when not editing (or when the editor count
+        // is zero, e.g. fresh mount).
+        wordCount={editing && cursorState.wordCount ? cursorState.wordCount : words}
         outgoingCount={outgoing}
         backlinksCount={backlinksCount}
         tagsCount={tags}

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useCallback, useState } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { AuthProvider } from './hooks/useAuth';
 import { PluginSlotRegistry, PluginProvider, usePluginSlots } from '@azrtydxb/ui';
 import { ClientPluginManager } from './plugins/PluginManager';
@@ -42,7 +42,7 @@ import { ModalsContainer } from './components/Modals/ModalsContainer';
 import { ErrorToast } from './components/Toast/ErrorToast';
 import { ToastContainer } from './components/Toast/ToastContainer';
 import { StatusBar } from './components/StatusBar/StatusBar';
-import { FileNode } from './lib/api';
+import { api, FileNode } from './lib/api';
 import LoginPage from './pages/LoginPage';
 
 export default function App() {
@@ -67,6 +67,16 @@ function AppStatusBar({
   noteContent: string | null;
 }) {
   const cursorState = useUIStore((s) => s.cursorState);
+
+  // Backlinks count is server-derived (live indexer); cached so the bar
+  // reflects current cross-references without forcing extra fetches.
+  const backlinksQuery = useQuery({
+    queryKey: ['backlinks-count', notePath],
+    queryFn: () => (notePath ? api.getBacklinks(notePath) : Promise.resolve([])),
+    enabled: !!notePath,
+    staleTime: 5_000,
+  });
+  const backlinksCount = backlinksQuery.data?.length ?? 0;
 
   // Derive outgoing-link and tag counts from the active note's content so the
   // status bar tracks the live document, not just file metadata. Strip
@@ -94,6 +104,7 @@ function AppStatusBar({
         col={cursorState.col}
         wordCount={cursorState.wordCount || words}
         outgoingCount={outgoing}
+        backlinksCount={backlinksCount}
         tagsCount={tags}
       />
       <PluginSlot slot="statusbar-right" />

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -255,8 +255,8 @@ function AppContent() {
 
   if (loading) {
     return (
-      <div className="h-screen flex items-center justify-center bg-white dark:bg-surface-950">
-        <div className="text-gray-500 dark:text-gray-400">Loading...</div>
+      <div className="h-screen flex items-center justify-center" style={{ background: 'var(--bg)' }}>
+        <div style={{ color: 'var(--fg-3)' }}>Loading...</div>
       </div>
     );
   }
@@ -266,7 +266,7 @@ function AppContent() {
   }
 
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-white dark:bg-surface-950">
+    <div className="h-screen flex flex-col overflow-hidden" style={{ background: 'var(--bg)' }}>
       <Header
         mobileMenuOpen={mobileMenuOpen}
         setMobileMenuOpen={setMobileMenuOpen}

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -331,7 +331,6 @@ function AppContent() {
                 starredPaths={starredPaths}
                 onNoteSelect={(p) => { handleNoteSelect(p); setView('note'); }}
                 fullscreen
-                mode="global"
               />
             ) : view === 'tags' ? (
               <TagsView

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -116,10 +116,16 @@ function AppModals({
   noteTree,
   onTemplateSelected,
   onNoteSelect,
+  onNewNote,
+  onDailyNote,
+  onGraphView,
 }: {
   noteTree: FileNode[];
   onTemplateSelected: (content: string) => void;
   onNoteSelect: (path: string) => void;
+  onNewNote?: () => void;
+  onDailyNote?: () => void;
+  onGraphView?: () => void;
 }) {
   const showTemplatePicker = useUIStore((s) => s.showTemplatePicker);
   const setShowTemplatePicker = useUIStore((s) => s.setShowTemplatePicker);
@@ -153,6 +159,10 @@ function AppModals({
       onCloseShareDialog={() => setShowShareDialog(false)}
       onCloseAccessRequests={() => setShowAccessRequests(false)}
       onCloseAccountSettings={() => setShowAccountSettings(false)}
+      onNewNote={onNewNote}
+      onDailyNote={onDailyNote}
+      onGraphView={onGraphView}
+      onSettings={() => setShowAccountSettings(true)}
     />
   );
 }
@@ -417,6 +427,9 @@ function AppContent() {
         noteTree={notes.tree}
         onTemplateSelected={handleTemplateSelected}
         onNoteSelect={handleNoteSelect}
+        onNewNote={callbacks.handleNewNote}
+        onDailyNote={callbacks.handleDailyNote}
+        onGraphView={() => setView('graph')}
       />
     </div>
   );

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -209,6 +209,7 @@ function AppContent() {
     toggleStar,
     toggleActiveNoteStar,
     handleNoteSelect,
+    handleTabClose,
     handleLinkClick,
     handleCreateNoteFromLink,
     handleDailyNote,
@@ -360,6 +361,7 @@ function AppContent() {
                   onContentChange={setEditContent}
                   onCursorStateChange={setCursorState}
                   onNoteSelect={handleNoteSelect}
+                  onTabClose={handleTabClose}
                   onLinkClick={handleLinkClick}
                   onCreateNote={handleCreateNoteFromLink}
                 />
@@ -374,6 +376,7 @@ function AppContent() {
                   onToggleStar={toggleActiveNoteStar}
                   onPdfExport={handlePdfExport}
                   onNoteSelect={handleNoteSelect}
+                  onTabClose={handleTabClose}
                   onLinkClick={handleLinkClick}
                   onCreateNote={handleCreateNoteFromLink}
                   onRestored={() => notes.openNote(notes.activeNote!.path)}

--- a/packages/client/src/components/ApiKeys/ApiKeyManager.tsx
+++ b/packages/client/src/components/ApiKeys/ApiKeyManager.tsx
@@ -1,11 +1,21 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ApiKeysPanel } from '@azrtydxb/ui';
 import type { ApiKeyInfo as UiApiKeyInfo, ApiKeyScope, ApiKeyExpiry, NewApiKeyResult } from '@azrtydxb/ui';
 import { apiKeyApi } from '../../lib/api';
+import {
+  Section,
+  Field,
+  Toolbar,
+  helpText,
+  inputStyle,
+  primaryBtn,
+  ghostBtn,
+  dangerBtn,
+} from '../Settings/settings-kit';
 
 /**
- * Thin wrapper around @azrtydxb/ui ApiKeysPanel.
- * Manages HTTP data-fetching; ui component handles all rendering.
+ * Renders the API-keys management surface inline, matching the visual
+ * language of AppearanceSection (the Settings dialog gold standard).
+ * Data is fetched via apiKeyApi; rendering uses the shared settings-kit.
  */
 export function ApiKeyManager() {
   const [keys, setKeys] = useState<UiApiKeyInfo[]>([]);
@@ -13,20 +23,28 @@ export function ApiKeyManager() {
   const [error, setError] = useState<string | null>(null);
   const [newKeyResult, setNewKeyResult] = useState<NewApiKeyResult | null>(null);
 
+  // Create-form state.
+  const [showForm, setShowForm] = useState(false);
+  const [formName, setFormName] = useState('');
+  const [formScope, setFormScope] = useState<ApiKeyScope>('read-only');
+  const [formExpiry, setFormExpiry] = useState<ApiKeyExpiry>('90d');
+  const [submitting, setSubmitting] = useState(false);
+
   const fetchKeys = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const result = await apiKeyApi.list();
-      // Map to ui's ApiKeyInfo shape (field names are identical)
-      setKeys(result.map(k => ({
-        id: k.id,
-        name: k.name,
-        keyPrefix: k.keyPrefix,
-        scope: k.scope as ApiKeyScope,
-        lastUsedAt: k.lastUsedAt,
-        expiresAt: k.expiresAt,
-      })));
+      setKeys(
+        result.map((k) => ({
+          id: k.id,
+          name: k.name,
+          keyPrefix: k.keyPrefix,
+          scope: k.scope as ApiKeyScope,
+          lastUsedAt: k.lastUsedAt,
+          expiresAt: k.expiresAt,
+        })),
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load API keys');
     } finally {
@@ -38,49 +56,215 @@ export function ApiKeyManager() {
     fetchKeys();
   }, [fetchKeys]);
 
-  const handleMint = useCallback(async (
-    name: string,
-    scope: ApiKeyScope,
-    expiry: ApiKeyExpiry,
-  ) => {
+  const handleMint = useCallback(async () => {
+    if (!formName.trim()) {
+      setError('Name is required');
+      return;
+    }
+    setSubmitting(true);
     setError(null);
     try {
       let expiresAt: string | undefined;
-      if (expiry !== 'never') {
+      if (formExpiry !== 'never') {
         const d = new Date();
-        if (expiry === '30d') d.setDate(d.getDate() + 30);
-        else if (expiry === '90d') d.setDate(d.getDate() + 90);
-        else if (expiry === '1y') d.setFullYear(d.getFullYear() + 1);
+        if (formExpiry === '30d') d.setDate(d.getDate() + 30);
+        else if (formExpiry === '90d') d.setDate(d.getDate() + 90);
+        else if (formExpiry === '1y') d.setFullYear(d.getFullYear() + 1);
         expiresAt = d.toISOString();
       }
-      const result = await apiKeyApi.create({ name, scope, expiresAt });
+      const result = await apiKeyApi.create({ name: formName.trim(), scope: formScope, expiresAt });
       setNewKeyResult({ id: result.id, key: result.key });
+      setFormName('');
+      setFormScope('read-only');
+      setFormExpiry('90d');
+      setShowForm(false);
       await fetchKeys();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create API key');
+    } finally {
+      setSubmitting(false);
     }
-  }, [fetchKeys]);
+  }, [fetchKeys, formName, formScope, formExpiry]);
 
-  const handleRevoke = useCallback(async (id: string) => {
-    setError(null);
-    try {
-      await apiKeyApi.revoke(id);
-      if (newKeyResult?.id === id) setNewKeyResult(null);
-      await fetchKeys();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to revoke API key');
-    }
-  }, [fetchKeys, newKeyResult]);
+  const handleRevoke = useCallback(
+    async (id: string) => {
+      setError(null);
+      try {
+        await apiKeyApi.revoke(id);
+        if (newKeyResult?.id === id) setNewKeyResult(null);
+        await fetchKeys();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to revoke API key');
+      }
+    },
+    [fetchKeys, newKeyResult],
+  );
+
+  const errorText: React.CSSProperties = { ...helpText, color: 'var(--accent-danger)', marginBottom: 12 };
+
+  const cardStyle: React.CSSProperties = {
+    background: 'var(--bg-1)',
+    border: '1px solid var(--line)',
+    borderRadius: 6,
+    padding: '10px 12px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    marginBottom: 8,
+  };
+
+  const badgeStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 10.5,
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase',
+    color: 'var(--fg-3)',
+    border: '1px solid var(--line)',
+    borderRadius: 4,
+    padding: '2px 6px',
+    background: 'var(--bg-2)',
+  };
+
+  const monoName: React.CSSProperties = {
+    fontFamily: 'var(--font-mono)',
+    fontSize: 12,
+    color: 'var(--fg)',
+  };
+
+  const formatLastUsed = (iso?: string | null) => {
+    if (!iso) return 'never used';
+    const d = new Date(iso);
+    return `used ${d.toLocaleDateString()}`;
+  };
 
   return (
-    <ApiKeysPanel
-      keys={keys}
-      isLoading={loading}
-      error={error}
-      newKeyResult={newKeyResult}
-      onDismissNewKey={() => setNewKeyResult(null)}
-      onMint={handleMint}
-      onRevoke={handleRevoke}
-    />
+    <Section title="api keys">
+      <div style={helpText}>
+        Personal access tokens for programmatic access. Treat them like passwords.
+      </div>
+
+      {error && <div style={errorText}>{error}</div>}
+
+      {newKeyResult && (
+        <div
+          style={{
+            background: 'var(--bg-1)',
+            border: '1px solid var(--line)',
+            borderRadius: 6,
+            padding: '10px 12px',
+            marginBottom: 12,
+          }}
+        >
+          <div style={{ ...helpText, marginBottom: 6 }}>
+            Copy this key now — it will not be shown again.
+          </div>
+          <div style={{ ...monoName, wordBreak: 'break-all', marginBottom: 8 }}>
+            {newKeyResult.key}
+          </div>
+          <Toolbar>
+            <button
+              type="button"
+              style={ghostBtn}
+              onClick={() => {
+                void navigator.clipboard?.writeText(newKeyResult.key);
+              }}
+            >
+              copy
+            </button>
+            <button type="button" style={ghostBtn} onClick={() => setNewKeyResult(null)}>
+              dismiss
+            </button>
+          </Toolbar>
+        </div>
+      )}
+
+      {loading ? (
+        <div style={helpText}>Loading keys...</div>
+      ) : keys.length === 0 ? (
+        <div style={helpText}>No API keys yet.</div>
+      ) : (
+        <div style={{ marginBottom: 14 }}>
+          {keys.map((k) => (
+            <div key={k.id} style={cardStyle}>
+              <div style={{ ...monoName, minWidth: 0 }}>
+                {k.name}
+                <span style={{ color: 'var(--fg-3)', marginLeft: 8 }}>{k.keyPrefix}…</span>
+              </div>
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginLeft: 'auto' }}>
+                <span style={badgeStyle}>{k.scope}</span>
+                <span style={badgeStyle}>{formatLastUsed(k.lastUsedAt)}</span>
+                <button type="button" style={dangerBtn} onClick={() => handleRevoke(k.id)}>
+                  revoke
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!showForm ? (
+        <Toolbar>
+          <button type="button" style={primaryBtn} onClick={() => setShowForm(true)}>
+            create key
+          </button>
+        </Toolbar>
+      ) : (
+        <div style={{ marginTop: 6 }}>
+          <Field label="name">
+            <input
+              type="text"
+              value={formName}
+              onChange={(e) => setFormName(e.target.value)}
+              placeholder="e.g. ci-pipeline"
+              style={inputStyle}
+              autoFocus
+            />
+          </Field>
+          <Field label="scope">
+            <select
+              value={formScope}
+              onChange={(e) => setFormScope(e.target.value as ApiKeyScope)}
+              style={inputStyle}
+            >
+              <option value="read-only">read-only</option>
+              <option value="read-write">read-write</option>
+            </select>
+          </Field>
+          <Field label="expires in">
+            <select
+              value={formExpiry}
+              onChange={(e) => setFormExpiry(e.target.value as ApiKeyExpiry)}
+              style={inputStyle}
+            >
+              <option value="30d">30 days</option>
+              <option value="90d">90 days</option>
+              <option value="1y">1 year</option>
+              <option value="never">never</option>
+            </select>
+          </Field>
+          <Toolbar>
+            <button
+              type="button"
+              style={{ ...primaryBtn, opacity: submitting ? 0.6 : 1 }}
+              onClick={handleMint}
+              disabled={submitting}
+            >
+              {submitting ? 'creating…' : 'generate'}
+            </button>
+            <button
+              type="button"
+              style={ghostBtn}
+              onClick={() => {
+                setShowForm(false);
+                setError(null);
+              }}
+              disabled={submitting}
+            >
+              cancel
+            </button>
+          </Toolbar>
+        </div>
+      )}
+    </Section>
   );
 }

--- a/packages/client/src/components/ApiKeys/ApiKeyManager.tsx
+++ b/packages/client/src/components/ApiKeys/ApiKeyManager.tsx
@@ -1,16 +1,14 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { ApiKeyInfo as UiApiKeyInfo, ApiKeyScope, ApiKeyExpiry, NewApiKeyResult } from '@azrtydxb/ui';
 import { apiKeyApi } from '../../lib/api';
+import { Section, Field, Toolbar } from '../Settings/settings-kit';
 import {
-  Section,
-  Field,
-  Toolbar,
   helpText,
   inputStyle,
   primaryBtn,
   ghostBtn,
   dangerBtn,
-} from '../Settings/settings-kit';
+} from '../Settings/settings-kit-styles';
 
 /**
  * Renders the API-keys management surface inline, matching the visual

--- a/packages/client/src/components/Editor/Editor.tsx
+++ b/packages/client/src/components/Editor/Editor.tsx
@@ -195,28 +195,25 @@ interface EditorTabStripProps {
  * so we render a single tab. Designed to extend to multi-tab later.
  */
 export function EditorTabStrip({ activePath, activeTitle, dirty, onClose }: EditorTabStripProps) {
-  const [hover, setHover] = useState(false);
+  void dirty;
+  void onClose;
 
   return (
     <div
       style={{
         display: 'flex',
-        alignItems: 'stretch',
-        height: 32,
+        alignItems: 'center',
+        height: 38,
         background: 'var(--bg)',
         flexShrink: 0,
       }}
     >
       <div
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
         style={{
           display: 'flex',
           alignItems: 'center',
           gap: 8,
-          padding: '6px 12px',
-          borderBottom: '2px solid var(--accent)',
-          marginBottom: -1,
+          padding: '0 12px',
           minWidth: 0,
           maxWidth: 280,
         }}
@@ -239,10 +236,8 @@ export function EditorTabStrip({ activePath, activeTitle, dirty, onClose }: Edit
             return basename.endsWith('.md') ? basename : `${activeTitle}.md`;
           })()}
         </span>
-        {/* Saved-status pill per prototype/app/editor.jsx EditorTabBar. The
-            dot pulses while dirty (mid-edit) and the label flips between
-            "saving" and "saved" — for now we always show "saved" since the
-            client autosaves on idle. */}
+        {/* Saved-status pill per prototype/app/editor.jsx EditorTabBar — always
+            shows the green pulsing dot + literal "saved" label. */}
         <span
           className="mono"
           style={{
@@ -260,44 +255,18 @@ export function EditorTabStrip({ activePath, activeTitle, dirty, onClose }: Edit
           }}
         >
           <span
-            className={dirty ? 'dot pulse' : 'dot'}
+            className="dot pulse"
             style={{
               width: 5,
               height: 5,
               borderRadius: '50%',
-              background: dirty ? 'var(--accent)' : 'var(--accent-good)',
+              background: 'var(--accent-good)',
               boxShadow: 'none',
             }}
             aria-hidden
           />
-          {dirty ? 'saving' : 'saved'}
+          saved
         </span>
-        {hover && onClose && (
-          <button
-            onClick={onClose}
-            title="Close"
-            style={{
-              marginLeft: 2,
-              width: 16,
-              height: 16,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              borderRadius: 3,
-              color: 'var(--fg-3)',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background = 'var(--bg-hover)';
-              e.currentTarget.style.color = 'var(--fg)';
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background = 'transparent';
-              e.currentTarget.style.color = 'var(--fg-3)';
-            }}
-          >
-            <Icons.X size={12} />
-          </button>
-        )}
       </div>
     </div>
   );
@@ -334,7 +303,7 @@ export function ModePills({ value, onChange }: ModePillsProps) {
       style={{
         display: 'inline-flex',
         alignItems: 'center',
-        gap: 2,
+        gap: 1,
         padding: 2,
         borderRadius: 7,
         background: 'var(--bg-1)',
@@ -363,7 +332,7 @@ function ModePill({
     display: 'inline-flex',
     alignItems: 'center',
     gap: 5,
-    padding: '4px 10px',
+    padding: '4px 8px',
     borderRadius: 5,
     fontFamily: 'var(--font-mono)',
     fontSize: 11.5,

--- a/packages/client/src/components/Editor/Editor.tsx
+++ b/packages/client/src/components/Editor/Editor.tsx
@@ -317,11 +317,11 @@ function Tab({ path, label, active, dirty, onSelect, onClose }: TabProps) {
 export function EditorTabStrip({ activePath, activeTitle, dirty, onSelect, onClose }: EditorTabStripProps) {
   const openTabs = useUIStore((s) => s.openTabs);
 
-  // Defensive: if the active note isn't yet in openTabs (e.g. very first
-  // render before handleNoteSelect's store mutation flushes), surface it
-  // anyway so the strip never looks empty while a note is loaded.
+  // If a load races ahead of the store update (active note set but tabs
+  // not yet flushed), surface the active path so the strip isn't briefly
+  // empty. Once openTabs catches up, this branch falls through to the
+  // store-driven list.
   const tabs = useMemo(() => {
-    if (openTabs.length === 0) return activePath ? [activePath] : [];
     if (activePath && !openTabs.includes(activePath)) return [...openTabs, activePath];
     return openTabs;
   }, [openTabs, activePath]);

--- a/packages/client/src/components/Editor/Editor.tsx
+++ b/packages/client/src/components/Editor/Editor.tsx
@@ -1,6 +1,7 @@
 import {
   useRef,
   useState,
+  useMemo,
   useImperativeHandle,
   forwardRef,
   type CSSProperties,
@@ -8,6 +9,7 @@ import {
 import { EditorView, type EditorPlugin, type EditorState } from '@azrtydxb/ui';
 import { Icons } from '../Icons';
 import { usePrefs, type EditorLayout } from '../../stores/prefsStore';
+import { useUIStore } from '../../stores/uiStore';
 
 export interface EditorCursorState {
   line: number;
@@ -183,91 +185,172 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(function Editor(
 /* -------------------------------------------------------------------------- */
 
 interface EditorTabStripProps {
+  /** Path of the currently-active tab. Comes from useAppState.notes.activeNote. */
   activePath: string;
+  /** Display title (used to derive the basename when the path lacks a .md). */
   activeTitle: string;
-  /** When true, the dirty-pulse dot is shown (replaces the "saved" check briefly). */
+  /** When true the active tab shows a saving-pulse instead of the green "saved" dot. */
   dirty?: boolean;
-  onClose?: () => void;
+  /** Called when the user selects a different tab. */
+  onSelect: (path: string) => void;
+  /** Called when the user closes a tab. */
+  onClose: (path: string) => void;
 }
 
-/**
- * Single-tab strip — the existing client only tracks one active note,
- * so we render a single tab. Designed to extend to multi-tab later.
- */
-export function EditorTabStrip({ activePath, activeTitle, dirty, onClose }: EditorTabStripProps) {
-  void dirty;
-  void onClose;
+function basenameOf(path: string, fallback: string): string {
+  const base = path.split('/').filter(Boolean).pop() || fallback;
+  return base.endsWith('.md') ? base : `${fallback}.md`;
+}
 
+interface TabProps {
+  path: string;
+  label: string;
+  active: boolean;
+  dirty: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+}
+
+/** A single chip in the tab strip — file icon, basename, saved/saving pill, X. */
+function Tab({ path, label, active, dirty, onSelect, onClose }: TabProps) {
+  const [hovered, setHovered] = useState(false);
   return (
     <div
+      role="tab"
+      aria-selected={active}
+      onClick={onSelect}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      title={path}
       style={{
-        display: 'flex',
+        display: 'inline-flex',
         alignItems: 'center',
+        gap: 8,
         height: 38,
-        background: 'var(--bg)',
-        flexShrink: 0,
+        padding: '0 10px 0 12px',
+        cursor: active ? 'default' : 'pointer',
+        background: active ? 'var(--bg)' : 'transparent',
+        borderRight: '1px solid var(--line)',
+        color: active ? 'var(--fg)' : 'var(--fg-3)',
+        minWidth: 0,
+        maxWidth: 240,
       }}
     >
-      <div
+      <Icons.FileText size={13} style={{ color: active ? 'var(--accent)' : 'var(--fg-4)' }} />
+      <span
+        className="mono"
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          padding: '0 12px',
-          minWidth: 0,
-          maxWidth: 280,
+          fontFamily: 'var(--font-mono)',
+          fontSize: 12,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
         }}
       >
-        <Icons.FileText size={13} style={{ color: 'var(--accent)' }} />
-        <span
-          className="mono"
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 12,
-            color: 'var(--fg)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-          title={activePath}
-        >
-          {(() => {
-            const basename = activePath.split('/').filter(Boolean).pop() || activeTitle;
-            return basename.endsWith('.md') ? basename : `${activeTitle}.md`;
-          })()}
-        </span>
-        {/* Saved-status pill per prototype/app/editor.jsx EditorTabBar — always
-            shows the green pulsing dot + literal "saved" label. */}
+        {label}
+      </span>
+      {active && (
         <span
           className="mono"
           style={{
             display: 'inline-flex',
             alignItems: 'center',
             gap: 4,
-            marginLeft: 4,
+            marginLeft: 2,
             padding: '2px 6px',
             borderRadius: 3,
             background: 'var(--bg-1)',
             border: '1px solid var(--line)',
             fontSize: 10,
-            fontFamily: 'var(--font-mono)',
             color: 'var(--fg-3)',
           }}
         >
           <span
-            className="dot pulse"
+            className={dirty ? 'dot pulse' : 'dot pulse'}
             style={{
               width: 5,
               height: 5,
               borderRadius: '50%',
-              background: 'var(--accent-good)',
+              background: dirty ? 'var(--accent-warn)' : 'var(--accent-good)',
               boxShadow: 'none',
             }}
             aria-hidden
           />
-          saved
+          {dirty ? 'saving' : 'saved'}
         </span>
-      </div>
+      )}
+      <button
+        type="button"
+        aria-label={`Close ${label}`}
+        title={`Close ${label}`}
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        style={{
+          marginLeft: 2,
+          width: 18,
+          height: 18,
+          borderRadius: 3,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'transparent',
+          color: 'var(--fg-3)',
+          // Hide unless the tab is hovered or active — avoids visual clutter
+          // when many tabs are open and the user isn't aiming at any of them.
+          visibility: hovered || active ? 'visible' : 'hidden',
+          cursor: 'pointer',
+        }}
+        onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--fg)'; }}
+        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--fg-3)'; }}
+      >
+        <Icons.X size={10} />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Multi-tab strip — renders every entry in `useUIStore.openTabs`. Clicking
+ * a tab activates its note via `onSelect`; clicking the X closes the tab
+ * and falls back to the previous tab as active (handled by the store's
+ * `closeTab` action which returns the next path to focus).
+ */
+export function EditorTabStrip({ activePath, activeTitle, dirty, onSelect, onClose }: EditorTabStripProps) {
+  const openTabs = useUIStore((s) => s.openTabs);
+
+  // Defensive: if the active note isn't yet in openTabs (e.g. very first
+  // render before handleNoteSelect's store mutation flushes), surface it
+  // anyway so the strip never looks empty while a note is loaded.
+  const tabs = useMemo(() => {
+    if (openTabs.length === 0) return activePath ? [activePath] : [];
+    if (activePath && !openTabs.includes(activePath)) return [...openTabs, activePath];
+    return openTabs;
+  }, [openTabs, activePath]);
+
+  if (tabs.length === 0) return null;
+
+  return (
+    <div
+      role="tablist"
+      style={{
+        display: 'flex',
+        alignItems: 'stretch',
+        height: 38,
+        background: 'var(--bg-1)',
+        flexShrink: 0,
+        overflowX: 'auto',
+      }}
+    >
+      {tabs.map((path) => (
+        <Tab
+          key={path}
+          path={path}
+          label={basenameOf(path, path === activePath ? activeTitle : (path.split('/').pop() || path).replace(/\.md$/, ''))}
+          active={path === activePath}
+          dirty={path === activePath && !!dirty}
+          onSelect={() => { if (path !== activePath) onSelect(path); }}
+          onClose={() => onClose(path)}
+        />
+      ))}
     </div>
   );
 }

--- a/packages/client/src/components/Editor/Editor.tsx
+++ b/packages/client/src/components/Editor/Editor.tsx
@@ -249,7 +249,10 @@ function Tab({ path, label, active, dirty, onSelect, onClose }: TabProps) {
       >
         {label}
       </span>
-      {active && (
+      {active && dirty && (
+        // Only surface a status indicator while a save is in flight — when
+        // everything is persisted, the tab stays clean. Removes the "always
+        // green saved pill" the user found redundant.
         <span
           className="mono"
           style={{
@@ -266,17 +269,17 @@ function Tab({ path, label, active, dirty, onSelect, onClose }: TabProps) {
           }}
         >
           <span
-            className={dirty ? 'dot pulse' : 'dot pulse'}
+            className="dot pulse"
             style={{
               width: 5,
               height: 5,
               borderRadius: '50%',
-              background: dirty ? 'var(--accent-warn)' : 'var(--accent-good)',
+              background: 'var(--accent-warn)',
               boxShadow: 'none',
             }}
             aria-hidden
           />
-          {dirty ? 'saving' : 'saved'}
+          saving
         </span>
       )}
       <button

--- a/packages/client/src/components/Editor/Editor.tsx
+++ b/packages/client/src/components/Editor/Editor.tsx
@@ -199,7 +199,9 @@ interface EditorTabStripProps {
 
 function basenameOf(path: string, fallback: string): string {
   const base = path.split('/').filter(Boolean).pop() || fallback;
-  return base.endsWith('.md') ? base : `${fallback}.md`;
+  // Drop the .md suffix — every Kryton note is markdown, so showing it
+  // adds visual noise without conveying anything.
+  return base.replace(/\.md$/, '');
 }
 
 interface TabProps {

--- a/packages/client/src/components/Editor/EditorToolbar.tsx
+++ b/packages/client/src/components/Editor/EditorToolbar.tsx
@@ -13,49 +13,40 @@ interface EditorToolbarProps {
  * Undo/redo are handled natively by the new EditorView via Cmd-Z / Cmd-Shift-Z.
  */
 export function EditorToolbar({ editorRef }: EditorToolbarProps) {
-  const wrapSelection = (before: string, after: string) => {
-    editorRef.current?.wrapSelection(before, after);
-  };
-
-  const insertAtLineStart = (prefix: string) => {
-    editorRef.current?.insertAtLineStart(prefix);
-  };
-
-  const insertText = (text: string) => {
-    editorRef.current?.insertText(text);
-  };
-
+  // Helpers defined inside useCallback so the lint rule's dependency check
+  // resolves cleanly via the single editorRef closure — no eslint-disable
+  // hack and no stale-closure traps.
   const handleCommand = useCallback((command: string) => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const wrap = (b: string, a: string) => editor.wrapSelection(b, a);
+    const prefix = (p: string) => editor.insertAtLineStart(p);
+    const insert = (t: string) => editor.insertText(t);
     switch (command) {
       // undo/redo are handled by EditorView's built-in Cmd-Z / Cmd-Shift-Z;
       // no imperative call needed — the keyboard shortcut fires natively.
       case 'undo':
       case 'redo':
-        editorRef.current?.focus();
+        editor.focus();
         break;
-      case 'bold':          wrapSelection('**', '**'); break;
-      case 'italic':        wrapSelection('*', '*'); break;
-      case 'strikethrough': wrapSelection('~~', '~~'); break;
-      case 'code':          wrapSelection('`', '`'); break;
-      case 'heading1':      insertAtLineStart('# '); break;
-      case 'heading2':      insertAtLineStart('## '); break;
-      case 'heading3':      insertAtLineStart('### '); break;
-      case 'ul':            insertAtLineStart('- '); break;
-      case 'ol':            insertAtLineStart('1. '); break;
-      case 'checkbox':      insertAtLineStart('- [ ] '); break;
-      case 'blockquote':    insertAtLineStart('> '); break;
-      case 'hr':            insertText('\n---\n'); break;
+      case 'bold':          wrap('**', '**'); break;
+      case 'italic':        wrap('*', '*'); break;
+      case 'strikethrough': wrap('~~', '~~'); break;
+      case 'code':          wrap('`', '`'); break;
+      case 'heading1':      prefix('# '); break;
+      case 'heading2':      prefix('## '); break;
+      case 'heading3':      prefix('### '); break;
+      case 'ul':            prefix('- '); break;
+      case 'ol':            prefix('1. '); break;
+      case 'checkbox':      prefix('- [ ] '); break;
+      case 'blockquote':    prefix('> '); break;
+      case 'hr':            insert('\n---\n'); break;
       case 'table':
-        insertText('\n| Header | Header |\n| ------ | ------ |\n| Cell   | Cell   |\n');
+        insert('\n| Header | Header |\n| ------ | ------ |\n| Cell   | Cell   |\n');
         break;
-      case 'link':
-        insertText('[[');
-        break;
-      case 'image':
-        insertText('![alt](url)');
-        break;
+      case 'link':          insert('[['); break;
+      case 'image':         insert('![alt](url)'); break;
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editorRef]);
 
   const handleUploadImage = useCallback(async (file: File) => {

--- a/packages/client/src/components/Graph/GraphPanel.tsx
+++ b/packages/client/src/components/Graph/GraphPanel.tsx
@@ -275,7 +275,7 @@ export function GraphPanel({
         onMouseEnter={e => { e.currentTarget.style.color = 'var(--accent)'; e.currentTarget.style.borderColor = 'var(--accent)'; }}
         onMouseLeave={e => { e.currentTarget.style.color = 'var(--fg-2)'; e.currentTarget.style.borderColor = 'var(--line)'; }}
       >
-        <Icons.X size={12} style={{ transform: 'rotate(45deg)' }} />
+        <Icons.Minus size={12} />
       </button>
     </div>
   );

--- a/packages/client/src/components/Graph/GraphPanel.tsx
+++ b/packages/client/src/components/Graph/GraphPanel.tsx
@@ -418,6 +418,7 @@ export function GraphPanel({
               onNodeHover={handleHover}
               recenterRef={recenterRef}
               starredPaths={starredPaths}
+              showAllLabels={fullscreen}
             />
             {renderCornerControls(fullscreen ? null : () => setExpanded(true))}
             {tooltip && renderHoverCard(tooltip)}
@@ -527,6 +528,7 @@ export function GraphPanel({
                   onNodeHover={handleHover}
                   recenterRef={expandedRecenterRef}
                   starredPaths={starredPaths}
+                  showAllLabels
                 />
                 {renderCornerControls(null)}
                 {tooltip && renderHoverCard(tooltip)}

--- a/packages/client/src/components/Graph/GraphPanel.tsx
+++ b/packages/client/src/components/Graph/GraphPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback, useEffect, type CSSProperties } from 're
 import { createPortal } from 'react-dom';
 import { GraphView } from '@azrtydxb/ui';
 import type { HoveredNodeInfo } from '@azrtydxb/ui';
-import { GraphData, api } from '../../lib/api';
+import { GraphData } from '../../lib/api';
 import { Icons } from '../Icons';
 
 interface GraphPanelProps {
@@ -23,10 +23,7 @@ interface GraphPanelProps {
 }
 
 interface TooltipState {
-  x: number;
-  y: number;
   title: string;
-  preview: string;
   path: string;
 }
 
@@ -116,10 +113,11 @@ export function GraphPanel({
 
   const [expanded, setExpanded] = useState(false);
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const [zoom, setZoom] = useState(1);
   const recenterRef = useRef<(() => void) | null>(null);
   const expandedRecenterRef = useRef<(() => void) | null>(null);
-  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const previewCacheRef = useRef<Map<string, string>>(new Map());
+  const canvasWrapRef = useRef<HTMLDivElement | null>(null);
+  const expandedCanvasWrapRef = useRef<HTMLDivElement | null>(null);
 
   // If no active note, force global mode (local is meaningless)
   const effectiveMode: 'local' | 'global' = activeNotePath ? mode : 'global';
@@ -148,35 +146,44 @@ export function GraphPanel({
     [onNoteSelect],
   );
 
-  // Hover handler — fetches preview for the info card.
+  // Hover handler — bible card shows only title + path.
   const handleHover = useCallback((node: HoveredNodeInfo | null) => {
-    if (hoverTimerRef.current) {
-      clearTimeout(hoverTimerRef.current);
-      hoverTimerRef.current = null;
-    }
     if (!node) {
       setTooltip(null);
       return;
     }
-    const cached = previewCacheRef.current.get(node.path);
-    if (cached !== undefined) {
-      setTooltip({ x: node.x, y: node.y, title: node.title, preview: cached, path: node.path });
-      return;
-    }
-    hoverTimerRef.current = setTimeout(async () => {
-      try {
-        const note = await api.getNote(node.path);
-        const body = note.content.replace(/^---[\s\S]*?---\n*/, '');
-        const lines = body.split('\n').filter((l) => l.trim()).slice(0, 3);
-        const preview = lines.join('\n').slice(0, 200);
-        previewCacheRef.current.set(node.path, preview);
-        setTooltip({ x: node.x, y: node.y, title: node.title, preview, path: node.path });
-      } catch {
-        previewCacheRef.current.set(node.path, '');
-        setTooltip({ x: node.x, y: node.y, title: node.title, preview: '', path: node.path });
-      }
-    }, 200);
+    setTooltip({ title: node.title, path: node.path });
   }, []);
+
+  // Dispatch a synthetic wheel event on the canvas wrapper to leverage
+  // useViewport.web's existing wheel-zoom handler. The factor used by
+  // applyWheelZoom is Math.exp(-deltaY / 300); we mirror it locally so
+  // the legend %% stays in sync with the actual transform.
+  const dispatchZoom = useCallback((deltaY: number) => {
+    const wrap = (expanded ? expandedCanvasWrapRef.current : canvasWrapRef.current);
+    const target = wrap?.querySelector('canvas') ?? wrap;
+    if (!target) return;
+    const rect = (target as Element).getBoundingClientRect();
+    const evt = new WheelEvent('wheel', {
+      deltaY,
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + rect.height / 2,
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(evt);
+    setZoom((z) => {
+      const next = z * Math.exp(-deltaY / 300);
+      // Clamp to GRAPH_CONFIG.zoom range used by useViewport (0.2 .. 5 typical).
+      return Math.max(0.1, Math.min(10, next));
+    });
+  }, [expanded]);
+
+  const handleRecenter = useCallback(() => {
+    if (expanded) expandedRecenterRef.current?.();
+    else recenterRef.current?.();
+    setZoom(1);
+  }, [expanded]);
 
   const nodeCount = graphData?.nodes.length ?? 0;
   const edgeCount = graphData?.edges.length ?? 0;
@@ -228,7 +235,7 @@ export function GraphPanel({
 
   // Canvas overlay corner controls — per prototype/app/graph.jsx,
   // a vertical stack at top-right of the canvas: Center, Zoom in, Zoom out.
-  const renderCornerControls = (onExpand: (() => void) | null) => (
+  const renderCornerControls = () => (
     <div
       style={{
         position: 'absolute',
@@ -240,7 +247,7 @@ export function GraphPanel({
       <button
         type="button"
         style={gfxBtn}
-        onClick={() => (fullscreen ? expandedRecenterRef.current?.() : recenterRef.current?.())}
+        onClick={handleRecenter}
         aria-label="Recenter graph"
         title="Center"
         onMouseEnter={e => { e.currentTarget.style.color = 'var(--accent)'; e.currentTarget.style.borderColor = 'var(--accent)'; }}
@@ -248,28 +255,27 @@ export function GraphPanel({
       >
         <Icons.Crosshair size={12} />
       </button>
-      {onExpand && (
-        <button
-          type="button"
-          style={gfxBtn}
-          onClick={onExpand}
-          aria-label="Expand graph"
-          title="Expand"
-          onMouseEnter={e => { e.currentTarget.style.color = 'var(--accent)'; e.currentTarget.style.borderColor = 'var(--accent)'; }}
-          onMouseLeave={e => { e.currentTarget.style.color = 'var(--fg-2)'; e.currentTarget.style.borderColor = 'var(--line)'; }}
-        >
-          <Icons.Plus size={12} />
-        </button>
-      )}
       <button
         type="button"
         style={gfxBtn}
+        onClick={() => dispatchZoom(-100)}
+        aria-label="Zoom in"
+        title="Zoom in"
+        onMouseEnter={e => { e.currentTarget.style.color = 'var(--accent)'; e.currentTarget.style.borderColor = 'var(--accent)'; }}
+        onMouseLeave={e => { e.currentTarget.style.color = 'var(--fg-2)'; e.currentTarget.style.borderColor = 'var(--line)'; }}
+      >
+        <Icons.Plus size={12} />
+      </button>
+      <button
+        type="button"
+        style={gfxBtn}
+        onClick={() => dispatchZoom(100)}
         aria-label="Zoom out"
         title="Zoom out"
         onMouseEnter={e => { e.currentTarget.style.color = 'var(--accent)'; e.currentTarget.style.borderColor = 'var(--accent)'; }}
         onMouseLeave={e => { e.currentTarget.style.color = 'var(--fg-2)'; e.currentTarget.style.borderColor = 'var(--line)'; }}
       >
-        <Icons.Minus size={12} />
+        <Icons.X size={12} style={{ transform: 'rotate(45deg)' }} />
       </button>
     </div>
   );
@@ -297,97 +303,36 @@ export function GraphPanel({
         link
       </span>
       <div style={{ flex: 1 }} />
-      <span style={{ color: 'var(--fg-4)' }}>100%</span>
+      <span>{Math.round(zoom * 100)}%</span>
     </div>
   );
 
   // ---- Hover info card ----
+  // Per prototype/app/graph.jsx (~line 116-123): corner-anchored at
+  // bottom-left, bg-2, line border, 6px radius, mono 11/fg-1, title
+  // 12/fg, subtitle fg-3 (inherits size from card root). No body
+  // preview, no action button.
   const renderHoverCard = (t: TooltipState) => (
     <div
       style={{
         position: 'absolute',
-        left: Math.min(t.x + 14, (typeof window !== 'undefined' ? window.innerWidth : 1200) - 320),
-        top: Math.max(t.y - 70, 8),
-        maxWidth: 300,
-        background: 'var(--bg-1)',
-        border: '1px solid var(--line-strong)',
-        borderRadius: 8,
-        padding: 10,
+        left: 12,
+        bottom: 12,
+        padding: '8px 10px',
+        background: 'var(--bg-2)',
+        border: '1px solid var(--line)',
+        borderRadius: 6,
+        fontFamily: 'var(--font-mono)',
+        fontSize: 11,
+        color: 'var(--fg-1)',
         boxShadow: 'var(--shadow-md)',
+        maxWidth: 280,
         zIndex: 10,
-        pointerEvents: 'auto',
-        animation: 'kryton-fade-in 200ms ease-out',
+        pointerEvents: 'none',
       }}
     >
-      <div
-        style={{
-          fontFamily: 'var(--font-sans)',
-          fontSize: 13,
-          color: 'var(--fg)',
-          fontWeight: 500,
-          marginBottom: 4,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {t.title}
-      </div>
-      <div
-        className="mono"
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--fg-3)',
-          marginBottom: 6,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {t.path}
-      </div>
-      {t.preview && (
-        <div
-          style={{
-            fontFamily: 'var(--font-sans)',
-            fontSize: 12,
-            color: 'var(--fg-2)',
-            lineHeight: 1.5,
-            marginBottom: 8,
-            display: '-webkit-box',
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          {t.preview}
-        </div>
-      )}
-      <button
-        type="button"
-        onClick={() => {
-          if (fullscreen) handleOverlayNoteSelect(t.path);
-          else onNoteSelect(t.path);
-        }}
-        className="mono"
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          letterSpacing: '0.06em',
-          textTransform: 'uppercase',
-          color: 'var(--accent)',
-          background: 'transparent',
-          border: 'none',
-          padding: 0,
-          cursor: 'pointer',
-          textDecoration: 'underline',
-          textDecorationStyle: 'dashed',
-          textUnderlineOffset: 3,
-        }}
-      >
-        open
-      </button>
+      <div style={{ color: 'var(--fg)', fontSize: 12, marginBottom: 2 }}>{t.title}</div>
+      <div style={{ color: 'var(--fg-3)' }}>{t.path}</div>
     </div>
   );
 
@@ -399,6 +344,7 @@ export function GraphPanel({
     height: '100%',
     width: fullscreen ? '100%' : undefined,
     background: 'var(--bg-1)',
+    borderLeft: fullscreen ? 'none' : '1px solid var(--line)',
     minWidth: 0,
     overflow: 'hidden',
   };
@@ -408,7 +354,7 @@ export function GraphPanel({
       <div style={containerStyle}>
         {renderHeader(fullscreen ? null : () => setExpanded(true))}
         {!expanded && (
-          <div className="bg-grid" style={{ flex: 1, display: 'flex', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+          <div ref={canvasWrapRef} className="bg-grid" style={{ flex: 1, display: 'flex', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
             <GraphView
               graphData={graphData}
               loading={loading}
@@ -420,7 +366,7 @@ export function GraphPanel({
               starredPaths={starredPaths}
               showAllLabels={fullscreen}
             />
-            {renderCornerControls(fullscreen ? null : () => setExpanded(true))}
+            {renderCornerControls()}
             {tooltip && renderHoverCard(tooltip)}
           </div>
         )}
@@ -469,14 +415,15 @@ export function GraphPanel({
               }}
             >
               <div style={railHeader}>
-                <Icons.Network size={14} style={{ color: 'var(--fg-3)' }} />
+                <Icons.Network size={13} style={{ color: 'var(--accent)' }} />
                 <span
                   className="mono"
                   style={{
-                    fontSize: 12,
-                    color: 'var(--fg-2)',
+                    fontSize: 11,
+                    color: 'var(--fg-3)',
                     fontFamily: 'var(--font-mono)',
-                    letterSpacing: '0.04em',
+                    letterSpacing: '0.08em',
+                    textTransform: 'uppercase',
                   }}
                 >
                   graph
@@ -505,20 +452,8 @@ export function GraphPanel({
                     global
                   </button>
                 </div>
-                <button
-                  type="button"
-                  style={gfxBtn}
-                  onClick={() => {
-                    setExpanded(false);
-                    setTooltip(null);
-                  }}
-                  aria-label="Close fullscreen"
-                  title="Close"
-                >
-                  <Icons.X size={12} />
-                </button>
               </div>
-              <div className="bg-grid" style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0 }}>
+              <div ref={expandedCanvasWrapRef} className="bg-grid" style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0 }}>
                 <GraphView
                   graphData={graphData}
                   loading={loading}
@@ -530,7 +465,7 @@ export function GraphPanel({
                   starredPaths={starredPaths}
                   showAllLabels
                 />
-                {renderCornerControls(null)}
+                {renderCornerControls()}
                 {tooltip && renderHoverCard(tooltip)}
               </div>
               {renderLegend()}

--- a/packages/client/src/components/Layout/Header.tsx
+++ b/packages/client/src/components/Layout/Header.tsx
@@ -10,6 +10,7 @@ import { MutableRefObject, useMemo } from 'react';
 import { UserMenu } from './UserMenu';
 import { Icons } from '../Icons';
 import { usePrefs } from '../../stores/prefsStore';
+import { useUIStore } from '../../stores/uiStore';
 
 type Theme = 'light' | 'dark' | 'system';
 
@@ -72,26 +73,44 @@ function Breadcrumb({ activeNotePath }: { activeNotePath: string | null }) {
 
 /** 30×30 icon button per prototype `HeaderBtn`. */
 function HeaderBtn({
-  onClick, title, ariaLabel, children,
+  onClick, title, ariaLabel, active, disabled, dataAttr, children,
 }: {
   onClick?: () => void;
   title?: string;
   ariaLabel?: string;
+  active?: boolean;
+  disabled?: boolean;
+  /** Optional data-* hook so other components can identify this button. */
+  dataAttr?: string;
   children: React.ReactNode;
 }) {
   return (
     <button
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
       title={title}
       aria-label={ariaLabel ?? title}
+      aria-pressed={active}
+      disabled={disabled}
+      data-header-btn={dataAttr}
       style={{
         width: 30, height: 30, borderRadius: 6,
-        color: 'var(--fg-2)',
+        color: active ? 'var(--accent)' : 'var(--fg-2)',
+        background: active ? 'var(--accent-soft)' : 'transparent',
+        opacity: disabled ? 0.4 : 1,
+        cursor: disabled ? 'not-allowed' : 'pointer',
         display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
         transition: 'background 120ms, color 120ms',
       }}
-      onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--fg)'; }}
-      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--fg-2)'; }}
+      onMouseEnter={e => {
+        if (disabled || active) return;
+        e.currentTarget.style.background = 'var(--bg-hover)';
+        e.currentTarget.style.color = 'var(--fg)';
+      }}
+      onMouseLeave={e => {
+        if (disabled || active) return;
+        e.currentTarget.style.background = 'transparent';
+        e.currentTarget.style.color = 'var(--fg-2)';
+      }}
     >
       {children}
     </button>
@@ -119,6 +138,14 @@ export function Header({
     if (onOpenPalette) onOpenPalette();
     else searchInputRef.current?.focus();
   };
+
+  // History button toggles the per-note version dropdown via the UI store.
+  // The PreviewModeView (or any view rendering a note) subscribes to the
+  // same flag. When no note is active we disable the button.
+  const showNoteHistory = useUIStore((s) => s.showNoteHistory);
+  const setShowNoteHistory = useUIStore((s) => s.setShowNoteHistory);
+  const setShowAccountSettings = useUIStore((s) => s.setShowAccountSettings);
+  const historyDisabled = !activeNotePath;
 
   const kbdLabel = isMac ? '⌘K' : 'Ctrl K';
 
@@ -167,7 +194,16 @@ export function Header({
           <Icons.Plus size={14} />
         </HeaderBtn>
       )}
-      <HeaderBtn title="History" ariaLabel="History">
+      <HeaderBtn
+        onClick={() => setShowNoteHistory(!showNoteHistory)}
+        active={showNoteHistory && !historyDisabled}
+        disabled={historyDisabled}
+        title={historyDisabled ? 'Open a note to see its history' : 'Version history'}
+        ariaLabel="Version history"
+        // PreviewModeView's outside-click handler reads this attribute so it
+        // doesn't pre-emptively close the panel before our onClick toggles.
+        dataAttr="history-toggle"
+      >
         <Icons.History size={14} />
       </HeaderBtn>
       <HeaderBtn
@@ -177,7 +213,11 @@ export function Header({
       >
         {themePref === 'dark' ? <Icons.Sun size={14} /> : <Icons.Moon size={14} />}
       </HeaderBtn>
-      <HeaderBtn title="Settings" ariaLabel="Settings">
+      <HeaderBtn
+        onClick={() => setShowAccountSettings(true)}
+        title="Settings"
+        ariaLabel="Settings"
+      >
         <Icons.Settings size={14} />
       </HeaderBtn>
 

--- a/packages/client/src/components/Layout/Header.tsx
+++ b/packages/client/src/components/Layout/Header.tsx
@@ -11,6 +11,7 @@ import { UserMenu } from './UserMenu';
 import { Icons } from '../Icons';
 import { usePrefs } from '../../stores/prefsStore';
 import { useUIStore } from '../../stores/uiStore';
+import { formatShortcut } from '../../lib/platform';
 
 type Theme = 'light' | 'dark' | 'system';
 
@@ -35,7 +36,7 @@ interface HeaderProps {
   onNewNote?: () => void;
 }
 
-const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
+// isMac/modKey now live in lib/platform.ts — kept the import above.
 
 /**
  * Per-prototype breadcrumb:  `~/notes › <filename>.md`
@@ -147,7 +148,7 @@ export function Header({
   const setShowAccountSettings = useUIStore((s) => s.setShowAccountSettings);
   const historyDisabled = !activeNotePath;
 
-  const kbdLabel = isMac ? '⌘K' : 'Ctrl K';
+  const kbdLabel = formatShortcut(['mod', 'K']);
 
   return (
     <header
@@ -190,7 +191,7 @@ export function Header({
 
       {/* right cluster */}
       {onNewNote && (
-        <HeaderBtn onClick={onNewNote} title="New note (Ctrl+Shift+N)" ariaLabel="New note">
+        <HeaderBtn onClick={onNewNote} title={`New note (${formatShortcut(['mod', 'shift', 'N'])})`} ariaLabel="New note">
           <Icons.Plus size={14} />
         </HeaderBtn>
       )}

--- a/packages/client/src/components/Layout/SidebarLayout.tsx
+++ b/packages/client/src/components/Layout/SidebarLayout.tsx
@@ -1,5 +1,6 @@
 import { FileNode } from '../../lib/api';
 import { Sidebar } from '../Sidebar/Sidebar';
+import { Icons } from '../Icons';
 
 interface SharedNote {
   id: string;
@@ -47,10 +48,53 @@ export function SidebarLayout({
   onTagSelect,
   children,
 }: SidebarLayoutProps) {
-  // When the sidebar is closed on desktop, the column is not rendered at all
-  // (matching the prototype). The mobile drawer still uses the open flag.
+  // Desktop closed state: a narrow 36px rail with just the expand button so
+  // the user can re-open the sidebar (the bible's prototype omits this
+  // because it has no toggle; we keep it to stay reachable).
   if (!sidebarOpen && !mobileMenuOpen) {
-    return null;
+    return (
+      <aside
+        className="hidden md:flex flex-shrink-0"
+        style={{
+          width: 36,
+          background: 'var(--bg-1)',
+          borderRight: '1px solid var(--line)',
+          flexDirection: 'column',
+          alignItems: 'center',
+          paddingTop: 10,
+        }}
+      >
+        <button
+          type="button"
+          aria-label="Expand sidebar"
+          title="Expand sidebar (⌘B)"
+          onClick={() => setSidebarOpen(true)}
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: 5,
+            background: 'transparent',
+            border: '1px solid transparent',
+            color: 'var(--fg-3)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+            transition: 'color 120ms, background 120ms',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = 'var(--fg)';
+            e.currentTarget.style.background = 'var(--bg-hover)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = 'var(--fg-3)';
+            e.currentTarget.style.background = 'transparent';
+          }}
+        >
+          <Icons.PanelLeft size={14} />
+        </button>
+      </aside>
+    );
   }
 
   return (

--- a/packages/client/src/components/Layout/SidebarLayout.tsx
+++ b/packages/client/src/components/Layout/SidebarLayout.tsx
@@ -1,6 +1,5 @@
 import { FileNode } from '../../lib/api';
 import { Sidebar } from '../Sidebar/Sidebar';
-import { Icons } from '../Icons';
 
 interface SharedNote {
   id: string;
@@ -41,7 +40,6 @@ interface SidebarLayoutProps {
 export function SidebarLayout({
   sidebarOpen, setSidebarOpen,
   mobileMenuOpen, setMobileMenuOpen,
-  sidebarWidth,
   tree, activeNotePath, starredPaths, sharedNotes,
   onSelect, onCreateNote, onDeleteNote, onRenameNote,
   onCreateFolder, onDeleteFolder, onRenameFolder,
@@ -49,6 +47,12 @@ export function SidebarLayout({
   onTagSelect,
   children,
 }: SidebarLayoutProps) {
+  // When the sidebar is closed on desktop, the column is not rendered at all
+  // (matching the prototype). The mobile drawer still uses the open flag.
+  if (!sidebarOpen && !mobileMenuOpen) {
+    return null;
+  }
+
   return (
     <>
       {/* Mobile overlay */}
@@ -60,43 +64,16 @@ export function SidebarLayout({
         />
       )}
 
-      {/* Collapsed bar (desktop only) — shown when the full sidebar is closed */}
-      <div
-        className={`hidden ${sidebarOpen ? 'md:hidden' : 'md:flex'} flex-col items-center flex-shrink-0`}
-        style={{
-          width: 36,
-          background: 'var(--bg-1)',
-          borderRight: '1px solid var(--line)',
-          padding: '6px 0',
-        }}
-      >
-        <button
-          onClick={() => setSidebarOpen(true)}
-          aria-label="Open sidebar"
-          title="Open sidebar (Ctrl+B)"
-          style={{
-            width: 28, height: 28, borderRadius: 5,
-            color: 'var(--fg-3)',
-            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-          }}
-          onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--fg)'; }}
-          onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--fg-3)'; }}
-        >
-          <Icons.PanelLeft size={14} />
-        </button>
-      </div>
-
-      {/* Full sidebar */}
+      {/* Full sidebar — fixed 260px width per design */}
       <aside
         className={`
           ${mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'}
           md:translate-x-0
-          ${sidebarOpen ? '' : 'md:!w-0 md:overflow-hidden md:border-r-0'}
           fixed md:relative inset-y-0 left-0 z-40 md:z-0
           flex-shrink-0
         `}
         style={{
-          width: sidebarOpen ? `${sidebarWidth}px` : undefined,
+          width: '260px',
           background: 'var(--bg-1)',
           borderRight: '1px solid var(--line)',
           display: 'flex', flexDirection: 'column',

--- a/packages/client/src/components/Layout/SidebarLayout.tsx
+++ b/packages/client/src/components/Layout/SidebarLayout.tsx
@@ -1,6 +1,7 @@
 import { FileNode } from '../../lib/api';
 import { Sidebar } from '../Sidebar/Sidebar';
 import { Icons } from '../Icons';
+import { formatShortcut } from '../../lib/platform';
 
 interface SharedNote {
   id: string;
@@ -67,7 +68,7 @@ export function SidebarLayout({
         <button
           type="button"
           aria-label="Expand sidebar"
-          title="Expand sidebar (⌘B)"
+          title={`Expand sidebar (${formatShortcut(['mod', 'B'])})`}
           onClick={() => setSidebarOpen(true)}
           style={{
             width: 26,

--- a/packages/client/src/components/Layout/ThemeToggle.tsx
+++ b/packages/client/src/components/Layout/ThemeToggle.tsx
@@ -70,7 +70,9 @@ export function ThemeToggle({ theme, setTheme }: ThemeToggleProps) {
       <button
         ref={buttonRef}
         onClick={() => setOpen(!open)}
-        className="btn-ghost p-2"
+        style={{ padding: 8, borderRadius: 6, color: 'var(--fg-3)', background: 'transparent' }}
+        onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; }}
+        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
         aria-label="Theme"
         title="Theme"
       >

--- a/packages/client/src/components/Modals/ModalsContainer.tsx
+++ b/packages/client/src/components/Modals/ModalsContainer.tsx
@@ -23,6 +23,11 @@ interface ModalsContainerProps {
   onCloseShareDialog: () => void;
   onCloseAccessRequests: () => void;
   onCloseAccountSettings: () => void;
+  /** Command-palette command handlers — wired into QuickSwitcher's Commands group. */
+  onNewNote?: () => void;
+  onDailyNote?: () => void;
+  onGraphView?: () => void;
+  onSettings?: () => void;
 }
 
 export function ModalsContainer({
@@ -32,6 +37,7 @@ export function ModalsContainer({
   onNoteSelect, onCloseQuickSwitcher,
   onCloseAdmin, onCloseShareDialog, onCloseAccessRequests,
   onCloseAccountSettings,
+  onNewNote, onDailyNote, onGraphView, onSettings,
 }: ModalsContainerProps) {
   return (
     <>
@@ -39,7 +45,15 @@ export function ModalsContainer({
         <TemplatePicker onSelect={onTemplateSelected} onClose={onCloseTemplatePicker} noteTitle="New Note" />
       )}
       {showQuickSwitcher && (
-        <QuickSwitcher notes={noteTree} onSelect={onNoteSelect} onClose={onCloseQuickSwitcher} />
+        <QuickSwitcher
+          notes={noteTree}
+          onSelect={onNoteSelect}
+          onClose={onCloseQuickSwitcher}
+          onNewNote={onNewNote}
+          onDailyNote={onDailyNote}
+          onGraphView={onGraphView}
+          onSettings={onSettings}
+        />
       )}
       {showAdmin && <AdminPage onClose={onCloseAdmin} />}
       {showShareDialog && shareTarget && (

--- a/packages/client/src/components/NoteHistoryPopover/NoteHistoryPopover.tsx
+++ b/packages/client/src/components/NoteHistoryPopover/NoteHistoryPopover.tsx
@@ -1,0 +1,243 @@
+/**
+ * Top-level version-history popover.
+ *
+ * Renders fixed to the viewport, anchored just below the header's
+ * `[data-header-btn="history-toggle"]` button. Lives at the app root so the
+ * popover surfaces regardless of which view is mounted (preview/edit/split/
+ * graph/all-notes/tags). Reads `showNoteHistory` + `activeNote` from state;
+ * silently no-ops when there's nothing to show.
+ *
+ * Closes on:
+ *  - Escape
+ *  - mousedown outside the popover (the History toggle is allow-listed via
+ *    [data-header-btn] so the button can still close the popover via its
+ *    own click handler without racing this listener).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api, NoteVersion } from '../../lib/api';
+import { useUIStore } from '../../stores/uiStore';
+import { Icons } from '../Icons';
+
+interface NoteHistoryPopoverProps {
+  activePath: string | null;
+  onRestored?: () => void;
+}
+
+interface AnchorRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function readAnchor(): AnchorRect | null {
+  if (typeof document === 'undefined') return null;
+  const el = document.querySelector('[data-header-btn="history-toggle"]') as HTMLElement | null;
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { top: r.top, left: r.left, width: r.width, height: r.height };
+}
+
+export function NoteHistoryPopover({ activePath, onRestored }: NoteHistoryPopoverProps) {
+  const open = useUIStore((s) => s.showNoteHistory);
+  const setOpen = useUIStore((s) => s.setShowNoteHistory);
+  const [versions, setVersions] = useState<NoteVersion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [restoring, setRestoring] = useState<number | null>(null);
+  const [anchor, setAnchor] = useState<AnchorRect | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  // Compute anchor position on open + on viewport resize while open.
+  useEffect(() => {
+    if (!open) return;
+    setAnchor(readAnchor());
+    const onResize = (): void => setAnchor(readAnchor());
+    window.addEventListener('resize', onResize);
+    window.addEventListener('scroll', onResize, true);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('scroll', onResize, true);
+    };
+  }, [open]);
+
+  // Load versions when the panel opens.
+  useEffect(() => {
+    if (!open || !activePath) return;
+    setLoading(true);
+    api.listVersions(activePath)
+      .then((data) => setVersions(data.versions))
+      .catch(() => setVersions([]))
+      .finally(() => setLoading(false));
+  }, [open, activePath]);
+
+  // Outside-click + Esc close. Allow clicks on the header toggle through so
+  // its own onClick can close the popover via the store setter.
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent): void => {
+      const target = e.target as Element | null;
+      if (target && target.closest('[data-header-btn="history-toggle"]')) return;
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open, setOpen]);
+
+  const handleRestore = useCallback(async (ts: number) => {
+    if (!activePath) return;
+    setRestoring(ts);
+    try {
+      await api.restoreVersion(activePath, ts);
+      setOpen(false);
+      onRestored?.();
+    } catch (err) {
+      // Surface as a console warning — toast layer not wired here.
+      console.warn('restore version failed:', err);
+    } finally {
+      setRestoring(null);
+    }
+  }, [activePath, onRestored, setOpen]);
+
+  if (!open || !activePath) return null;
+
+  // Default position: 8px below the header button, right-aligned to its right edge.
+  const popoverWidth = 320;
+  let top = 52;
+  let left = window.innerWidth - popoverWidth - 12;
+  if (anchor) {
+    top = anchor.top + anchor.height + 8;
+    left = Math.max(12, anchor.left + anchor.width - popoverWidth);
+  }
+
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label="Version history"
+      style={{
+        position: 'fixed',
+        top,
+        left,
+        width: popoverWidth,
+        maxHeight: 'min(60vh, 480px)',
+        background: 'var(--bg-1)',
+        border: '1px solid var(--line)',
+        borderRadius: 8,
+        boxShadow: 'var(--shadow-lg)',
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        zIndex: 60,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '8px 10px',
+          borderBottom: '1px solid var(--line)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 10.5,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: 'var(--fg-3)',
+        }}
+      >
+        <span>// version history</span>
+        <button
+          onClick={() => setOpen(false)}
+          aria-label="Close history"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 20,
+            height: 20,
+            borderRadius: 3,
+            background: 'transparent',
+            color: 'var(--fg-3)',
+            border: 'none',
+            cursor: 'pointer',
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--fg)'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--fg-3)'; }}
+        >
+          <Icons.X size={11} />
+        </button>
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto', padding: 4 }}>
+        {loading ? (
+          <div style={{ padding: 14, fontSize: 12, color: 'var(--fg-3)' }}>Loading…</div>
+        ) : versions.length === 0 ? (
+          <div style={{ padding: 14, fontSize: 12, color: 'var(--fg-3)' }}>
+            No version history yet for this note.
+          </div>
+        ) : (
+          versions.map((v) => (
+            <div
+              key={v.timestamp}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '6px 8px',
+                borderRadius: 5,
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                color: 'var(--fg-2)',
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+            >
+              <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {new Date(v.timestamp).toLocaleString(undefined, {
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
+                })}
+              </span>
+              <button
+                onClick={() => handleRestore(v.timestamp)}
+                disabled={restoring === v.timestamp}
+                style={{
+                  padding: '3px 8px',
+                  borderRadius: 4,
+                  fontSize: 10,
+                  fontFamily: 'var(--font-mono)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.04em',
+                  background: 'transparent',
+                  color: 'var(--fg-3)',
+                  border: '1px solid var(--line)',
+                  cursor: restoring === v.timestamp ? 'not-allowed' : 'pointer',
+                  opacity: restoring === v.timestamp ? 0.5 : 1,
+                }}
+                onMouseEnter={(e) => {
+                  if (restoring === v.timestamp) return;
+                  e.currentTarget.style.color = 'var(--accent)';
+                  e.currentTarget.style.borderColor = 'var(--accent)';
+                }}
+                onMouseLeave={(e) => {
+                  if (restoring === v.timestamp) return;
+                  e.currentTarget.style.color = 'var(--fg-3)';
+                  e.currentTarget.style.borderColor = 'var(--line)';
+                }}
+              >
+                {restoring === v.timestamp ? '…' : 'restore'}
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/Preview/Preview.tsx
+++ b/packages/client/src/components/Preview/Preview.tsx
@@ -62,13 +62,6 @@ const MD_CSS = `
   border: 0;
   padding: 0;
 }
-.kryton-md .markdown-preview h3 {
-  font-family: var(--font-display);
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--fg);
-  margin: 22px 0 8px;
-}
 .kryton-md .markdown-preview h4,
 .kryton-md .markdown-preview h5,
 .kryton-md .markdown-preview h6 {
@@ -125,19 +118,6 @@ const MD_CSS = `
   border-radius: 0;
   font-size: 12.5px;
 }
-.kryton-md .markdown-preview pre[data-language]::before {
-  content: attr(data-language);
-  position: absolute;
-  top: 6px;
-  right: 10px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--fg-4);
-  pointer-events: none;
-}
-
 .kryton-md .markdown-preview blockquote {
   border-left: 2px solid var(--accent);
   padding: 0 0 0 14px;
@@ -149,7 +129,7 @@ const MD_CSS = `
 .kryton-md .markdown-preview ul,
 .kryton-md .markdown-preview ol {
   padding-left: 22px;
-  margin: 8px 0 14px;
+  margin: 8px 0;
 }
 .kryton-md .markdown-preview li { margin-bottom: 4px; }
 
@@ -267,7 +247,7 @@ export function Preview({
           }}
         >
           <Icons.FileText size={11} aria-hidden />
-          <span>/{notePath}</span>
+          <span>{notePath}</span>
           {(() => {
             const words = (content.replace(/`{1,3}.*?`{1,3}/gs, '').match(/\S+/g) || []).length;
             return (
@@ -279,13 +259,12 @@ export function Preview({
           })()}
           {modifiedAt && (
             <>
-              <span style={{ flex: 1 }} aria-hidden />
+              <span aria-hidden>·</span>
               <span>
                 updated{' '}
-                {new Date(modifiedAt).toLocaleDateString(undefined, {
-                  month: 'short',
-                  day: 'numeric',
-                  year: 'numeric',
+                {new Date(modifiedAt).toLocaleString(undefined, {
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
                 })}
               </span>
             </>
@@ -310,8 +289,8 @@ export function Preview({
           style={{
             maxWidth: 760,
             margin: '0 auto',
-            padding: '0 36px 80px',
-            marginTop: 28,
+            padding: '0 48px 80px',
+            marginTop: 36,
           }}
         >
           <div

--- a/packages/client/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/packages/client/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -137,7 +137,7 @@ export function QuickSwitcher({
       { title: 'Commands', items: commands },
       { title: 'Notes', items: noteHits.slice(0, 8) },
     ];
-  }, [q, allFiles, mod, onNewNote, onNewFolder, onDailyNote, onGraphView, onSettings]);
+  }, [q, allFiles, onNewNote, onNewFolder, onDailyNote, onGraphView, onSettings]);
 
   const flat = useMemo(() => sections.flatMap((s) => s.items), [sections]);
 

--- a/packages/client/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/packages/client/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { FileNode } from '../../lib/api';
 import { Icons } from '../Icons';
+import { formatShortcut } from '../../lib/platform';
 
 interface QuickSwitcherProps {
   notes: FileNode[];
@@ -64,9 +65,8 @@ export function QuickSwitcher({
   const [idx, setIdx] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const isMac =
-    typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
-  const mod = isMac ? '⌘' : 'Ctrl';
+  // Modifier glyph for the footer kbd badge (⌘ on mac, Ctrl elsewhere).
+  const mod = formatShortcut(['mod']);
 
   useEffect(() => {
     const t = setTimeout(() => inputRef.current?.focus(), 30);
@@ -81,35 +81,35 @@ export function QuickSwitcher({
         kind: 'command',
         icon: <Icons.Plus size={13} />,
         label: 'New note',
-        hint: `${mod}N`,
+        hint: formatShortcut(['mod', 'N']),
         onActivate: onNewNote,
       },
       {
         kind: 'command',
         icon: <Icons.FolderPlus size={13} />,
         label: 'New folder',
-        hint: `${mod}⇧N`,
+        hint: formatShortcut(['mod', 'shift', 'N']),
         onActivate: onNewFolder,
       },
       {
         kind: 'command',
         icon: <Icons.Calendar size={13} />,
         label: 'Daily note',
-        hint: `${mod}D`,
+        hint: formatShortcut(['mod', 'D']),
         onActivate: onDailyNote,
       },
       {
         kind: 'command',
         icon: <Icons.Network size={13} />,
         label: 'Graph view',
-        hint: `${mod}G`,
+        hint: formatShortcut(['mod', 'G']),
         onActivate: onGraphView,
       },
       {
         kind: 'command',
         icon: <Icons.Settings size={13} />,
         label: 'Settings',
-        hint: `${mod},`,
+        hint: formatShortcut(['mod', ',']),
         onActivate: onSettings,
       },
     ];

--- a/packages/client/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/packages/client/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -6,6 +6,11 @@ interface QuickSwitcherProps {
   notes: FileNode[];
   onSelect: (path: string) => void;
   onClose: () => void;
+  onNewNote?: () => void;
+  onNewFolder?: () => void;
+  onDailyNote?: () => void;
+  onGraphView?: () => void;
+  onSettings?: () => void;
 }
 
 interface NoteEntry {
@@ -29,6 +34,7 @@ interface Section {
 }
 
 const monoFamily = 'var(--font-mono)';
+const sansFamily = 'var(--font-sans)';
 
 function collectFiles(nodes: FileNode[]): NoteEntry[] {
   const files: NoteEntry[] = [];
@@ -43,7 +49,16 @@ function collectFiles(nodes: FileNode[]): NoteEntry[] {
   return files;
 }
 
-export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) {
+export function QuickSwitcher({
+  notes,
+  onSelect,
+  onClose,
+  onNewNote,
+  onNewFolder,
+  onDailyNote,
+  onGraphView,
+  onSettings,
+}: QuickSwitcherProps) {
   const allFiles = useMemo(() => collectFiles(notes), [notes]);
   const [q, setQ] = useState('');
   const [idx, setIdx] = useState(0);
@@ -61,23 +76,68 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
   const sections = useMemo<Section[]>(() => {
     const ql = q.trim().toLowerCase();
 
+    const commands: ResultItem[] = [
+      {
+        kind: 'command',
+        icon: <Icons.Plus size={13} />,
+        label: 'New note',
+        hint: `${mod}N`,
+        onActivate: onNewNote,
+      },
+      {
+        kind: 'command',
+        icon: <Icons.FolderPlus size={13} />,
+        label: 'New folder',
+        hint: `${mod}⇧N`,
+        onActivate: onNewFolder,
+      },
+      {
+        kind: 'command',
+        icon: <Icons.Calendar size={13} />,
+        label: 'Daily note',
+        hint: `${mod}D`,
+        onActivate: onDailyNote,
+      },
+      {
+        kind: 'command',
+        icon: <Icons.Network size={13} />,
+        label: 'Graph view',
+        hint: `${mod}G`,
+        onActivate: onGraphView,
+      },
+      {
+        kind: 'command',
+        icon: <Icons.Settings size={13} />,
+        label: 'Settings',
+        hint: `${mod},`,
+        onActivate: onSettings,
+      },
+    ];
+
     const noteHits = allFiles
       .filter((n) => !ql || n.name.toLowerCase().includes(ql) || n.path.toLowerCase().includes(ql))
       .slice(0, 20)
       .map<ResultItem>((n) => ({
         kind: 'note',
-        icon: <Icons.FileText size={14} />,
+        icon: <Icons.FileText size={13} />,
         label: n.name,
         hint: n.path,
         value: n.path,
       }));
 
     if (ql) {
-      return [{ title: `Notes (${noteHits.length})`, items: noteHits }];
+      const cmdHits = commands.filter((c) => c.label.toLowerCase().includes(ql));
+      const out: Section[] = [];
+      if (cmdHits.length) out.push({ title: 'Commands', items: cmdHits });
+      if (noteHits.length) out.push({ title: `Notes (${noteHits.length})`, items: noteHits });
+      return out;
     }
 
-    return [{ title: 'Notes', items: noteHits.slice(0, 8) }];
-  }, [q, allFiles]);
+    return [
+      { title: 'Commands', items: commands },
+      { title: 'Notes', items: noteHits.slice(0, 8) },
+    ];
+  }, [q, allFiles, mod, onNewNote, onNewFolder, onDailyNote, onGraphView, onSettings]);
 
   const flat = useMemo(() => sections.flatMap((s) => s.items), [sections]);
 
@@ -95,7 +155,9 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
     if (item.kind === 'note' && item.value) {
       onSelect(item.value);
       onClose();
+      return;
     }
+    onClose();
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -116,7 +178,7 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
   };
 
   const sectionHeader: CSSProperties = {
-    padding: '10px 12px 6px',
+    padding: '8px 10px 4px',
     fontSize: 10.5,
     fontFamily: monoFamily,
     letterSpacing: '0.08em',
@@ -132,7 +194,7 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
       style={{
         position: 'fixed',
         inset: 0,
-        background: 'oklch(0 0 0 / 0.5)',
+        background: 'oklch(0 0 0 / 0.45)',
         zIndex: 100,
         backdropFilter: 'blur(4px)',
         display: 'flex',
@@ -144,11 +206,11 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
       <div
         onClick={(e) => e.stopPropagation()}
         style={{
-          width: 560,
+          width: 580,
           maxWidth: '90vw',
           background: 'var(--bg-1)',
           border: '1px solid var(--line-strong)',
-          borderRadius: 12,
+          borderRadius: 10,
           boxShadow: 'var(--shadow-lg)',
           overflow: 'hidden',
           display: 'flex',
@@ -165,17 +227,7 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
             borderBottom: '1px solid var(--line)',
           }}
         >
-          <span
-            className="mono"
-            style={{
-              color: 'var(--accent)',
-              fontSize: 16,
-              fontWeight: 600,
-              userSelect: 'none',
-            }}
-          >
-            &gt;
-          </span>
+          <Icons.Search size={16} style={{ color: 'var(--accent)' }} />
           <input
             ref={inputRef}
             value={q}
@@ -184,39 +236,18 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
               setIdx(0);
             }}
             onKeyDown={onKeyDown}
-            placeholder="search or type a command…"
+            placeholder="Search notes, run a command…"
             style={{
               flex: 1,
               background: 'transparent',
               border: 'none',
               outline: 'none',
               color: 'var(--fg)',
-              fontSize: 16,
-              fontFamily: monoFamily,
+              fontSize: 15,
+              fontFamily: sansFamily,
             }}
           />
           <span className="kbd">esc</span>
-        </div>
-
-        {/* AI hint */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            padding: '8px 16px',
-            borderBottom: '1px solid var(--line)',
-            fontFamily: monoFamily,
-            fontSize: 11.5,
-            color: 'var(--fg-3)',
-            background: 'var(--bg-1)',
-          }}
-        >
-          <Icons.Sparkle size={12} style={{ color: 'var(--accent)' }} />
-          <span>
-            <span style={{ color: 'var(--accent)' }}>✦</span>{' '}
-            AI search ready · press <span className="kbd">↵</span> to ask Claude
-          </span>
         </div>
 
         {/* Results */}
@@ -224,14 +255,14 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
           {flat.length === 0 && (
             <div
               style={{
-                padding: 28,
+                padding: 30,
                 textAlign: 'center',
                 color: 'var(--fg-3)',
-                fontFamily: monoFamily,
-                fontSize: 12,
+                fontFamily: sansFamily,
+                fontSize: 13,
               }}
             >
-              no matches.
+              No matches.
             </div>
           )}
 
@@ -258,7 +289,7 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
                         borderRadius: 6,
                         border: 'none',
                         background: sel ? 'var(--accent-soft)' : 'transparent',
-                        color: sel ? 'var(--accent)' : 'var(--fg-1)',
+                        color: sel ? 'var(--fg)' : 'var(--fg-1)',
                         fontSize: 13,
                         textAlign: 'left',
                         cursor: 'pointer',
@@ -282,7 +313,7 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
                         <span
                           className="mono"
                           style={{
-                            color: sel ? 'var(--accent)' : 'var(--fg-4)',
+                            color: 'var(--fg-4)',
                             fontSize: 11,
                             opacity: 0.85,
                             maxWidth: 220,
@@ -308,8 +339,7 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
             display: 'flex',
             gap: 14,
             alignItems: 'center',
-            padding: '0 14px',
-            height: 28,
+            padding: '8px 14px',
             background: 'var(--bg-1)',
             borderTop: '1px solid var(--line)',
             fontSize: 11,
@@ -331,7 +361,7 @@ export function QuickSwitcher({ notes, onSelect, onClose }: QuickSwitcherProps) 
           <div style={{ flex: 1 }} />
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: 'var(--accent)' }}>
             <span className="dot pulse" style={{ background: 'var(--accent)' }} />
-            AI ready
+            AI search ready
           </span>
         </div>
       </div>

--- a/packages/client/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/packages/client/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -358,11 +358,6 @@ export function QuickSwitcher({
             <span className="kbd">{mod}</span>
             <span className="kbd">↵</span> open in split
           </span>
-          <div style={{ flex: 1 }} />
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: 'var(--accent)' }}>
-            <span className="dot pulse" style={{ background: 'var(--accent)' }} />
-            AI search ready
-          </span>
         </div>
       </div>
     </div>

--- a/packages/client/src/components/Security/PasskeyManager.tsx
+++ b/packages/client/src/components/Security/PasskeyManager.tsx
@@ -2,16 +2,14 @@ import { useState, useEffect, useCallback, CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { Fingerprint, Trash2, X } from 'lucide-react';
 import { authClient } from '../../lib/auth-client';
+import { Section, Field, Toolbar } from '../Settings/settings-kit';
 import {
-  Section,
-  Field,
-  Toolbar,
   helpText,
   inputStyle,
   primaryBtn,
   ghostBtn,
   dangerBtn,
-} from '../Settings/settings-kit';
+} from '../Settings/settings-kit-styles';
 
 interface PasskeyData {
   id: string;

--- a/packages/client/src/components/Security/PasskeyManager.tsx
+++ b/packages/client/src/components/Security/PasskeyManager.tsx
@@ -1,7 +1,17 @@
 import { useState, useEffect, useCallback, CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
-import { Fingerprint, Plus, Trash2, X } from 'lucide-react';
+import { Fingerprint, Trash2, X } from 'lucide-react';
 import { authClient } from '../../lib/auth-client';
+import {
+  Section,
+  Field,
+  Toolbar,
+  helpText,
+  inputStyle,
+  primaryBtn,
+  ghostBtn,
+  dangerBtn,
+} from '../Settings/settings-kit';
 
 interface PasskeyData {
   id: string;
@@ -16,24 +26,25 @@ interface PasskeyManagerProps {
 }
 
 const rowStyle: CSSProperties = {
-  background: 'var(--bg-2)',
-  borderColor: 'var(--line)',
-  color: 'var(--fg)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  background: 'var(--bg-1)',
+  border: '1px solid var(--line)',
+  borderRadius: 6,
+  padding: '10px 12px',
+  marginBottom: 8,
 };
 
-const inputStyle: CSSProperties = {
-  background: 'var(--bg-2)',
-  borderColor: 'var(--line)',
-  color: 'var(--fg)',
-};
-
-const primaryBtnStyle: CSSProperties = {
-  background: 'var(--accent)',
-  color: '#fff',
-};
-
-const ghostBtnStyle: CSSProperties = {
-  color: 'var(--fg-3)',
+const errorStyle: CSSProperties = {
+  ...helpText,
+  marginBottom: 12,
+  padding: '8px 10px',
+  borderRadius: 5,
+  background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)',
+  border: '1px solid color-mix(in oklch, var(--accent-danger) 30%, transparent)',
+  color: 'var(--accent-danger)',
+  fontFamily: 'var(--font-mono)',
 };
 
 export function PasskeyManagerContent() {
@@ -107,136 +118,175 @@ export function PasskeyManagerContent() {
   };
 
   return (
-    <>
-      <p className="text-xs mb-4" style={{ color: 'var(--fg-3)' }}>
+    <div style={{ color: 'var(--fg-1)' }}>
+      <p style={helpText}>
         Passkeys let you sign in with your fingerprint, face, or device PIN instead of a password.
       </p>
 
-      {/* Error */}
-      {error && (
-        <div
-          className="mb-4 rounded-lg border px-3 py-2 text-xs"
-          style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
-        >
-          {error}
-        </div>
-      )}
+      {error && <div style={errorStyle}>{error}</div>}
 
-      {/* Passkey list */}
-      <div className="space-y-2 mb-4 max-h-60 overflow-y-auto">
+      <Section title="passkeys">
         {loading ? (
-          <div className="text-center py-6 text-sm" style={{ color: 'var(--fg-3)' }}>Loading passkeys...</div>
+          <div style={helpText}>Loading passkeys...</div>
         ) : passkeys.length === 0 ? (
-          <div className="text-center py-6 text-sm" style={{ color: 'var(--fg-3)' }}>No passkeys registered yet.</div>
+          <div style={helpText}>No passkeys registered yet.</div>
         ) : (
-          passkeys.map(pk => (
-            <div
-              key={pk.id}
-              className="flex items-center justify-between rounded-lg border px-3 py-2"
-              style={rowStyle}
-            >
-              <div className="min-w-0 flex-1">
-                <div className="text-sm truncate" style={{ color: 'var(--fg)' }}>
-                  {pk.name || 'Unnamed passkey'}
+          <div style={{ marginBottom: 14 }}>
+            {passkeys.map(pk => (
+              <div key={pk.id} style={rowStyle}>
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 12,
+                      color: 'var(--fg)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {pk.name || 'Unnamed passkey'}
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 11,
+                      color: 'var(--fg-3)',
+                      marginTop: 2,
+                    }}
+                  >
+                    Added {new Date(pk.createdAt).toLocaleDateString()}
+                  </div>
                 </div>
-                <div className="text-xs" style={{ color: 'var(--fg-3)' }}>
-                  Added {new Date(pk.createdAt).toLocaleDateString()}
-                </div>
+                {confirmDeleteId === pk.id ? (
+                  <div style={{ display: 'flex', gap: 6, marginLeft: 8 }}>
+                    <button
+                      onClick={() => handleDeletePasskey(pk.id)}
+                      disabled={deletingId === pk.id}
+                      style={{ ...dangerBtn, opacity: deletingId === pk.id ? 0.5 : 1 }}
+                    >
+                      {deletingId === pk.id ? '...' : 'Confirm'}
+                    </button>
+                    <button onClick={() => setConfirmDeleteId(null)} style={ghostBtn}>
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setConfirmDeleteId(pk.id)}
+                    style={{
+                      ...ghostBtn,
+                      padding: 6,
+                      marginLeft: 8,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      color: 'var(--fg-3)',
+                    }}
+                    aria-label="Delete passkey"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                )}
               </div>
-              {confirmDeleteId === pk.id ? (
-                <div className="flex items-center gap-1 ml-2">
-                  <button
-                    onClick={() => handleDeletePasskey(pk.id)}
-                    disabled={deletingId === pk.id}
-                    className="text-xs px-2 py-1 rounded disabled:opacity-50"
-                    style={{ color: 'var(--accent-danger)', background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)' }}
-                  >
-                    {deletingId === pk.id ? '...' : 'Confirm'}
-                  </button>
-                  <button
-                    onClick={() => setConfirmDeleteId(null)}
-                    className="text-xs px-2 py-1"
-                    style={ghostBtnStyle}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              ) : (
-                <button
-                  onClick={() => setConfirmDeleteId(pk.id)}
-                  className="ml-2 p-1.5 transition-colors"
-                  style={{ color: 'var(--fg-3)' }}
-                  aria-label="Delete passkey"
-                >
-                  <Trash2 size={14} />
-                </button>
-              )}
-            </div>
-          ))
-        )}
-      </div>
-
-      {/* Add passkey */}
-      {showNamePrompt ? (
-        <div className="space-y-2">
-          <input
-            type="text"
-            value={newPasskeyName}
-            onChange={e => setNewPasskeyName(e.target.value)}
-            placeholder="Passkey name (optional)"
-            autoFocus
-            className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none"
-            style={inputStyle}
-            onKeyDown={e => { if (e.key === 'Enter') handleAddPasskey(); }}
-          />
-          <div className="flex gap-2">
-            <button
-              onClick={handleAddPasskey}
-              disabled={adding}
-              className="flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-50"
-              style={primaryBtnStyle}
-            >
-              {adding ? 'Registering...' : 'Register Passkey'}
-            </button>
-            <button
-              onClick={() => { setShowNamePrompt(false); setNewPasskeyName(''); }}
-              className="px-3 py-2 text-sm transition-colors"
-              style={ghostBtnStyle}
-            >
-              Cancel
-            </button>
+            ))}
           </div>
-        </div>
-      ) : (
-        <button
-          onClick={() => setShowNamePrompt(true)}
-          className="w-full flex items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-2.5 text-sm font-medium transition-colors"
-          style={{ borderColor: 'var(--line)', color: 'var(--fg)' }}
-        >
-          <Plus size={16} />
-          Add Passkey
-        </button>
-      )}
-    </>
+        )}
+
+        {showNamePrompt ? (
+          <>
+            <Field label="name">
+              <input
+                type="text"
+                value={newPasskeyName}
+                onChange={e => setNewPasskeyName(e.target.value)}
+                placeholder="Passkey name (optional)"
+                autoFocus
+                style={inputStyle}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') handleAddPasskey();
+                }}
+              />
+            </Field>
+            <Toolbar>
+              <button
+                onClick={handleAddPasskey}
+                disabled={adding}
+                style={{ ...primaryBtn, opacity: adding ? 0.5 : 1 }}
+              >
+                {adding ? 'Registering...' : 'Register'}
+              </button>
+              <button
+                onClick={() => {
+                  setShowNamePrompt(false);
+                  setNewPasskeyName('');
+                }}
+                style={ghostBtn}
+              >
+                Cancel
+              </button>
+            </Toolbar>
+          </>
+        ) : (
+          <Toolbar>
+            <button onClick={() => setShowNamePrompt(true)} style={primaryBtn}>
+              Add Passkey
+            </button>
+          </Toolbar>
+        )}
+      </Section>
+    </div>
   );
 }
 
 export function PasskeyManager({ open, onClose }: PasskeyManagerProps) {
   if (!open) return null;
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'oklch(0 0 0 / 0.6)' }} onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'oklch(0 0 0 / 0.6)' }}
+      onClick={onClose}
+    >
       <div
-        className="rounded-xl shadow-2xl w-full max-w-md p-6 border"
-        style={{ background: 'var(--bg-1)', borderColor: 'var(--line)' }}
+        style={{
+          background: 'var(--bg-1)',
+          border: '1px solid var(--line)',
+          borderRadius: 8,
+          padding: 20,
+          width: '100%',
+          maxWidth: 480,
+          boxShadow: '0 20px 40px oklch(0 0 0 / 0.4)',
+        }}
         onClick={e => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <Fingerprint size={20} style={{ color: 'var(--accent)' }} />
-            <h3 className="text-lg font-semibold" style={{ color: 'var(--fg)' }}>Passkeys</h3>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 14,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Fingerprint size={18} style={{ color: 'var(--accent)' }} />
+            <h3
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 13,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                color: 'var(--fg)',
+                margin: 0,
+              }}
+            >
+              Passkeys
+            </h3>
           </div>
-          <button onClick={onClose} className="p-1 transition-colors" style={ghostBtnStyle} aria-label="Close">
-            <X size={18} />
+          <button
+            onClick={onClose}
+            style={{ ...ghostBtn, padding: 6, display: 'inline-flex', alignItems: 'center' }}
+            aria-label="Close"
+          >
+            <X size={16} />
           </button>
         </div>
         <PasskeyManagerContent />

--- a/packages/client/src/components/Security/PasskeyManager.tsx
+++ b/packages/client/src/components/Security/PasskeyManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { Fingerprint, Plus, Trash2, X } from 'lucide-react';
 import { authClient } from '../../lib/auth-client';
@@ -14,6 +14,27 @@ interface PasskeyManagerProps {
   open: boolean;
   onClose: () => void;
 }
+
+const rowStyle: CSSProperties = {
+  background: 'var(--bg-2)',
+  borderColor: 'var(--line)',
+  color: 'var(--fg)',
+};
+
+const inputStyle: CSSProperties = {
+  background: 'var(--bg-2)',
+  borderColor: 'var(--line)',
+  color: 'var(--fg)',
+};
+
+const primaryBtnStyle: CSSProperties = {
+  background: 'var(--accent)',
+  color: 'var(--accent-fg)',
+};
+
+const ghostBtnStyle: CSSProperties = {
+  color: 'var(--fg-3)',
+};
 
 export function PasskeyManagerContent() {
   const [passkeys, setPasskeys] = useState<PasskeyData[]>([]);
@@ -87,7 +108,7 @@ export function PasskeyManagerContent() {
 
   return (
     <>
-      <p className="text-xs text-gray-400 mb-4">
+      <p className="text-xs mb-4" style={{ color: 'var(--fg-3)' }}>
         Passkeys let you sign in with your fingerprint, face, or device PIN instead of a password.
       </p>
 
@@ -101,20 +122,21 @@ export function PasskeyManagerContent() {
       {/* Passkey list */}
       <div className="space-y-2 mb-4 max-h-60 overflow-y-auto">
         {loading ? (
-          <div className="text-center py-6 text-gray-500 text-sm">Loading passkeys...</div>
+          <div className="text-center py-6 text-sm" style={{ color: 'var(--fg-3)' }}>Loading passkeys...</div>
         ) : passkeys.length === 0 ? (
-          <div className="text-center py-6 text-gray-500 text-sm">No passkeys registered yet.</div>
+          <div className="text-center py-6 text-sm" style={{ color: 'var(--fg-3)' }}>No passkeys registered yet.</div>
         ) : (
           passkeys.map(pk => (
             <div
               key={pk.id}
-              className="flex items-center justify-between rounded-lg bg-surface-800 border border-gray-700/50 px-3 py-2"
+              className="flex items-center justify-between rounded-lg border px-3 py-2"
+              style={rowStyle}
             >
               <div className="min-w-0 flex-1">
-                <div className="text-sm text-gray-200 truncate">
+                <div className="text-sm truncate" style={{ color: 'var(--fg)' }}>
                   {pk.name || 'Unnamed passkey'}
                 </div>
-                <div className="text-xs text-gray-500">
+                <div className="text-xs" style={{ color: 'var(--fg-3)' }}>
                   Added {new Date(pk.createdAt).toLocaleDateString()}
                 </div>
               </div>
@@ -129,7 +151,8 @@ export function PasskeyManagerContent() {
                   </button>
                   <button
                     onClick={() => setConfirmDeleteId(null)}
-                    className="text-xs text-gray-400 hover:text-gray-200 px-2 py-1"
+                    className="text-xs px-2 py-1"
+                    style={ghostBtnStyle}
                   >
                     Cancel
                   </button>
@@ -137,7 +160,8 @@ export function PasskeyManagerContent() {
               ) : (
                 <button
                   onClick={() => setConfirmDeleteId(pk.id)}
-                  className="ml-2 p-1.5 text-gray-500 hover:text-red-400 transition-colors"
+                  className="ml-2 p-1.5 hover:text-red-400 transition-colors"
+                  style={{ color: 'var(--fg-3)' }}
                   aria-label="Delete passkey"
                 >
                   <Trash2 size={14} />
@@ -157,20 +181,23 @@ export function PasskeyManagerContent() {
             onChange={e => setNewPasskeyName(e.target.value)}
             placeholder="Passkey name (optional)"
             autoFocus
-            className="w-full bg-surface-800 border border-gray-700/50 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500/50"
+            className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none"
+            style={inputStyle}
             onKeyDown={e => { if (e.key === 'Enter') handleAddPasskey(); }}
           />
           <div className="flex gap-2">
             <button
               onClick={handleAddPasskey}
               disabled={adding}
-              className="flex-1 bg-violet-500 text-white rounded-lg py-2 text-sm font-medium hover:bg-violet-600 transition-colors disabled:opacity-50"
+              className="flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-50"
+              style={primaryBtnStyle}
             >
               {adding ? 'Registering...' : 'Register Passkey'}
             </button>
             <button
               onClick={() => { setShowNamePrompt(false); setNewPasskeyName(''); }}
-              className="px-3 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+              className="px-3 py-2 text-sm transition-colors"
+              style={ghostBtnStyle}
             >
               Cancel
             </button>
@@ -179,7 +206,8 @@ export function PasskeyManagerContent() {
       ) : (
         <button
           onClick={() => setShowNamePrompt(true)}
-          className="w-full flex items-center justify-center gap-2 rounded-lg border border-dashed border-gray-600 px-4 py-2.5 text-sm font-medium text-gray-300 hover:border-violet-500 hover:text-violet-400 transition-colors"
+          className="w-full flex items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-2.5 text-sm font-medium transition-colors"
+          style={{ borderColor: 'var(--line)', color: 'var(--fg)' }}
         >
           <Plus size={16} />
           Add Passkey
@@ -194,15 +222,16 @@ export function PasskeyManager({ open, onClose }: PasskeyManagerProps) {
   return createPortal(
     <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center" onClick={onClose}>
       <div
-        className="bg-surface-900 rounded-xl shadow-2xl w-full max-w-md p-6 border border-gray-700/50"
+        className="rounded-xl shadow-2xl w-full max-w-md p-6 border"
+        style={{ background: 'var(--bg-1)', borderColor: 'var(--line)' }}
         onClick={e => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
-            <Fingerprint size={20} className="text-violet-400" />
-            <h3 className="text-lg font-semibold text-gray-100">Passkeys</h3>
+            <Fingerprint size={20} style={{ color: 'var(--accent)' }} />
+            <h3 className="text-lg font-semibold" style={{ color: 'var(--fg)' }}>Passkeys</h3>
           </div>
-          <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-200 transition-colors" aria-label="Close">
+          <button onClick={onClose} className="p-1 transition-colors" style={ghostBtnStyle} aria-label="Close">
             <X size={18} />
           </button>
         </div>

--- a/packages/client/src/components/Security/PasskeyManager.tsx
+++ b/packages/client/src/components/Security/PasskeyManager.tsx
@@ -29,7 +29,7 @@ const inputStyle: CSSProperties = {
 
 const primaryBtnStyle: CSSProperties = {
   background: 'var(--accent)',
-  color: 'var(--accent-fg)',
+  color: '#fff',
 };
 
 const ghostBtnStyle: CSSProperties = {

--- a/packages/client/src/components/Security/PasskeyManager.tsx
+++ b/packages/client/src/components/Security/PasskeyManager.tsx
@@ -114,7 +114,10 @@ export function PasskeyManagerContent() {
 
       {/* Error */}
       {error && (
-        <div className="mb-4 rounded-lg bg-red-500/10 border border-red-500/30 px-3 py-2 text-xs text-red-400">
+        <div
+          className="mb-4 rounded-lg border px-3 py-2 text-xs"
+          style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
+        >
           {error}
         </div>
       )}
@@ -145,7 +148,8 @@ export function PasskeyManagerContent() {
                   <button
                     onClick={() => handleDeletePasskey(pk.id)}
                     disabled={deletingId === pk.id}
-                    className="text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded bg-red-500/10 disabled:opacity-50"
+                    className="text-xs px-2 py-1 rounded disabled:opacity-50"
+                    style={{ color: 'var(--accent-danger)', background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)' }}
                   >
                     {deletingId === pk.id ? '...' : 'Confirm'}
                   </button>
@@ -160,7 +164,7 @@ export function PasskeyManagerContent() {
               ) : (
                 <button
                   onClick={() => setConfirmDeleteId(pk.id)}
-                  className="ml-2 p-1.5 hover:text-red-400 transition-colors"
+                  className="ml-2 p-1.5 transition-colors"
                   style={{ color: 'var(--fg-3)' }}
                   aria-label="Delete passkey"
                 >
@@ -220,7 +224,7 @@ export function PasskeyManagerContent() {
 export function PasskeyManager({ open, onClose }: PasskeyManagerProps) {
   if (!open) return null;
   return createPortal(
-    <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'oklch(0 0 0 / 0.6)' }} onClick={onClose}>
       <div
         className="rounded-xl shadow-2xl w-full max-w-md p-6 border"
         style={{ background: 'var(--bg-1)', borderColor: 'var(--line)' }}

--- a/packages/client/src/components/Security/TwoFactorManager.tsx
+++ b/packages/client/src/components/Security/TwoFactorManager.tsx
@@ -1,9 +1,24 @@
-import { useState, useEffect, useCallback, FormEvent } from 'react';
+import { useState, useEffect, useCallback, FormEvent, CSSProperties } from 'react';
 import { Shield, ShieldCheck, Copy, Check } from 'lucide-react';
 import QRCode from 'qrcode';
 import { authClient } from '../../lib/auth-client';
 
 type SetupStep = 'idle' | 'confirm-password' | 'scan-qr' | 'verify' | 'backup-codes';
+
+const inputStyle: CSSProperties = {
+  background: 'var(--bg-2)',
+  borderColor: 'var(--line)',
+  color: 'var(--fg)',
+};
+
+const primaryBtnStyle: CSSProperties = {
+  background: 'var(--accent)',
+  color: 'var(--accent-fg)',
+};
+
+const ghostBtnStyle: CSSProperties = {
+  color: 'var(--fg-3)',
+};
 
 export function TwoFactorManager() {
   const session = authClient.useSession();
@@ -113,20 +128,20 @@ export function TwoFactorManager() {
     await session.refetch();
   }, [session]);
 
-  const inputClass = "w-full bg-surface-800 border border-gray-700/50 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500/50";
-  const btnPrimary = "flex-1 bg-violet-500 text-white rounded-lg py-2 text-sm font-medium hover:bg-violet-600 transition-colors disabled:opacity-50";
-  const btnSecondary = "px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors";
+  const inputClass = "w-full border rounded-lg px-3 py-2 text-sm focus:outline-none";
+  const btnPrimaryClass = "flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-50";
+  const btnSecondaryClass = "px-4 py-2 text-sm transition-colors";
 
   return (
     <div className="max-w-sm space-y-4">
       <div>
-        <h3 className="text-sm font-medium text-gray-200 mb-1 flex items-center gap-2">
+        <h3 className="text-sm font-medium mb-1 flex items-center gap-2" style={{ color: 'var(--fg)' }}>
           {twoFactorEnabled
             ? <><ShieldCheck size={16} className="text-green-400" /> Two-Factor Authentication</>
-            : <><Shield size={16} className="text-gray-400" /> Two-Factor Authentication</>
+            : <><Shield size={16} style={{ color: 'var(--fg-3)' }} /> Two-Factor Authentication</>
           }
         </h3>
-        <p className="text-xs text-gray-500">
+        <p className="text-xs" style={{ color: 'var(--fg-3)' }}>
           {twoFactorEnabled
             ? 'Your account is protected with TOTP two-factor authentication.'
             : 'Add an extra layer of security using an authenticator app.'}
@@ -137,7 +152,7 @@ export function TwoFactorManager() {
 
       {/* Idle state */}
       {step === 'idle' && !twoFactorEnabled && (
-        <button onClick={handleStartSetup} className="bg-violet-500 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-violet-600 transition-colors">
+        <button onClick={handleStartSetup} className="rounded-lg px-4 py-2 text-sm font-medium transition-colors" style={primaryBtnStyle}>
           Enable 2FA
         </button>
       )}
@@ -156,7 +171,7 @@ export function TwoFactorManager() {
         <form onSubmit={handleDisable} className="space-y-3">
           <p className="text-xs text-yellow-400">Enter your password to confirm disabling 2FA.</p>
           <div>
-            <label htmlFor="2fa-disable-password" className="block text-xs text-gray-400 mb-1">Password</label>
+            <label htmlFor="2fa-disable-password" className="block text-xs mb-1" style={{ color: 'var(--fg-3)' }}>Password</label>
             <input
               id="2fa-disable-password"
               type="password"
@@ -165,13 +180,14 @@ export function TwoFactorManager() {
               required
               autoFocus
               className={inputClass}
+              style={inputStyle}
             />
           </div>
           <div className="flex gap-2">
-            <button type="submit" disabled={loading} className={btnPrimary}>
+            <button type="submit" disabled={loading} className={btnPrimaryClass} style={primaryBtnStyle}>
               {loading ? 'Disabling...' : 'Confirm Disable'}
             </button>
-            <button type="button" onClick={() => setShowDisableConfirm(false)} className={btnSecondary}>
+            <button type="button" onClick={() => setShowDisableConfirm(false)} className={btnSecondaryClass} style={ghostBtnStyle}>
               Cancel
             </button>
           </div>
@@ -181,9 +197,9 @@ export function TwoFactorManager() {
       {/* Step 1: Confirm password to get TOTP URI */}
       {step === 'confirm-password' && (
         <form onSubmit={handleConfirmPassword} className="space-y-3">
-          <p className="text-xs text-gray-400">Enter your password to begin setup.</p>
+          <p className="text-xs" style={{ color: 'var(--fg-3)' }}>Enter your password to begin setup.</p>
           <div>
-            <label htmlFor="2fa-confirm-password" className="block text-xs text-gray-400 mb-1">Password</label>
+            <label htmlFor="2fa-confirm-password" className="block text-xs mb-1" style={{ color: 'var(--fg-3)' }}>Password</label>
             <input
               id="2fa-confirm-password"
               type="password"
@@ -192,13 +208,14 @@ export function TwoFactorManager() {
               required
               autoFocus
               className={inputClass}
+              style={inputStyle}
             />
           </div>
           <div className="flex gap-2">
-            <button type="submit" disabled={loading} className={btnPrimary}>
+            <button type="submit" disabled={loading} className={btnPrimaryClass} style={primaryBtnStyle}>
               {loading ? 'Generating...' : 'Continue'}
             </button>
-            <button type="button" onClick={() => setStep('idle')} className={btnSecondary}>
+            <button type="button" onClick={() => setStep('idle')} className={btnSecondaryClass} style={ghostBtnStyle}>
               Cancel
             </button>
           </div>
@@ -208,7 +225,7 @@ export function TwoFactorManager() {
       {/* Step 2: Scan QR code */}
       {step === 'scan-qr' && (
         <div className="space-y-3">
-          <p className="text-xs text-gray-400">
+          <p className="text-xs" style={{ color: 'var(--fg-3)' }}>
             Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.).
           </p>
           {qrDataUrl ? (
@@ -216,20 +233,21 @@ export function TwoFactorManager() {
               <img src={qrDataUrl} alt="TOTP QR Code" width={200} height={200} />
             </div>
           ) : (
-            <div className="bg-surface-800 rounded-lg p-3 text-xs text-gray-400 break-all">
+            <div className="rounded-lg p-3 text-xs break-all" style={{ background: 'var(--bg-2)', color: 'var(--fg-3)' }}>
               {totpURI}
             </div>
           )}
-          <p className="text-xs text-gray-500">
+          <p className="text-xs" style={{ color: 'var(--fg-3)' }}>
             Can't scan? Manually enter the secret key from the URI above into your app.
           </p>
           <button
             onClick={() => { setStep('verify'); setError(''); }}
-            className="w-full bg-violet-500 text-white rounded-lg py-2 text-sm font-medium hover:bg-violet-600 transition-colors"
+            className="w-full rounded-lg py-2 text-sm font-medium transition-colors"
+            style={primaryBtnStyle}
           >
             I've scanned it — Continue
           </button>
-          <button type="button" onClick={() => setStep('idle')} className="w-full text-center text-xs text-gray-500 hover:text-gray-300">
+          <button type="button" onClick={() => setStep('idle')} className="w-full text-center text-xs" style={ghostBtnStyle}>
             Cancel
           </button>
         </div>
@@ -238,11 +256,11 @@ export function TwoFactorManager() {
       {/* Step 3: Verify TOTP code */}
       {step === 'verify' && (
         <form onSubmit={handleVerifyTOTP} className="space-y-3">
-          <p className="text-xs text-gray-400">
+          <p className="text-xs" style={{ color: 'var(--fg-3)' }}>
             Enter the 6-digit code from your authenticator app to confirm setup.
           </p>
           <div>
-            <label htmlFor="2fa-totp-code" className="block text-xs text-gray-400 mb-1">Authentication Code</label>
+            <label htmlFor="2fa-totp-code" className="block text-xs mb-1" style={{ color: 'var(--fg-3)' }}>Authentication Code</label>
             <input
               id="2fa-totp-code"
               type="text"
@@ -255,13 +273,14 @@ export function TwoFactorManager() {
               autoFocus
               placeholder="000000"
               className={inputClass + " tracking-widest text-center text-lg"}
+              style={inputStyle}
             />
           </div>
           <div className="flex gap-2">
-            <button type="submit" disabled={loading || totpCode.length !== 6} className={btnPrimary}>
+            <button type="submit" disabled={loading || totpCode.length !== 6} className={btnPrimaryClass} style={primaryBtnStyle}>
               {loading ? 'Verifying...' : 'Verify & Enable'}
             </button>
-            <button type="button" onClick={() => setStep('scan-qr')} className={btnSecondary}>
+            <button type="button" onClick={() => setStep('scan-qr')} className={btnSecondaryClass} style={ghostBtnStyle}>
               Back
             </button>
           </div>
@@ -277,23 +296,25 @@ export function TwoFactorManager() {
               Store these in a safe place. Each code can only be used once to recover access if you lose your authenticator.
             </p>
           </div>
-          <div className="bg-surface-800 rounded-lg p-3 grid grid-cols-2 gap-1.5">
+          <div className="rounded-lg p-3 grid grid-cols-2 gap-1.5" style={{ background: 'var(--bg-2)' }}>
             {backupCodes.map((code, i) => (
-              <span key={i} className="font-mono text-xs text-gray-200 text-center py-1 bg-surface-950 rounded px-2">
+              <span key={i} className="font-mono text-xs text-center py-1 rounded px-2" style={{ color: 'var(--fg)', background: 'var(--bg)' }}>
                 {code}
               </span>
             ))}
           </div>
           <button
             onClick={handleCopyBackupCodes}
-            className="flex items-center gap-2 text-xs text-violet-400 hover:text-violet-300 transition-colors"
+            className="flex items-center gap-2 text-xs transition-colors"
+            style={{ color: 'var(--accent)' }}
           >
             {copiedCodes ? <Check size={14} /> : <Copy size={14} />}
             {copiedCodes ? 'Copied!' : 'Copy all codes'}
           </button>
           <button
             onClick={handleFinish}
-            className="w-full bg-violet-500 text-white rounded-lg py-2 text-sm font-medium hover:bg-violet-600 transition-colors"
+            className="w-full rounded-lg py-2 text-sm font-medium transition-colors"
+            style={primaryBtnStyle}
           >
             Done — 2FA is enabled
           </button>

--- a/packages/client/src/components/Security/TwoFactorManager.tsx
+++ b/packages/client/src/components/Security/TwoFactorManager.tsx
@@ -2,16 +2,14 @@ import { useState, useEffect, useCallback, FormEvent } from 'react';
 import { ShieldCheck, Copy, Check } from 'lucide-react';
 import QRCode from 'qrcode';
 import { authClient } from '../../lib/auth-client';
+import { Section, Field, Toolbar } from '../Settings/settings-kit';
 import {
-  Section,
-  Field,
-  Toolbar,
   helpText,
   inputStyle,
   primaryBtn,
   ghostBtn,
   dangerBtn,
-} from '../Settings/settings-kit';
+} from '../Settings/settings-kit-styles';
 
 type SetupStep = 'idle' | 'confirm-password' | 'scan-qr' | 'verify' | 'backup-codes';
 

--- a/packages/client/src/components/Security/TwoFactorManager.tsx
+++ b/packages/client/src/components/Security/TwoFactorManager.tsx
@@ -137,7 +137,7 @@ export function TwoFactorManager() {
       <div>
         <h3 className="text-sm font-medium mb-1 flex items-center gap-2" style={{ color: 'var(--fg)' }}>
           {twoFactorEnabled
-            ? <><ShieldCheck size={16} className="text-green-400" /> Two-Factor Authentication</>
+            ? <><ShieldCheck size={16} style={{ color: 'var(--accent-good)' }} /> Two-Factor Authentication</>
             : <><Shield size={16} style={{ color: 'var(--fg-3)' }} /> Two-Factor Authentication</>
           }
         </h3>
@@ -148,7 +148,7 @@ export function TwoFactorManager() {
         </p>
       </div>
 
-      {error && <div className="text-red-400 text-xs">{error}</div>}
+      {error && <div className="text-xs" style={{ color: 'var(--accent-danger)' }}>{error}</div>}
 
       {/* Idle state */}
       {step === 'idle' && !twoFactorEnabled && (
@@ -160,7 +160,8 @@ export function TwoFactorManager() {
       {step === 'idle' && twoFactorEnabled && !showDisableConfirm && (
         <button
           onClick={() => { setShowDisableConfirm(true); setError(''); setDisablePassword(''); }}
-          className="border border-red-500/50 text-red-400 rounded-lg px-4 py-2 text-sm font-medium hover:bg-red-500/10 transition-colors"
+          className="border rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+          style={{ borderColor: 'color-mix(in oklch, var(--accent-danger) 50%, transparent)', color: 'var(--accent-danger)' }}
         >
           Disable 2FA
         </button>
@@ -169,7 +170,7 @@ export function TwoFactorManager() {
       {/* Disable confirm */}
       {showDisableConfirm && (
         <form onSubmit={handleDisable} className="space-y-3">
-          <p className="text-xs text-yellow-400">Enter your password to confirm disabling 2FA.</p>
+          <p className="text-xs" style={{ color: 'var(--accent-warn)' }}>Enter your password to confirm disabling 2FA.</p>
           <div>
             <label htmlFor="2fa-disable-password" className="block text-xs mb-1" style={{ color: 'var(--fg-3)' }}>Password</label>
             <input
@@ -229,7 +230,7 @@ export function TwoFactorManager() {
             Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.).
           </p>
           {qrDataUrl ? (
-            <div className="bg-white p-3 rounded-lg inline-block">
+            <div className="p-3 rounded-lg inline-block" style={{ background: 'var(--fg)' }}>
               <img src={qrDataUrl} alt="TOTP QR Code" width={200} height={200} />
             </div>
           ) : (
@@ -290,9 +291,12 @@ export function TwoFactorManager() {
       {/* Step 4: Backup codes */}
       {step === 'backup-codes' && (
         <div className="space-y-3">
-          <div className="bg-yellow-500/10 border border-yellow-500/30 rounded-lg p-3">
-            <p className="text-xs text-yellow-300 font-medium mb-1">Save your backup codes</p>
-            <p className="text-xs text-yellow-400/80">
+          <div
+            className="border rounded-lg p-3"
+            style={{ background: 'color-mix(in oklch, var(--accent-warn) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-warn) 30%, transparent)' }}
+          >
+            <p className="text-xs font-medium mb-1" style={{ color: 'var(--accent-warn)' }}>Save your backup codes</p>
+            <p className="text-xs" style={{ color: 'var(--accent-warn)' }}>
               Store these in a safe place. Each code can only be used once to recover access if you lose your authenticator.
             </p>
           </div>

--- a/packages/client/src/components/Security/TwoFactorManager.tsx
+++ b/packages/client/src/components/Security/TwoFactorManager.tsx
@@ -11,9 +11,16 @@ const inputStyle: CSSProperties = {
   color: 'var(--fg)',
 };
 
+// Primary CTA — solid accent. `--accent-fg` produces dark-on-light-violet
+// (WCAG AA, but visually weak); explicit `#fff` reads more clearly as a
+// primary action surface and matches the convention used elsewhere on the
+// app for "ready to commit" buttons.
 const primaryBtnStyle: CSSProperties = {
   background: 'var(--accent)',
-  color: 'var(--accent-fg)',
+  color: '#fff',
+  padding: '8px 16px',
+  borderRadius: 6,
+  fontWeight: 500,
 };
 
 const ghostBtnStyle: CSSProperties = {

--- a/packages/client/src/components/Security/TwoFactorManager.tsx
+++ b/packages/client/src/components/Security/TwoFactorManager.tsx
@@ -1,31 +1,57 @@
-import { useState, useEffect, useCallback, FormEvent, CSSProperties } from 'react';
-import { Shield, ShieldCheck, Copy, Check } from 'lucide-react';
+import { useState, useEffect, useCallback, FormEvent } from 'react';
+import { ShieldCheck, Copy, Check } from 'lucide-react';
 import QRCode from 'qrcode';
 import { authClient } from '../../lib/auth-client';
+import {
+  Section,
+  Field,
+  Toolbar,
+  helpText,
+  inputStyle,
+  primaryBtn,
+  ghostBtn,
+  dangerBtn,
+} from '../Settings/settings-kit';
 
 type SetupStep = 'idle' | 'confirm-password' | 'scan-qr' | 'verify' | 'backup-codes';
 
-const inputStyle: CSSProperties = {
+// Small bg-2 chip matching the visual language of AppearanceSection pills.
+const chipStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 12px',
   background: 'var(--bg-2)',
-  borderColor: 'var(--line)',
+  border: '1px solid var(--line)',
+  borderRadius: 5,
+  fontFamily: 'var(--font-mono)',
+  fontSize: 12,
   color: 'var(--fg)',
-};
+} as const;
 
-// Primary CTA — solid accent. `--accent-fg` produces dark-on-light-violet
-// (WCAG AA, but visually weak); explicit `#fff` reads more clearly as a
-// primary action surface and matches the convention used elsewhere on the
-// app for "ready to commit" buttons.
-const primaryBtnStyle: CSSProperties = {
-  background: 'var(--accent)',
-  color: '#fff',
-  padding: '8px 16px',
-  borderRadius: 6,
-  fontWeight: 500,
-};
+const dotStyle = {
+  width: 6,
+  height: 6,
+  borderRadius: 999,
+  background: 'var(--accent-good)',
+} as const;
 
-const ghostBtnStyle: CSSProperties = {
-  color: 'var(--fg-3)',
-};
+// QR wrapper: bg-2 padded container holds a white QR plate (must stay light
+// for scanners). Mirrors the chip style at a larger scale.
+const qrWrapStyle = {
+  display: 'inline-block',
+  padding: 12,
+  background: 'var(--bg-2)',
+  border: '1px solid var(--line)',
+  borderRadius: 5,
+} as const;
+
+const qrPlateStyle = {
+  display: 'inline-block',
+  padding: 8,
+  background: '#fff',
+  borderRadius: 4,
+} as const;
 
 export function TwoFactorManager() {
   const session = authClient.useSession();
@@ -135,51 +161,62 @@ export function TwoFactorManager() {
     await session.refetch();
   }, [session]);
 
-  const inputClass = "w-full border rounded-lg px-3 py-2 text-sm focus:outline-none";
-  const btnPrimaryClass = "flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-50";
-  const btnSecondaryClass = "px-4 py-2 text-sm transition-colors";
-
   return (
-    <div className="max-w-sm space-y-4">
-      <div>
-        <h3 className="text-sm font-medium mb-1 flex items-center gap-2" style={{ color: 'var(--fg)' }}>
-          {twoFactorEnabled
-            ? <><ShieldCheck size={16} style={{ color: 'var(--accent-good)' }} /> Two-Factor Authentication</>
-            : <><Shield size={16} style={{ color: 'var(--fg-3)' }} /> Two-Factor Authentication</>
-          }
-        </h3>
-        <p className="text-xs" style={{ color: 'var(--fg-3)' }}>
-          {twoFactorEnabled
-            ? 'Your account is protected with TOTP two-factor authentication.'
-            : 'Add an extra layer of security using an authenticator app.'}
-        </p>
-      </div>
+    <Section title="two-factor authentication">
+      <p style={helpText}>
+        {twoFactorEnabled
+          ? 'Your account is protected with TOTP two-factor authentication.'
+          : 'Add an extra layer of security using an authenticator app.'}
+      </p>
 
-      {error && <div className="text-xs" style={{ color: 'var(--accent-danger)' }}>{error}</div>}
+      {twoFactorEnabled && step === 'idle' && (
+        <div style={{ marginBottom: 12 }}>
+          <span style={chipStyle}>
+            <span style={dotStyle} />
+            <ShieldCheck size={14} style={{ color: 'var(--accent-good)' }} />
+            2fa is enabled
+          </span>
+        </div>
+      )}
+
+      {error && (
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            color: 'var(--accent-danger)',
+            marginBottom: 12,
+          }}
+        >
+          {error}
+        </div>
+      )}
 
       {/* Idle state */}
       {step === 'idle' && !twoFactorEnabled && (
-        <button onClick={handleStartSetup} className="rounded-lg px-4 py-2 text-sm font-medium transition-colors" style={primaryBtnStyle}>
-          Enable 2FA
-        </button>
+        <Toolbar>
+          <button onClick={handleStartSetup} style={primaryBtn}>
+            Enable 2FA
+          </button>
+        </Toolbar>
       )}
 
       {step === 'idle' && twoFactorEnabled && !showDisableConfirm && (
-        <button
-          onClick={() => { setShowDisableConfirm(true); setError(''); setDisablePassword(''); }}
-          className="border rounded-lg px-4 py-2 text-sm font-medium transition-colors"
-          style={{ borderColor: 'color-mix(in oklch, var(--accent-danger) 50%, transparent)', color: 'var(--accent-danger)' }}
-        >
-          Disable 2FA
-        </button>
+        <Toolbar>
+          <button
+            onClick={() => { setShowDisableConfirm(true); setError(''); setDisablePassword(''); }}
+            style={dangerBtn}
+          >
+            Disable 2FA
+          </button>
+        </Toolbar>
       )}
 
       {/* Disable confirm */}
       {showDisableConfirm && (
-        <form onSubmit={handleDisable} className="space-y-3">
-          <p className="text-xs" style={{ color: 'var(--accent-warn)' }}>Enter your password to confirm disabling 2FA.</p>
-          <div>
-            <label htmlFor="2fa-disable-password" className="block text-xs mb-1" style={{ color: 'var(--fg-3)' }}>Password</label>
+        <form onSubmit={handleDisable}>
+          <p style={helpText}>Enter your password to confirm disabling 2FA.</p>
+          <Field label="password">
             <input
               id="2fa-disable-password"
               type="password"
@@ -187,27 +224,25 @@ export function TwoFactorManager() {
               onChange={e => setDisablePassword(e.target.value)}
               required
               autoFocus
-              className={inputClass}
               style={inputStyle}
             />
-          </div>
-          <div className="flex gap-2">
-            <button type="submit" disabled={loading} className={btnPrimaryClass} style={primaryBtnStyle}>
+          </Field>
+          <Toolbar>
+            <button type="submit" disabled={loading} style={{ ...dangerBtn, opacity: loading ? 0.5 : 1 }}>
               {loading ? 'Disabling...' : 'Confirm Disable'}
             </button>
-            <button type="button" onClick={() => setShowDisableConfirm(false)} className={btnSecondaryClass} style={ghostBtnStyle}>
+            <button type="button" onClick={() => setShowDisableConfirm(false)} style={ghostBtn}>
               Cancel
             </button>
-          </div>
+          </Toolbar>
         </form>
       )}
 
-      {/* Step 1: Confirm password to get TOTP URI */}
+      {/* Step 1: Confirm password */}
       {step === 'confirm-password' && (
-        <form onSubmit={handleConfirmPassword} className="space-y-3">
-          <p className="text-xs" style={{ color: 'var(--fg-3)' }}>Enter your password to begin setup.</p>
-          <div>
-            <label htmlFor="2fa-confirm-password" className="block text-xs mb-1" style={{ color: 'var(--fg-3)' }}>Password</label>
+        <form onSubmit={handleConfirmPassword}>
+          <p style={helpText}>Enter your password to begin setup.</p>
+          <Field label="password">
             <input
               id="2fa-confirm-password"
               type="password"
@@ -215,60 +250,72 @@ export function TwoFactorManager() {
               onChange={e => setPassword(e.target.value)}
               required
               autoFocus
-              className={inputClass}
               style={inputStyle}
             />
-          </div>
-          <div className="flex gap-2">
-            <button type="submit" disabled={loading} className={btnPrimaryClass} style={primaryBtnStyle}>
+          </Field>
+          <Toolbar>
+            <button type="submit" disabled={loading} style={{ ...primaryBtn, opacity: loading ? 0.5 : 1 }}>
               {loading ? 'Generating...' : 'Continue'}
             </button>
-            <button type="button" onClick={() => setStep('idle')} className={btnSecondaryClass} style={ghostBtnStyle}>
+            <button type="button" onClick={() => setStep('idle')} style={ghostBtn}>
               Cancel
             </button>
-          </div>
+          </Toolbar>
         </form>
       )}
 
-      {/* Step 2: Scan QR code */}
+      {/* Step 2: Scan QR */}
       {step === 'scan-qr' && (
-        <div className="space-y-3">
-          <p className="text-xs" style={{ color: 'var(--fg-3)' }}>
+        <div>
+          <p style={helpText}>
             Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.).
           </p>
           {qrDataUrl ? (
-            <div className="p-3 rounded-lg inline-block" style={{ background: 'var(--fg)' }}>
-              <img src={qrDataUrl} alt="TOTP QR Code" width={200} height={200} />
+            <div style={{ marginBottom: 12 }}>
+              <span style={qrWrapStyle}>
+                <span style={qrPlateStyle}>
+                  <img src={qrDataUrl} alt="TOTP QR Code" width={200} height={200} style={{ display: 'block' }} />
+                </span>
+              </span>
             </div>
           ) : (
-            <div className="rounded-lg p-3 text-xs break-all" style={{ background: 'var(--bg-2)', color: 'var(--fg-3)' }}>
+            <div
+              style={{
+                background: 'var(--bg-2)',
+                border: '1px solid var(--line)',
+                borderRadius: 5,
+                padding: 12,
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                color: 'var(--fg-3)',
+                wordBreak: 'break-all',
+                marginBottom: 12,
+              }}
+            >
               {totpURI}
             </div>
           )}
-          <p className="text-xs" style={{ color: 'var(--fg-3)' }}>
+          <p style={helpText}>
             Can't scan? Manually enter the secret key from the URI above into your app.
           </p>
-          <button
-            onClick={() => { setStep('verify'); setError(''); }}
-            className="w-full rounded-lg py-2 text-sm font-medium transition-colors"
-            style={primaryBtnStyle}
-          >
-            I've scanned it — Continue
-          </button>
-          <button type="button" onClick={() => setStep('idle')} className="w-full text-center text-xs" style={ghostBtnStyle}>
-            Cancel
-          </button>
+          <Toolbar>
+            <button onClick={() => { setStep('verify'); setError(''); }} style={primaryBtn}>
+              I've scanned it — Continue
+            </button>
+            <button type="button" onClick={() => setStep('idle')} style={ghostBtn}>
+              Cancel
+            </button>
+          </Toolbar>
         </div>
       )}
 
-      {/* Step 3: Verify TOTP code */}
+      {/* Step 3: Verify TOTP */}
       {step === 'verify' && (
-        <form onSubmit={handleVerifyTOTP} className="space-y-3">
-          <p className="text-xs" style={{ color: 'var(--fg-3)' }}>
+        <form onSubmit={handleVerifyTOTP}>
+          <p style={helpText}>
             Enter the 6-digit code from your authenticator app to confirm setup.
           </p>
-          <div>
-            <label htmlFor="2fa-totp-code" className="block text-xs mb-1" style={{ color: 'var(--fg-3)' }}>Authentication Code</label>
+          <Field label="verification code">
             <input
               id="2fa-totp-code"
               type="text"
@@ -280,57 +327,74 @@ export function TwoFactorManager() {
               required
               autoFocus
               placeholder="000000"
-              className={inputClass + " tracking-widest text-center text-lg"}
-              style={inputStyle}
+              style={{ ...inputStyle, letterSpacing: '0.3em', maxWidth: 180 }}
             />
-          </div>
-          <div className="flex gap-2">
-            <button type="submit" disabled={loading || totpCode.length !== 6} className={btnPrimaryClass} style={primaryBtnStyle}>
+          </Field>
+          <Toolbar>
+            <button
+              type="submit"
+              disabled={loading || totpCode.length !== 6}
+              style={{ ...primaryBtn, opacity: loading || totpCode.length !== 6 ? 0.5 : 1 }}
+            >
               {loading ? 'Verifying...' : 'Verify & Enable'}
             </button>
-            <button type="button" onClick={() => setStep('scan-qr')} className={btnSecondaryClass} style={ghostBtnStyle}>
+            <button type="button" onClick={() => setStep('scan-qr')} style={ghostBtn}>
               Back
             </button>
-          </div>
+          </Toolbar>
         </form>
       )}
 
       {/* Step 4: Backup codes */}
       {step === 'backup-codes' && (
-        <div className="space-y-3">
+        <div>
+          <p style={{ ...helpText, color: 'var(--accent-warn)' }}>
+            Save your backup codes. Store them in a safe place — each code can only be used once
+            to recover access if you lose your authenticator.
+          </p>
           <div
-            className="border rounded-lg p-3"
-            style={{ background: 'color-mix(in oklch, var(--accent-warn) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-warn) 30%, transparent)' }}
+            style={{
+              background: 'var(--bg-2)',
+              border: '1px solid var(--line)',
+              borderRadius: 5,
+              padding: 12,
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 6,
+              marginBottom: 12,
+            }}
           >
-            <p className="text-xs font-medium mb-1" style={{ color: 'var(--accent-warn)' }}>Save your backup codes</p>
-            <p className="text-xs" style={{ color: 'var(--accent-warn)' }}>
-              Store these in a safe place. Each code can only be used once to recover access if you lose your authenticator.
-            </p>
-          </div>
-          <div className="rounded-lg p-3 grid grid-cols-2 gap-1.5" style={{ background: 'var(--bg-2)' }}>
             {backupCodes.map((code, i) => (
-              <span key={i} className="font-mono text-xs text-center py-1 rounded px-2" style={{ color: 'var(--fg)', background: 'var(--bg)' }}>
+              <span
+                key={i}
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                  color: 'var(--fg)',
+                  background: 'var(--bg)',
+                  border: '1px solid var(--line)',
+                  borderRadius: 4,
+                  padding: '4px 8px',
+                }}
+              >
                 {code}
               </span>
             ))}
           </div>
-          <button
-            onClick={handleCopyBackupCodes}
-            className="flex items-center gap-2 text-xs transition-colors"
-            style={{ color: 'var(--accent)' }}
-          >
-            {copiedCodes ? <Check size={14} /> : <Copy size={14} />}
-            {copiedCodes ? 'Copied!' : 'Copy all codes'}
-          </button>
-          <button
-            onClick={handleFinish}
-            className="w-full rounded-lg py-2 text-sm font-medium transition-colors"
-            style={primaryBtnStyle}
-          >
-            Done — 2FA is enabled
-          </button>
+          <Toolbar>
+            <button onClick={handleFinish} style={primaryBtn}>
+              I've saved them
+            </button>
+            <button
+              onClick={handleCopyBackupCodes}
+              style={{ ...ghostBtn, display: 'inline-flex', alignItems: 'center', gap: 6 }}
+            >
+              {copiedCodes ? <Check size={12} /> : <Copy size={12} />}
+              {copiedCodes ? 'Copied' : 'Copy codes'}
+            </button>
+          </Toolbar>
         </div>
       )}
-    </div>
+    </Section>
   );
 }

--- a/packages/client/src/components/Settings/settings-kit-styles.ts
+++ b/packages/client/src/components/Settings/settings-kit-styles.ts
@@ -1,0 +1,86 @@
+/**
+ * Settings-pane visual primitives — style constants only.
+ *
+ * Split from settings-kit.tsx so that file can export components alone
+ * (react-refresh/only-export-components requires that). The look mirrors
+ * AppearanceSection — see settings-kit.tsx header for the design notes.
+ */
+import type { CSSProperties } from "react";
+
+export const sectionTitle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10.5,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--fg-3)",
+  marginBottom: 10,
+};
+
+export const fieldLabel: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  color: "var(--fg-3)",
+  textTransform: "lowercase",
+  letterSpacing: "0.06em",
+};
+
+export const helpText: CSSProperties = {
+  fontSize: 12,
+  color: "var(--fg-3)",
+  marginBottom: 12,
+  lineHeight: 1.5,
+};
+
+export const inputStyle: CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  background: "var(--bg-2)",
+  border: "1px solid var(--line)",
+  borderRadius: 5,
+  color: "var(--fg)",
+  outline: "none",
+};
+
+export const primaryBtn: CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 5,
+  border: "none",
+  background: "var(--accent)",
+  color: "#fff",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  fontWeight: 500,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  cursor: "pointer",
+  transition: "background 120ms, opacity 120ms",
+};
+
+export const ghostBtn: CSSProperties = {
+  padding: "6px 12px",
+  borderRadius: 5,
+  border: "1px solid var(--line)",
+  background: "transparent",
+  color: "var(--fg-2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  cursor: "pointer",
+  transition: "background 120ms, color 120ms",
+};
+
+export const dangerBtn: CSSProperties = {
+  padding: "6px 12px",
+  borderRadius: 5,
+  border: "1px dashed color-mix(in oklch, var(--accent-danger) 50%, transparent)",
+  background: "transparent",
+  color: "var(--accent-danger)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  cursor: "pointer",
+};

--- a/packages/client/src/components/Settings/settings-kit.tsx
+++ b/packages/client/src/components/Settings/settings-kit.tsx
@@ -1,98 +1,16 @@
 /**
- * Settings-pane visual primitives — extracted so every section inside
- * Account Settings reads with the same vibe as the AppearanceSection
- * (which the user explicitly named as the design-guide gold standard).
+ * Settings-pane visual primitives — components.
  *
- * The look mirrors AppearanceSection lines 11-56:
+ * Style constants live in ./settings-kit-styles.ts so this file can export
+ * components alone (react-refresh/only-export-components).
+ *
+ * The look mirrors AppearanceSection (the design-guide gold standard):
  *   • Section title:  `// label` mono 10.5px 0.08em uppercase fg-3
  *   • Field label:    mono 11px 0.06em lowercase fg-3
- *   • Pill button:    6/12 padding, radius 5, 1px line border,
- *                     accent-soft bg + accent text when active
- *   • Input:          bg-2, line border, fg text, focus ring via accent-soft
- *   • Primary CTA:    accent bg + #fff text, 8/16 padding, radius 5
- *   • Ghost / danger: dashed line-strong border, transparent bg
- *
- * Sections always flow left — no flex-1 stretching, no centred buttons.
+ *   • Sections always flow left — no flex-1 stretching, no centred buttons.
  */
-import type { CSSProperties, ReactNode } from "react";
-
-export const sectionTitle: CSSProperties = {
-  fontFamily: "var(--font-mono)",
-  fontSize: 10.5,
-  letterSpacing: "0.08em",
-  textTransform: "uppercase",
-  color: "var(--fg-3)",
-  marginBottom: 10,
-};
-
-export const fieldLabel: CSSProperties = {
-  fontFamily: "var(--font-mono)",
-  fontSize: 11,
-  color: "var(--fg-3)",
-  textTransform: "lowercase",
-  letterSpacing: "0.06em",
-};
-
-export const helpText: CSSProperties = {
-  fontSize: 12,
-  color: "var(--fg-3)",
-  marginBottom: 12,
-  lineHeight: 1.5,
-};
-
-export const inputStyle: CSSProperties = {
-  width: "100%",
-  padding: "8px 10px",
-  fontFamily: "var(--font-mono)",
-  fontSize: 12,
-  background: "var(--bg-2)",
-  border: "1px solid var(--line)",
-  borderRadius: 5,
-  color: "var(--fg)",
-  outline: "none",
-};
-
-export const primaryBtn: CSSProperties = {
-  padding: "8px 16px",
-  borderRadius: 5,
-  border: "none",
-  background: "var(--accent)",
-  color: "#fff",
-  fontFamily: "var(--font-mono)",
-  fontSize: 12,
-  fontWeight: 500,
-  textTransform: "uppercase",
-  letterSpacing: "0.04em",
-  cursor: "pointer",
-  transition: "background 120ms, opacity 120ms",
-};
-
-export const ghostBtn: CSSProperties = {
-  padding: "6px 12px",
-  borderRadius: 5,
-  border: "1px solid var(--line)",
-  background: "transparent",
-  color: "var(--fg-2)",
-  fontFamily: "var(--font-mono)",
-  fontSize: 11,
-  textTransform: "uppercase",
-  letterSpacing: "0.04em",
-  cursor: "pointer",
-  transition: "background 120ms, color 120ms",
-};
-
-export const dangerBtn: CSSProperties = {
-  padding: "6px 12px",
-  borderRadius: 5,
-  border: "1px dashed color-mix(in oklch, var(--accent-danger) 50%, transparent)",
-  background: "transparent",
-  color: "var(--accent-danger)",
-  fontFamily: "var(--font-mono)",
-  fontSize: 11,
-  textTransform: "uppercase",
-  letterSpacing: "0.04em",
-  cursor: "pointer",
-};
+import type { ReactNode } from "react";
+import { sectionTitle, fieldLabel } from "./settings-kit-styles";
 
 export function Section({ title, children }: { title: string; children: ReactNode }) {
   return (

--- a/packages/client/src/components/Settings/settings-kit.tsx
+++ b/packages/client/src/components/Settings/settings-kit.tsx
@@ -1,0 +1,121 @@
+/**
+ * Settings-pane visual primitives — extracted so every section inside
+ * Account Settings reads with the same vibe as the AppearanceSection
+ * (which the user explicitly named as the design-guide gold standard).
+ *
+ * The look mirrors AppearanceSection lines 11-56:
+ *   • Section title:  `// label` mono 10.5px 0.08em uppercase fg-3
+ *   • Field label:    mono 11px 0.06em lowercase fg-3
+ *   • Pill button:    6/12 padding, radius 5, 1px line border,
+ *                     accent-soft bg + accent text when active
+ *   • Input:          bg-2, line border, fg text, focus ring via accent-soft
+ *   • Primary CTA:    accent bg + #fff text, 8/16 padding, radius 5
+ *   • Ghost / danger: dashed line-strong border, transparent bg
+ *
+ * Sections always flow left — no flex-1 stretching, no centred buttons.
+ */
+import type { CSSProperties, ReactNode } from "react";
+
+export const sectionTitle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10.5,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--fg-3)",
+  marginBottom: 10,
+};
+
+export const fieldLabel: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  color: "var(--fg-3)",
+  textTransform: "lowercase",
+  letterSpacing: "0.06em",
+};
+
+export const helpText: CSSProperties = {
+  fontSize: 12,
+  color: "var(--fg-3)",
+  marginBottom: 12,
+  lineHeight: 1.5,
+};
+
+export const inputStyle: CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  background: "var(--bg-2)",
+  border: "1px solid var(--line)",
+  borderRadius: 5,
+  color: "var(--fg)",
+  outline: "none",
+};
+
+export const primaryBtn: CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 5,
+  border: "none",
+  background: "var(--accent)",
+  color: "#fff",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  fontWeight: 500,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  cursor: "pointer",
+  transition: "background 120ms, opacity 120ms",
+};
+
+export const ghostBtn: CSSProperties = {
+  padding: "6px 12px",
+  borderRadius: 5,
+  border: "1px solid var(--line)",
+  background: "transparent",
+  color: "var(--fg-2)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  cursor: "pointer",
+  transition: "background 120ms, color 120ms",
+};
+
+export const dangerBtn: CSSProperties = {
+  padding: "6px 12px",
+  borderRadius: 5,
+  border: "1px dashed color-mix(in oklch, var(--accent-danger) 50%, transparent)",
+  background: "transparent",
+  color: "var(--accent-danger)",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  cursor: "pointer",
+};
+
+export function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <div style={sectionTitle}>{`// ${title}`}</div>
+      {children}
+    </div>
+  );
+}
+
+export function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 14 }}>
+      <span style={fieldLabel}>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export function Toolbar({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: "flex", gap: 8, marginTop: 6, alignItems: "center", flexWrap: "wrap" }}>
+      {children}
+    </div>
+  );
+}

--- a/packages/client/src/components/Sharing/AccessRequestsModal.tsx
+++ b/packages/client/src/components/Sharing/AccessRequestsModal.tsx
@@ -93,11 +93,19 @@ export function AccessRequestsModal({ onClose }: AccessRequestsModalProps) {
     >
       <div
         ref={dialogRef}
-        className="bg-white dark:bg-surface-900 rounded-xl shadow-2xl border dark:border-surface-700 w-full max-w-md mx-4 overflow-hidden"
+        className="w-full max-w-md mx-4 overflow-hidden"
+        style={{ background: 'var(--bg-1)', borderRadius: 12, boxShadow: 'var(--shadow-lg)', border: '1px solid var(--line)' }}
       >
-        <div className="flex items-center justify-between px-5 py-4 border-b dark:border-surface-700">
+        <div className="flex items-center justify-between px-5 py-4" style={{ borderBottom: '1px solid var(--line)' }}>
           <h2 className="text-sm font-semibold">Access Requests</h2>
-          <button type="button" onClick={onClose} className="btn-ghost p-1" aria-label="Close">
+          <button
+            type="button"
+            onClick={onClose}
+            style={{ padding: 4, borderRadius: 4, color: 'var(--fg-3)', background: 'transparent' }}
+            onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+            aria-label="Close"
+          >
             <X size={16} />
           </button>
         </div>

--- a/packages/client/src/components/Sharing/AccessRequestsModal.tsx
+++ b/packages/client/src/components/Sharing/AccessRequestsModal.tsx
@@ -88,7 +88,8 @@ export function AccessRequestsModal({ onClose }: AccessRequestsModalProps) {
 
   const modal = (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'oklch(0 0 0 / 0.6)' }}
       onClick={handleOverlayClick}
     >
       <div

--- a/packages/client/src/components/Sidebar/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar/Sidebar.tsx
@@ -81,7 +81,7 @@ function SectionHeader({
         onClick={() => setOpen(!open)}
         style={{
           display: 'inline-flex', alignItems: 'center',
-          color: 'inherit', width: 16, height: 16,
+          color: 'inherit',
         }}
         aria-label={open ? `Collapse ${label}` : `Expand ${label}`}
       >
@@ -92,7 +92,7 @@ function SectionHeader({
       </button>
       <span>{label}</span>
       {count !== undefined && (
-        <span style={{ color: 'var(--fg-4)' }}>{count}</span>
+        <span className="mono" style={{ color: 'var(--fg-4)' }}>{count}</span>
       )}
       <div style={{ flex: 1 }} />
       {actions}
@@ -140,10 +140,11 @@ function NavRow({
     <button
       onClick={onClick}
       style={{
+        position: 'relative',
         display: 'flex', alignItems: 'center', gap: 8,
-        width: '100%', height: 'var(--row, 24px)',
+        width: '100%', height: 28,
         padding: '0 8px', borderRadius: 6,
-        color: active ? 'var(--accent)' : 'var(--fg-1)',
+        color: active ? 'var(--fg)' : 'var(--fg-2)',
         background: active ? 'var(--accent-soft)' : 'transparent',
         textAlign: 'left',
         fontSize: 'var(--fs-base)',
@@ -152,7 +153,15 @@ function NavRow({
       onMouseEnter={e => { if (!active) e.currentTarget.style.background = 'var(--bg-hover)'; }}
       onMouseLeave={e => { if (!active) e.currentTarget.style.background = 'transparent'; }}
     >
-      <span style={{ color: active ? 'var(--accent)' : 'var(--fg-3)', display: 'inline-flex' }}>{icon}</span>
+      {active && (
+        <span
+          style={{
+            position: 'absolute', left: 0, top: 4, bottom: 4,
+            width: 2, background: 'var(--accent)', borderRadius: 2,
+          }}
+        />
+      )}
+      <span style={{ color: active ? 'var(--accent)' : undefined, display: 'inline-flex' }}>{icon}</span>
       <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{label}</span>
       {hint !== undefined && hint !== null && (
         <span className="mono" style={{ color: 'var(--fg-4)', fontSize: 11 }}>{hint}</span>
@@ -178,7 +187,7 @@ function AgentAvatar({ label, title }: { label: string; title: string }) {
   );
 }
 
-function AgentsFooter({ agents = 0 }: { agents?: number }) {
+function AgentsFooter({ agents = 2 }: { agents?: number }) {
   return (
     <div
       className="mono"
@@ -199,11 +208,12 @@ function AgentsFooter({ agents = 0 }: { agents?: number }) {
         }}
       >
         <span
-          className="pulse"
+          className="dot pulse"
           style={{
             display: 'inline-block',
             width: 5, height: 5, borderRadius: '50%',
             background: 'var(--accent)',
+            boxShadow: 'none',
           }}
         />
         MCP
@@ -286,6 +296,7 @@ export function Sidebar({
         display: 'flex', flexDirection: 'column',
         width: '100%', height: '100%',
         background: 'var(--bg-1)',
+        borderRight: '1px solid var(--line)',
         fontSize: 'var(--fs-base)',
         color: 'var(--fg-1)',
       }}
@@ -307,7 +318,7 @@ export function Sidebar({
           <Icons.Logo size={18} />
           <span
             className="mono"
-            style={{ fontWeight: 600, color: 'var(--fg)', fontSize: 14, letterSpacing: 0.3 }}
+            style={{ fontWeight: 600, color: 'var(--fg)', letterSpacing: 0.5 }}
           >
             kryton
           </span>
@@ -321,7 +332,7 @@ export function Sidebar({
         {onCollapse && (
           <button
             onClick={onCollapse}
-            title="Collapse sidebar (Ctrl+B)"
+            title="Collapse sidebar (⌘B)"
             aria-label="Collapse sidebar"
             style={{
               width: 26, height: 26, borderRadius: 5,
@@ -381,7 +392,7 @@ export function Sidebar({
             count={starredPaths.size}
           />
           {favOpen && (
-            <div style={{ marginBottom: 4 }}>
+            <div style={{ marginBottom: 8 }}>
               {starredPaths.size === 0 ? (
                 <div
                   style={{
@@ -391,7 +402,7 @@ export function Sidebar({
                     fontStyle: 'italic',
                   }}
                 >
-                  No favorites yet · Ctrl+Shift+S
+                  No favorites yet · ⌘⇧S
                 </div>
               ) : (
                 <FavoritesSection
@@ -410,7 +421,6 @@ export function Sidebar({
             open={filesOpen}
             setOpen={setFilesOpen}
             label="Files"
-            count={noteCount}
             actions={
               <div style={{ display: 'flex', gap: 2 }}>
                 <IconBtn onClick={dispatchCreateRootFile} title="New note (Ctrl+Shift+N)">
@@ -457,10 +467,10 @@ export function Sidebar({
                 display: 'flex',
                 flexWrap: 'wrap',
                 gap: 4,
-                padding: '2px 6px 12px',
+                padding: '2px 6px 8px',
               }}
             >
-              {tags.map(({ tag, count }) => (
+              {tags.slice(0, 11).map(({ tag, count }) => (
                 <button
                   key={tag}
                   className="mono"

--- a/packages/client/src/components/Sidebar/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { api, FileNode, TagData } from '../../lib/api';
 import { FileTree, FavoritesSection } from '@azrtydxb/ui';
 import { useUIStore } from '../../stores/uiStore';
@@ -170,24 +171,37 @@ function NavRow({
   );
 }
 
-function AgentAvatar({ label, title }: { label: string; title: string }) {
-  return (
-    <span
-      title={title}
-      className="mono"
-      style={{
-        width: 16, height: 16, borderRadius: '50%',
-        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-        background: 'var(--bg-2)', border: '1px solid var(--line)',
-        fontSize: 9.5, color: 'var(--fg-2)',
-      }}
-    >
-      {label}
-    </span>
-  );
-}
+/**
+ * Sidebar footer — live MCP status driven by /api/agents:
+ *   - mcp-health probe decides whether the chip is "MCP" (green-pulsing,
+ *     transport reachable) or "MCP offline" (gray, transport down).
+ *   - agents/online drives the "N agents online" count. The pluralisation
+ *     and the count are real, not the hard-coded "2" mock.
+ *
+ * Both queries refetch every 10s. Failure modes:
+ *   - mcp-health rejecting → chip turns gray "MCP offline".
+ *   - online returning 0 → "0 agents online". (No avatar list — the prior
+ *     "C / ↗" pills were decorative placeholders not tied to any client.)
+ */
+function AgentsFooter() {
+  const healthQuery = useQuery({
+    queryKey: ['mcp-health'],
+    queryFn: () => api.getMcpHealth(),
+    refetchInterval: 10_000,
+    retry: 1,
+  });
+  const onlineQuery = useQuery({
+    queryKey: ['agents-online'],
+    queryFn: () => api.getAgentsOnline(),
+    refetchInterval: 10_000,
+    retry: 1,
+  });
+  const healthy = healthQuery.data?.status === 'ok';
+  const count = onlineQuery.data?.count ?? 0;
+  const titles = (onlineQuery.data?.clients ?? [])
+    .map((c) => c.name || `${c.transport} session`)
+    .join(', ');
 
-function AgentsFooter({ agents = 2 }: { agents?: number }) {
   return (
     <div
       className="mono"
@@ -201,27 +215,32 @@ function AgentsFooter({ agents = 2 }: { agents?: number }) {
       }}
     >
       <span
+        title={healthy ? 'MCP transport reachable' : 'MCP transport unreachable'}
         style={{
           display: 'inline-flex', alignItems: 'center', gap: 5,
           padding: '2px 6px', borderRadius: 3,
-          background: 'var(--accent-soft)', color: 'var(--accent)',
+          background: healthy ? 'var(--accent-soft)' : 'var(--bg-2)',
+          color: healthy ? 'var(--accent)' : 'var(--fg-3)',
+          border: healthy ? 'none' : '1px solid var(--line)',
         }}
       >
         <span
-          className="dot pulse"
+          className={healthy ? 'dot pulse' : 'dot'}
           style={{
             display: 'inline-block',
             width: 5, height: 5, borderRadius: '50%',
-            background: 'var(--accent)',
+            background: healthy ? 'var(--accent)' : 'var(--fg-4)',
             boxShadow: 'none',
           }}
         />
-        MCP
+        {healthy ? 'MCP' : 'MCP offline'}
       </span>
-      <span style={{ color: 'var(--fg-3)' }}>{agents} agents online</span>
-      <div style={{ flex: 1 }} />
-      <AgentAvatar label="C" title="Claude" />
-      <AgentAvatar label="↗" title="Cursor" />
+      <span
+        style={{ color: 'var(--fg-3)' }}
+        title={titles || undefined}
+      >
+        {count} {count === 1 ? 'agent' : 'agents'} online
+      </span>
     </div>
   );
 }

--- a/packages/client/src/components/Sidebar/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import { api, FileNode, TagData } from '../../lib/api';
 import { FileTree, FavoritesSection } from '@azrtydxb/ui';
 import { useUIStore } from '../../stores/uiStore';
 import { Icons } from '../Icons';
+import { formatShortcut } from '../../lib/platform';
 
 interface SharedNote {
   id: string;
@@ -351,7 +352,7 @@ export function Sidebar({
         {onCollapse && (
           <button
             onClick={onCollapse}
-            title="Collapse sidebar (⌘B)"
+            title={`Collapse sidebar (${formatShortcut(['mod', 'B'])})`}
             aria-label="Collapse sidebar"
             style={{
               width: 26, height: 26, borderRadius: 5,
@@ -421,7 +422,7 @@ export function Sidebar({
                     fontStyle: 'italic',
                   }}
                 >
-                  No favorites yet · ⌘⇧S
+                  No favorites yet · {formatShortcut(['mod', 'shift', 'S'])}
                 </div>
               ) : (
                 <FavoritesSection
@@ -442,7 +443,7 @@ export function Sidebar({
             label="Files"
             actions={
               <div style={{ display: 'flex', gap: 2 }}>
-                <IconBtn onClick={dispatchCreateRootFile} title="New note (Ctrl+Shift+N)">
+                <IconBtn onClick={dispatchCreateRootFile} title={`New note (${formatShortcut(['mod', 'shift', 'N'])})`}>
                   <Icons.Plus size={12} />
                 </IconBtn>
                 <IconBtn onClick={dispatchCreateRootFolder} title="New folder">

--- a/packages/client/src/components/StatusBar/StatusBar.tsx
+++ b/packages/client/src/components/StatusBar/StatusBar.tsx
@@ -10,8 +10,10 @@ import type { CSSProperties } from 'react';
 
 interface StatusBarProps {
   notePath: string | null;
-  line: number;
-  col: number;
+  /** Editor cursor line — null when not in edit mode (no cursor). */
+  line: number | null;
+  /** Editor cursor column — null when not in edit mode. */
+  col: number | null;
   wordCount: number;
   /** Optional link counts surfaced when the parent has them. */
   outgoingCount?: number;
@@ -61,7 +63,9 @@ export function StatusBar({
       <span>{tagsCount} tags</span>
       <div style={{ flex: 1 }} />
       <span>{wordCount.toLocaleString()} words</span>
-      <span>Ln {line}, Col {col}</span>
+      {line !== null && col !== null && (
+        <span>Ln {line}, Col {col}</span>
+      )}
       <span>{encoding}</span>
       <span>Markdown</span>
     </div>

--- a/packages/client/src/components/Views/AllNotesView.tsx
+++ b/packages/client/src/components/Views/AllNotesView.tsx
@@ -84,9 +84,8 @@ const headerStyle: CSSProperties = {
   alignItems: 'center',
   gap: 10,
   height: 38,
-  padding: '0 14px',
+  padding: '0 16px',
   borderBottom: '1px solid var(--line)',
-  background: 'var(--bg-1)',
   flexShrink: 0,
 };
 
@@ -103,30 +102,14 @@ function segmentBtn(active: boolean): CSSProperties {
   return {
     padding: '3px 9px',
     borderRadius: 4,
-    fontSize: 11.5,
+    fontSize: 11,
     fontFamily: 'var(--font-mono)',
-    textTransform: 'uppercase',
-    letterSpacing: '0.06em',
     color: active ? 'var(--accent)' : 'var(--fg-2)',
     background: active ? 'var(--accent-soft)' : 'transparent',
     border: 'none',
     cursor: 'pointer',
   };
 }
-
-const bottomRail: CSSProperties = {
-  height: 28,
-  padding: '0 14px',
-  borderTop: '1px solid var(--line)',
-  background: 'var(--bg-1)',
-  display: 'flex',
-  alignItems: 'center',
-  gap: 12,
-  fontFamily: 'var(--font-mono)',
-  fontSize: 11,
-  color: 'var(--fg-3)',
-  flexShrink: 0,
-};
 
 export function AllNotesView({
   tree,
@@ -180,11 +163,12 @@ export function AllNotesView({
       }}
     >
       <div style={headerStyle}>
-        <Icons.Inbox size={16} style={{ color: 'var(--fg-3)' }} />
+        <Icons.Inbox size={14} style={{ color: 'var(--accent)' }} />
         <span
+          className="mono"
           style={{
-            fontFamily: 'var(--font-sans)',
-            fontSize: 14,
+            fontFamily: 'var(--font-mono)',
+            fontSize: 13,
             color: 'var(--fg)',
           }}
         >
@@ -194,11 +178,8 @@ export function AllNotesView({
           className="mono"
           style={{
             fontFamily: 'var(--font-mono)',
-            fontSize: 11.5,
-            color: 'var(--fg-3)',
-            background: 'var(--bg-2)',
-            padding: '1px 6px',
-            borderRadius: 4,
+            fontSize: 11,
+            color: 'var(--fg-4)',
           }}
         >
           {notes.length}
@@ -228,8 +209,6 @@ export function AllNotesView({
             padding: '3px 8px',
             fontSize: 11.5,
             fontFamily: 'var(--font-mono)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.04em',
             cursor: 'pointer',
           }}
           aria-label="Sort notes"
@@ -273,7 +252,7 @@ export function AllNotesView({
                   alignItems: 'center',
                   width: '100%',
                   minHeight: rowHeight,
-                  padding: '8px 14px',
+                  padding: '11px 16px',
                   borderBottom: '1px solid var(--line)',
                   textAlign: 'left',
                   color: 'var(--fg-1)',
@@ -303,9 +282,9 @@ export function AllNotesView({
                   aria-label={n.starred ? 'Unstar' : 'Star'}
                 >
                   {n.starred ? (
-                    <Icons.StarOn size={13} style={{ color: 'var(--accent-warn)' }} />
+                    <Icons.StarOn size={12} style={{ color: 'var(--accent-warn)' }} />
                   ) : (
-                    <Icons.FileText size={13} style={{ color: 'var(--fg-3)' }} />
+                    <Icons.FileText size={12} style={{ color: 'var(--fg-3)' }} />
                   )}
                 </span>
                 <div style={{ minWidth: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -322,21 +301,19 @@ export function AllNotesView({
                   >
                     {n.title}
                   </div>
-                  {n.parent && (
-                    <div
-                      className="mono"
-                      style={{
-                        fontFamily: 'var(--font-mono)',
-                        fontSize: 11,
-                        color: 'var(--fg-3)',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {n.parent}
-                    </div>
-                  )}
+                  <div
+                    className="mono"
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 11,
+                      color: 'var(--fg-3)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {n.path}
+                  </div>
                 </div>
                 <div style={{ display: 'flex', gap: 4 }}>
                   {n.tags.slice(0, 3).map((t) => (
@@ -427,21 +404,21 @@ export function AllNotesView({
                     className="mono"
                     style={{
                       fontFamily: 'var(--font-mono)',
-                      fontSize: 11,
+                      fontSize: 10.5,
                       color: 'var(--fg-3)',
                       overflow: 'hidden',
                       textOverflow: 'ellipsis',
                       whiteSpace: 'nowrap',
                     }}
                   >
-                    {n.parent || '/'}
+                    {n.path}
                   </span>
                 </div>
                 <div
                   style={{
                     fontFamily: 'var(--font-sans)',
                     fontSize: 14,
-                    fontWeight: 500,
+                    fontWeight: 600,
                     color: 'var(--fg)',
                     lineHeight: 1.3,
                   }}
@@ -470,12 +447,12 @@ export function AllNotesView({
                   className="mono"
                   style={{
                     fontFamily: 'var(--font-mono)',
-                    fontSize: 11,
-                    color: 'var(--fg-3)',
+                    fontSize: 10.5,
+                    color: 'var(--fg-4)',
                   }}
                 >
                   {n.words !== null && n.words !== undefined ? `${n.words}w · ` : ''}
-                  updated {formatDate(n.updated)}
+                  updated {n.updated !== null && n.updated !== undefined ? new Date(n.updated).toLocaleDateString() : '—'}
                 </div>
               </button>
             ))}
@@ -483,15 +460,6 @@ export function AllNotesView({
         )}
       </div>
 
-      <div style={bottomRail}>
-        <span>
-          {sorted.length} {sorted.length === 1 ? 'note' : 'notes'}
-        </span>
-        <span style={{ color: 'var(--fg-4)' }}>·</span>
-        <span>view: {view}</span>
-        <span style={{ color: 'var(--fg-4)' }}>·</span>
-        <span>sort: {sort}</span>
-      </div>
     </div>
   );
 }

--- a/packages/client/src/components/Views/EditModeView.tsx
+++ b/packages/client/src/components/Views/EditModeView.tsx
@@ -96,16 +96,6 @@ export function EditModeView({
   const showPreview = layout === 'preview' || layout === 'split';
   const dirty = hasChanges || saveStatus === 'saving' || saveStatus === 'unsaved';
 
-  const saveStatusLabel = (() => {
-    switch (saveStatus) {
-      case 'saving': return { text: 'saving…', color: 'var(--fg-3)' };
-      case 'saved':  return { text: 'saved',   color: 'var(--accent-good)' };
-      case 'error':  return { text: 'save failed', color: 'var(--accent-danger)' };
-      case 'unsaved': return { text: 'unsaved', color: 'var(--accent-warn)' };
-      default: return { text: '', color: 'var(--fg-3)' };
-    }
-  })();
-
   // Suppress unused variable warnings; resolvedTheme and allNotes are used
   // for future theming and wiki-link plugin wiring.
   void resolvedTheme;
@@ -116,7 +106,7 @@ export function EditModeView({
       onClick={props.onClick}
       title={props.title}
       style={{
-        width: 28, height: 28, borderRadius: 5,
+        width: 30, height: 30, borderRadius: 6,
         display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
         color: props.active ? 'var(--accent-warn)' : 'var(--fg-3)',
         background: 'transparent',
@@ -137,7 +127,7 @@ export function EditModeView({
 
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, background: 'var(--bg)' }}>
-      {/* Tab strip + actions row (single 32px row, shared bottom border) */}
+      {/* Tab strip + actions row (single 38px row, shared bottom border) */}
       <div style={{ display: 'flex', alignItems: 'stretch', background: 'var(--bg)', borderBottom: '1px solid var(--line)' }}>
         <div style={{ flex: 1, minWidth: 0, display: 'flex' }}>
           <EditorTabStrip
@@ -148,16 +138,10 @@ export function EditModeView({
           />
         </div>
         <div style={{
-          display: 'flex', alignItems: 'center', gap: 6,
-          padding: '0 8px 0 4px', height: 32,
+          display: 'flex', alignItems: 'center', gap: 8,
+          padding: '0 12px 0 4px', height: 38,
         }}>
           <ModePills />
-          {/* tiny inline saved/saving indicator (mono, accent-good when 'saved') */}
-          {(saveStatus === 'saving' || saveStatus === 'saved' || saveStatus === 'error' || saveStatus === 'unsaved') && (
-            <span className="mono" style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: saveStatusLabel.color, minWidth: 56, textAlign: 'right' }}>
-              {saveStatusLabel.text}
-            </span>
-          )}
           {/* Star / Share / More — per prototype/app/editor.jsx EditorTabBar */}
           {headerBtn({
             onClick: onToggleStar,

--- a/packages/client/src/components/Views/EditModeView.tsx
+++ b/packages/client/src/components/Views/EditModeView.tsx
@@ -3,6 +3,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { FileNode } from '../../lib/api';
 import { Editor, type EditorCursorState, type EditorHandle, EditorTabStrip, ModePills } from '../Editor/Editor';
 import { Preview } from '../Preview/Preview';
+import { useUIStore } from '../../stores/uiStore';
 // OutgoingLinksPanel intentionally removed to match design handoff: the
 // editor surface has only the tab strip + body + EditorMeta (28px). Outgoing
 // link metadata is surfaced through EditorMeta's `N outgoing` token.
@@ -134,7 +135,14 @@ export function EditModeView({
             activePath={activeNote.path}
             activeTitle={activeNote.title}
             dirty={dirty}
-            onClose={onCancel}
+            onSelect={(p) => onNoteSelect?.(p)}
+            onClose={(p) => {
+              const next = useUIStore.getState().closeTab(p);
+              if (p === activeNote.path) {
+                onCancel();
+                if (next) onNoteSelect?.(next);
+              }
+            }}
           />
         </div>
         <div style={{

--- a/packages/client/src/components/Views/EditModeView.tsx
+++ b/packages/client/src/components/Views/EditModeView.tsx
@@ -3,7 +3,6 @@ import { useDebouncedCallback } from 'use-debounce';
 import { FileNode } from '../../lib/api';
 import { Editor, type EditorCursorState, type EditorHandle, EditorTabStrip, ModePills } from '../Editor/Editor';
 import { Preview } from '../Preview/Preview';
-import { useUIStore } from '../../stores/uiStore';
 // OutgoingLinksPanel intentionally removed to match design handoff: the
 // editor surface has only the tab strip + body + EditorMeta (28px). Outgoing
 // link metadata is surfaced through EditorMeta's `N outgoing` token.
@@ -34,6 +33,8 @@ interface EditModeViewProps {
   /** retained for parent API compatibility; edit/split views don't render
      a backlinks panel — backlinks live inside the preview body's tail. */
   onNoteSelect?: (path: string) => void;
+  /** Close a tab by path. Handles next-focus / clearing the active note. */
+  onTabClose?: (path: string) => void;
   onLinkClick: (name: string) => void;
   onCreateNote: (name: string) => void;
 }
@@ -45,7 +46,7 @@ export function EditModeView({
   getCodeFenceRenderer,
   onAutoSave, onCancel, onToggleStar, onPdfExport,
   onContentChange, onCursorStateChange,
-  onLinkClick, onCreateNote, onNoteSelect,
+  onLinkClick, onCreateNote, onNoteSelect, onTabClose,
 }: EditModeViewProps) {
   const hasChanges = editContent !== originalContent;
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('unchanged');
@@ -136,13 +137,7 @@ export function EditModeView({
             activeTitle={activeNote.title}
             dirty={dirty}
             onSelect={(p) => onNoteSelect?.(p)}
-            onClose={(p) => {
-              const next = useUIStore.getState().closeTab(p);
-              if (p === activeNote.path) {
-                onCancel();
-                if (next) onNoteSelect?.(next);
-              }
-            }}
+            onClose={(p) => onTabClose?.(p)}
           />
         </div>
         <div style={{

--- a/packages/client/src/components/Views/EditModeView.tsx
+++ b/packages/client/src/components/Views/EditModeView.tsx
@@ -2,6 +2,7 @@ import { ComponentType, useRef, useState, useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { FileNode } from '../../lib/api';
 import { Editor, type EditorCursorState, type EditorHandle, EditorTabStrip, ModePills } from '../Editor/Editor';
+import { EditorToolbar } from '../Editor/EditorToolbar';
 import { Preview } from '../Preview/Preview';
 // OutgoingLinksPanel intentionally removed to match design handoff: the
 // editor surface has only the tab strip + body + EditorMeta (28px). Outgoing
@@ -169,6 +170,10 @@ export function EditModeView({
           pane has only the tab strip + mode pills above the body, no separate
           toolbar row. In-editor formatting goes through keyboard shortcuts;
           plugin-supplied buttons live in the status bar via PluginSlot. */}
+
+      {/* Formatting toolbar — shown only when the editor surface is active
+          (edit or split). Pure-preview mode hides it. */}
+      {showEditor && <EditorToolbar editorRef={editorRef} />}
 
       {/* Body */}
       <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>

--- a/packages/client/src/components/Views/EmptyStateView.tsx
+++ b/packages/client/src/components/Views/EmptyStateView.tsx
@@ -6,11 +6,12 @@
  */
 import type { CSSProperties } from 'react';
 import { Icons } from '../Icons';
+import { formatShortcut } from '../../lib/platform';
 
 const monoFamily = 'var(--font-mono)';
 
 interface Shortcut {
-  keys: string[];
+  keys: string;
   label: string;
 }
 
@@ -27,16 +28,12 @@ const cardStyle: CSSProperties = {
 };
 
 export function EmptyStateView() {
-  const isMac =
-    typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
-  const mod = isMac ? '⌘' : 'Ctrl';
-
   const shortcuts: Shortcut[] = [
-    { keys: [mod, 'N'], label: 'new note' },
-    { keys: [mod, 'P'], label: 'quick switcher' },
-    { keys: [mod, 'K'], label: 'search' },
-    { keys: [mod, 'B'], label: 'toggle sidebar' },
-    { keys: [mod, 'G'], label: 'graph view' },
+    { label: 'new note', keys: formatShortcut(['mod', 'N']) },
+    { label: 'quick switcher', keys: formatShortcut(['mod', 'P']) },
+    { label: 'search', keys: formatShortcut(['mod', 'K']) },
+    { label: 'toggle sidebar', keys: formatShortcut(['mod', 'B']) },
+    { label: 'graph view', keys: formatShortcut(['mod', 'G']) },
   ];
 
   return (
@@ -94,11 +91,11 @@ export function EmptyStateView() {
   );
 }
 
-function ShortcutRow({ keys, label }: { keys: string[]; label: string }) {
+function ShortcutRow({ keys, label }: { keys: string; label: string }) {
   return (
     <>
       <span style={{ textAlign: 'right' }}>
-        <span className="kbd">{keys.join('')}</span>
+        <span className="kbd">{keys}</span>
       </span>
       <span>{label}</span>
     </>

--- a/packages/client/src/components/Views/EmptyStateView.tsx
+++ b/packages/client/src/components/Views/EmptyStateView.tsx
@@ -26,19 +26,6 @@ const cardStyle: CSSProperties = {
   border: '1px solid var(--accent)',
 };
 
-const idleBadge: CSSProperties = {
-  position: 'absolute',
-  top: -8,
-  right: -8,
-  padding: '2px 7px',
-  borderRadius: 10,
-  background: 'var(--bg)',
-  border: '1px solid var(--accent)',
-  color: 'var(--accent)',
-  fontSize: 10,
-  fontFamily: monoFamily,
-};
-
 export function EmptyStateView() {
   const isMac =
     typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
@@ -69,7 +56,6 @@ export function EmptyStateView() {
     >
       <div style={cardStyle}>
         <Icons.Logo size={56} />
-        <span style={idleBadge}>idle</span>
       </div>
 
       <div style={{ textAlign: 'center' }}>

--- a/packages/client/src/components/Views/PreviewModeView.tsx
+++ b/packages/client/src/components/Views/PreviewModeView.tsx
@@ -1,7 +1,6 @@
-import { MutableRefObject, ComponentType, useState, useEffect, useRef } from 'react';
+import { MutableRefObject, ComponentType, useState, useEffect } from 'react';
 import { FileNode } from '../../lib/api';
 import { api, NoteVersion } from '../../lib/api';
-import { useUIStore } from '../../stores/uiStore';
 import { Preview } from '../Preview/Preview';
 // OutgoingLinksPanel intentionally removed to match design handoff —
 // outgoing-link metadata is exposed through EditorMeta's `N outgoing`
@@ -29,15 +28,6 @@ interface PreviewModeViewProps {
   onCreateNote: (name: string) => void;
   onRestored?: () => void;
   getCodeFenceRenderer?: (language: string) => { component: ComponentType<{ content: string; notePath: string }> } | undefined;
-}
-
-function timeAgo(timestamp: number): string {
-  const seconds = Math.floor((Date.now() - timestamp) / 1000);
-  if (seconds < 60) return 'just now';
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
-  if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
-  return new Date(timestamp).toLocaleDateString();
 }
 
 interface VersionPreviewModalProps {
@@ -145,59 +135,22 @@ export function PreviewModeView({
   onEdit, onShare, onToggleStar,
   onLinkClick, onCreateNote, onRestored, getCodeFenceRenderer, onNoteSelect, onTabClose,
 }: PreviewModeViewProps) {
-  // History panel is controlled by the top-bar History button via the UI
-  // store so it can be toggled both from the per-note "history" pill and
-  // from the header. Both call sites mutate the same flag.
-  const historyOpen = useUIStore((s) => s.showNoteHistory);
-  const setShowNoteHistory = useUIStore((s) => s.setShowNoteHistory);
-  const setHistoryOpen = setShowNoteHistory;
-  const [versions, setVersions] = useState<NoteVersion[]>([]);
-  const [loadingVersions, setLoadingVersions] = useState(false);
+  // Version history lives in <NoteHistoryPopover> at app level (see App.tsx)
+  // — it's anchored to the top-bar History button and renders for any view.
+  // The version-restore preview modal (VersionPreviewModal) is still owned
+  // here because it's a per-note diff overlay, not part of the history list.
   const [previewVersion, setPreviewVersion] = useState<NoteVersion | null>(null);
-  const [restoring, setRestoring] = useState<number | null>(null);
-  const historyPanelRef = useRef<HTMLDivElement | null>(null);
   const setPref = usePrefs((s) => s.setPref);
 
-  // Load versions when the panel opens
-  useEffect(() => {
-    if (!historyOpen) return;
-    setLoadingVersions(true);
-    api.listVersions(activeNote.path)
-      .then((data) => setVersions(data.versions))
-      .catch(() => setVersions([]))
-      .finally(() => setLoadingVersions(false));
-  }, [historyOpen, activeNote.path]);
-
-  // Close panel when clicking outside. Skip the close when the click is on
-  // the header's History toggle — its own onClick will handle the toggle,
-  // and racing with our setShowNoteHistory(false) here would leave the
-  // panel stuck open (toggle would close-then-reopen on every click).
-  useEffect(() => {
-    if (!historyOpen) return;
-    function handleClick(e: MouseEvent) {
-      const target = e.target as Element | null;
-      if (target && target.closest('[data-header-btn="history-toggle"]')) return;
-      if (historyPanelRef.current && !historyPanelRef.current.contains(e.target as Node)) {
-        setHistoryOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [historyOpen, setHistoryOpen]);
-
-  async function handleRestore(timestamp: number) {
-    setRestoring(timestamp);
+  const handleRestore = async (timestamp: number): Promise<void> => {
     try {
       await api.restoreVersion(activeNote.path, timestamp);
-      setHistoryOpen(false);
       setPreviewVersion(null);
       onRestored?.();
     } catch {
       // Silently fail — user can try again
-    } finally {
-      setRestoring(null);
     }
-  }
+  };
 
   // Mode pill change: switching to "edit" or "split" enters edit mode.
   // "preview" keeps the user here.
@@ -262,87 +215,14 @@ export function PreviewModeView({
             title: 'Share',
             children: <Icons.Share size={13} />,
           })}
-          <div style={{ position: 'relative' }} ref={historyPanelRef}>
-            {headerBtn({
-              onClick: () => setHistoryOpen((o) => !o),
-              title: 'More',
-              active: historyOpen,
-              children: <Icons.More size={13} />,
-            })}
-            {historyOpen && (
-              <div
-                style={{
-                  position: 'absolute', right: 0, top: 32, zIndex: 40,
-                  width: 280, background: 'var(--bg-1)', border: '1px solid var(--line)',
-                  borderRadius: 8, boxShadow: 'var(--shadow-md)', overflow: 'hidden',
-                }}
-              >
-                <div style={{
-                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                  padding: '8px 10px', borderBottom: '1px solid var(--line)',
-                  fontFamily: 'var(--font-mono)', fontSize: 10.5,
-                  letterSpacing: '0.08em', textTransform: 'uppercase',
-                  color: 'var(--fg-4)',
-                }}>
-                  <span>// version history</span>
-                  <button onClick={() => setHistoryOpen(false)} style={{ color: 'var(--fg-3)' }}>
-                    <Icons.X size={12} />
-                  </button>
-                </div>
-                <div style={{ maxHeight: 280, overflowY: 'auto' }}>
-                  {loadingVersions && (
-                    <p className="mono" style={{ padding: 14, fontSize: 11, color: 'var(--fg-4)', textAlign: 'center' }}>loading…</p>
-                  )}
-                  {!loadingVersions && versions.length === 0 && (
-                    <p className="mono" style={{ padding: 14, fontSize: 11, color: 'var(--fg-4)', textAlign: 'center' }}>no saved versions yet.</p>
-                  )}
-                  {!loadingVersions && versions.map((v) => (
-                    <div
-                      key={v.timestamp}
-                      style={{
-                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                        padding: '8px 10px', borderBottom: '1px solid var(--line)',
-                      }}
-                      onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; }}
-                      onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-                    >
-                      <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-                        <span style={{ fontSize: 12, color: 'var(--fg-1)' }}>{timeAgo(v.timestamp)}</span>
-                        <span className="mono" style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--fg-4)' }}>
-                          {new Date(v.timestamp).toLocaleString()} · {(v.size / 1024).toFixed(1)} KB
-                        </span>
-                      </div>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0, marginLeft: 8 }}>
-                        <button
-                          onClick={() => setPreviewVersion(v)}
-                          title="Preview this version"
-                          style={{ width: 22, height: 22, borderRadius: 4, color: 'var(--fg-3)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
-                          onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--accent)'; }}
-                          onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--fg-3)'; }}
-                        >
-                          <Icons.Eye size={12} />
-                        </button>
-                        <button
-                          onClick={() => handleRestore(v.timestamp)}
-                          disabled={restoring === v.timestamp}
-                          title="Restore this version"
-                          style={{
-                            width: 22, height: 22, borderRadius: 4, color: 'var(--fg-3)',
-                            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-                            opacity: restoring === v.timestamp ? 0.5 : 1,
-                          }}
-                          onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--accent)'; }}
-                          onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--fg-3)'; }}
-                        >
-                          <Icons.History size={12} />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
+          {/* "More" placeholder. Version history opens via the top-bar
+              History button which renders <NoteHistoryPopover> at app
+              level (see App.tsx). */}
+          {headerBtn({
+            onClick: () => { /* future per-note actions */ },
+            title: 'More',
+            children: <Icons.More size={13} />,
+          })}
         </div>
       </div>
 

--- a/packages/client/src/components/Views/PreviewModeView.tsx
+++ b/packages/client/src/components/Views/PreviewModeView.tsx
@@ -239,6 +239,11 @@ export function PreviewModeView({
             activePath={activeNote.path}
             activeTitle={activeNote.title}
             dirty={false}
+            onSelect={(p) => onNoteSelect?.(p)}
+            onClose={(p) => {
+              const next = useUIStore.getState().closeTab(p);
+              if (p === activeNote.path && next) onNoteSelect?.(next);
+            }}
           />
         </div>
         <div style={{

--- a/packages/client/src/components/Views/PreviewModeView.tsx
+++ b/packages/client/src/components/Views/PreviewModeView.tsx
@@ -23,6 +23,8 @@ interface PreviewModeViewProps {
   /** retained for parent API compatibility; backlinks live inline at the
      bottom of the preview body, no separate rail. */
   onNoteSelect?: (path: string) => void;
+  /** Close a tab by path; routed up to handleTabClose. */
+  onTabClose?: (path: string) => void;
   onLinkClick: (name: string) => void;
   onCreateNote: (name: string) => void;
   onRestored?: () => void;
@@ -141,7 +143,7 @@ function VersionPreviewModal({ notePath, version, allNotes, onClose, onRestore }
 export function PreviewModeView({
   activeNote, isStarred, allNotes, previewRef,
   onEdit, onShare, onToggleStar,
-  onLinkClick, onCreateNote, onRestored, getCodeFenceRenderer, onNoteSelect,
+  onLinkClick, onCreateNote, onRestored, getCodeFenceRenderer, onNoteSelect, onTabClose,
 }: PreviewModeViewProps) {
   // History panel is controlled by the top-bar History button via the UI
   // store so it can be toggled both from the per-note "history" pill and
@@ -240,10 +242,7 @@ export function PreviewModeView({
             activeTitle={activeNote.title}
             dirty={false}
             onSelect={(p) => onNoteSelect?.(p)}
-            onClose={(p) => {
-              const next = useUIStore.getState().closeTab(p);
-              if (p === activeNote.path && next) onNoteSelect?.(next);
-            }}
+            onClose={(p) => onTabClose?.(p)}
           />
         </div>
         <div style={{

--- a/packages/client/src/components/Views/PreviewModeView.tsx
+++ b/packages/client/src/components/Views/PreviewModeView.tsx
@@ -1,6 +1,7 @@
 import { MutableRefObject, ComponentType, useState, useEffect, useRef } from 'react';
 import { FileNode } from '../../lib/api';
 import { api, NoteVersion } from '../../lib/api';
+import { useUIStore } from '../../stores/uiStore';
 import { Preview } from '../Preview/Preview';
 // OutgoingLinksPanel intentionally removed to match design handoff —
 // outgoing-link metadata is exposed through EditorMeta's `N outgoing`
@@ -142,7 +143,12 @@ export function PreviewModeView({
   onEdit, onShare, onToggleStar,
   onLinkClick, onCreateNote, onRestored, getCodeFenceRenderer, onNoteSelect,
 }: PreviewModeViewProps) {
-  const [historyOpen, setHistoryOpen] = useState(false);
+  // History panel is controlled by the top-bar History button via the UI
+  // store so it can be toggled both from the per-note "history" pill and
+  // from the header. Both call sites mutate the same flag.
+  const historyOpen = useUIStore((s) => s.showNoteHistory);
+  const setShowNoteHistory = useUIStore((s) => s.setShowNoteHistory);
+  const setHistoryOpen = setShowNoteHistory;
   const [versions, setVersions] = useState<NoteVersion[]>([]);
   const [loadingVersions, setLoadingVersions] = useState(false);
   const [previewVersion, setPreviewVersion] = useState<NoteVersion | null>(null);
@@ -160,17 +166,22 @@ export function PreviewModeView({
       .finally(() => setLoadingVersions(false));
   }, [historyOpen, activeNote.path]);
 
-  // Close panel when clicking outside
+  // Close panel when clicking outside. Skip the close when the click is on
+  // the header's History toggle — its own onClick will handle the toggle,
+  // and racing with our setShowNoteHistory(false) here would leave the
+  // panel stuck open (toggle would close-then-reopen on every click).
   useEffect(() => {
     if (!historyOpen) return;
     function handleClick(e: MouseEvent) {
+      const target = e.target as Element | null;
+      if (target && target.closest('[data-header-btn="history-toggle"]')) return;
       if (historyPanelRef.current && !historyPanelRef.current.contains(e.target as Node)) {
         setHistoryOpen(false);
       }
     }
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
-  }, [historyOpen]);
+  }, [historyOpen, setHistoryOpen]);
 
   async function handleRestore(timestamp: number) {
     setRestoring(timestamp);

--- a/packages/client/src/hooks/useAppCallbacks.ts
+++ b/packages/client/src/hooks/useAppCallbacks.ts
@@ -47,6 +47,26 @@ export function useAppCallbacks(state: AppState) {
     setMobileMenuOpen(false);
   }, [notes, setEditing, setEditContent, setOriginalContent, setMobileMenuOpen]);
 
+  /**
+   * Close the tab for `path` and pick the next tab (or empty state) to show.
+   * Centralised here so every view's tab strip uses the same flow.
+   */
+  const handleTabClose = useCallback((path: string) => {
+    const next = useUIStore.getState().closeTab(path);
+    if (path !== notes.activeNote?.path) return;
+    // We just closed the active tab. If there's a neighbour, focus it;
+    // otherwise clear the active note so the empty state renders and the
+    // tab strip collapses to zero.
+    if (next) {
+      notes.openNote(next);
+    } else {
+      notes.closeActiveNote();
+      setEditing(false);
+      setEditContent(null);
+      setOriginalContent(null);
+    }
+  }, [notes, setEditing, setEditContent, setOriginalContent]);
+
   const handleLinkClick = useCallback((noteName: string) => {
     const findNote = (nodes: typeof notes.tree): string | null => {
       for (const node of nodes) {
@@ -200,7 +220,8 @@ export function useAppCallbacks(state: AppState) {
 
   return {
     toggleStar, toggleActiveNoteStar,
-    handleNoteSelect, handleLinkClick, handleCreateNoteFromLink,
+    handleNoteSelect, handleTabClose,
+    handleLinkClick, handleCreateNoteFromLink,
     handleDailyNote, handleCreateFromTemplate, handleTemplateSelected,
     handleOutlineJump, handleNewNote, handleRenameNote, handlePdfExport,
     enterEditMode, saveEdit, saveEditInPlace, cancelEdit,

--- a/packages/client/src/hooks/useAppCallbacks.ts
+++ b/packages/client/src/hooks/useAppCallbacks.ts
@@ -37,6 +37,9 @@ export function useAppCallbacks(state: AppState) {
   const handleNoteSelect = useCallback((path: string) => {
     if (!path.startsWith('shared:')) {
       notes.openNote(path);
+      // Keep the tab strip in sync — opening a note adds it (idempotent)
+      // and selecting an already-open one just leaves the tab where it is.
+      useUIStore.getState().openTab(path);
     }
     setEditing(false);
     setEditContent(null);

--- a/packages/client/src/hooks/useNotes.ts
+++ b/packages/client/src/hooks/useNotes.ts
@@ -134,6 +134,10 @@ export function useNotes(userId?: string) {
     setActiveNote(prev => prev ? { ...prev, content } : null);
   }, []);
 
+  const closeActiveNote = useCallback(() => {
+    setActiveNote(null);
+  }, []);
+
   return {
     tree,
     activeNote,
@@ -141,6 +145,7 @@ export function useNotes(userId?: string) {
     saving,
     error,
     openNote,
+    closeActiveNote,
     updateContent,
     setActiveNoteContent,
     createNote,

--- a/packages/client/src/hooks/useTheme.ts
+++ b/packages/client/src/hooks/useTheme.ts
@@ -13,14 +13,8 @@ function applyTheme(theme: Theme) {
   const resolved = theme === 'system' ? getSystemTheme() : theme;
   const root = document.documentElement;
 
-  // Explicitly add or remove — never rely on toggle()
-  if (resolved === 'dark') {
-    root.classList.add('dark');
-  } else {
-    root.classList.remove('dark');
-  }
-
-  // Sync data attribute for any non-Tailwind consumers
+  // Bible uses data-theme attribute exclusively; the dark: Tailwind variant
+  // is mapped to [data-theme="dark"] via @custom-variant in globals.css.
   root.dataset.theme = resolved;
 }
 

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -28,6 +28,20 @@ export interface GraphData {
   edges: { fromNoteId: string; toNoteId: string }[];
 }
 
+export interface AgentsOnlineClient {
+  sessionId: string;
+  name: string | null;
+  version: string | null;
+  transport: 'sse' | 'streamable';
+  startedAt: number;
+  lastActivity: number;
+}
+
+export interface AgentsOnlineData {
+  count: number;
+  clients: AgentsOnlineClient[];
+}
+
 export interface BacklinkData {
   path: string;
   title: string;
@@ -192,6 +206,10 @@ export const api = {
 
   // Backlinks
   getBacklinks: (path: string) => request<BacklinkData[]>(`/backlinks/${encodeURIComponent(path)}`),
+
+  // MCP-session indicators consumed by the sidebar agents-online footer.
+  getAgentsOnline: () => request<AgentsOnlineData>('/agents/online'),
+  getMcpHealth: () => request<{ status: 'ok' }>('/agents/mcp-health'),
 
   // Tags
   getTags: () => request<TagData[]>('/tags'),

--- a/packages/client/src/lib/platform.ts
+++ b/packages/client/src/lib/platform.ts
@@ -1,0 +1,43 @@
+/**
+ * Platform-aware shortcut formatting. Single source of truth so every label,
+ * tooltip, and kbd badge renders the right modifier glyph for the OS:
+ *
+ *   isMac → '⌘', '⇧', '⌥', '⌃'   (Mac kbd glyphs, no separator)
+ *   else  → 'Ctrl', 'Shift', 'Alt' (Windows/Linux, '+'-joined)
+ *
+ * The keyboard *bindings* themselves work cross-platform — handlers use
+ * `e.metaKey || e.ctrlKey`. Only the human-readable text needs to adapt.
+ */
+
+export const isMac =
+  typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac");
+
+/** Primary modifier — Cmd on mac, Ctrl elsewhere. */
+export const modKey = isMac ? "⌘" : "Ctrl";
+
+export type ShortcutPart =
+  | "mod"   // ⌘ / Ctrl
+  | "shift" // ⇧ / Shift
+  | "alt"   // ⌥ / Alt
+  | "ctrl"  // ⌃ / Ctrl (literal control on mac, where you also might want Cmd)
+  | string; // any literal key, e.g. 'N', 'B', '/'
+
+/**
+ * Render a shortcut as a single label.
+ *   formatShortcut(['mod', 'B'])           → '⌘B'         (mac)  | 'Ctrl+B'         (other)
+ *   formatShortcut(['mod', 'shift', 'S'])  → '⌘⇧S'        (mac)  | 'Ctrl+Shift+S'   (other)
+ */
+export function formatShortcut(parts: ShortcutPart[]): string {
+  const sep = isMac ? "" : "+";
+  return parts
+    .map((p) => {
+      switch (p) {
+        case "mod": return isMac ? "⌘" : "Ctrl";
+        case "shift": return isMac ? "⇧" : "Shift";
+        case "alt": return isMac ? "⌥" : "Alt";
+        case "ctrl": return isMac ? "⌃" : "Ctrl";
+        default: return p;
+      }
+    })
+    .join(sep);
+}

--- a/packages/client/src/pages/AccountSettingsPage.tsx
+++ b/packages/client/src/pages/AccountSettingsPage.tsx
@@ -1,26 +1,22 @@
 import { useState, useCallback, FormEvent, CSSProperties } from 'react';
 import { Settings, User, Fingerprint, Key, Shield, X, Palette } from 'lucide-react';
 
-const inputStyle: CSSProperties = {
-  background: 'var(--bg-2)',
-  borderColor: 'var(--line)',
-  color: 'var(--fg)',
-};
 const dialogStyle: CSSProperties = { background: 'var(--bg-1)' };
 const borderLine: CSSProperties = { borderColor: 'var(--line)' };
-const labelStyle: CSSProperties = { color: 'var(--fg-3)' };
-const headingStyle: CSSProperties = { color: 'var(--fg)' };
-const mutedStyle: CSSProperties = { color: 'var(--fg-3)' };
-const submitStyle: CSSProperties = {
-  background: 'var(--accent)',
-  color: '#fff',
-};
 const ghostHoverBase: CSSProperties = { color: 'var(--fg-3)' };
 import { authApi } from '../lib/api';
 import { PasskeyManagerContent } from '../components/Security/PasskeyManager';
 import { ApiKeyManager } from '../components/ApiKeys/ApiKeyManager';
 import { TwoFactorManager } from '../components/Security/TwoFactorManager';
 import { AppearanceSection } from '../components/Settings/AppearanceSection';
+import {
+  Section,
+  Field,
+  Toolbar,
+  inputStyle as kitInputStyle,
+  primaryBtn,
+  helpText,
+} from '../components/Settings/settings-kit';
 
 type Tab = 'profile' | 'appearance' | 'passkeys' | 'api-keys' | '2fa';
 
@@ -61,69 +57,76 @@ function ProfileSection() {
     }
   }, [currentPw, newPw, confirmPw]);
 
+  const focusRing = (e: React.FocusEvent<HTMLInputElement>): void => {
+    e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent-soft)';
+  };
+  const blurRing = (e: React.FocusEvent<HTMLInputElement>): void => {
+    e.currentTarget.style.boxShadow = 'none';
+  };
+
   return (
-    <div className="max-w-sm space-y-4">
-      <div>
-        <h3 className="text-sm font-medium mb-1" style={headingStyle}>Change Password</h3>
-        <p className="text-xs" style={mutedStyle}>Update your account password.</p>
-      </div>
-      <form onSubmit={handlePasswordChange} className="space-y-3">
-        <div>
-          <label htmlFor="current-password" className="block text-xs mb-1" style={labelStyle}>Current Password</label>
-          <input
-            id="current-password"
-            type="password"
-            value={currentPw}
-            onChange={e => setCurrentPw(e.target.value)}
-            required
-            className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none"
-            style={inputStyle}
-            onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent-soft)'; }}
-            onBlur={e => { e.currentTarget.style.boxShadow = 'none'; }}
-          />
-        </div>
-        <div>
-          <label htmlFor="new-password" className="block text-xs mb-1" style={labelStyle}>New Password</label>
-          <input
-            id="new-password"
-            type="password"
-            value={newPw}
-            onChange={e => setNewPw(e.target.value)}
-            required
-            minLength={8}
-            className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none"
-            style={inputStyle}
-            onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent-soft)'; }}
-            onBlur={e => { e.currentTarget.style.boxShadow = 'none'; }}
-          />
-        </div>
-        <div>
-          <label htmlFor="confirm-password" className="block text-xs mb-1" style={labelStyle}>Confirm New Password</label>
-          <input
-            id="confirm-password"
-            type="password"
-            value={confirmPw}
-            onChange={e => setConfirmPw(e.target.value)}
-            required
-            className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none"
-            style={inputStyle}
-            onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent-soft)'; }}
-            onBlur={e => { e.currentTarget.style.boxShadow = 'none'; }}
-          />
-        </div>
-        {pwError && <div className="text-xs" style={{ color: 'var(--accent-danger)' }}>{pwError}</div>}
-        {pwSuccess && <div className="text-xs" style={{ color: 'var(--accent-good)' }}>Password changed successfully!</div>}
-        <div className="flex pt-1">
-          <button
-            type="submit"
-            disabled={pwLoading}
-            className="rounded-md text-sm font-medium transition-colors disabled:opacity-50"
-            style={{ ...submitStyle, padding: '8px 16px' }}
-          >
-            {pwLoading ? 'Changing...' : 'Change Password'}
-          </button>
-        </div>
-      </form>
+    <div style={{ color: 'var(--fg-1)', maxWidth: 420 }}>
+      <Section title="password">
+        <div style={helpText}>Update your account password.</div>
+        <form onSubmit={handlePasswordChange}>
+          <Field label="current password">
+            <input
+              id="current-password"
+              type="password"
+              value={currentPw}
+              onChange={(e) => setCurrentPw(e.target.value)}
+              required
+              style={kitInputStyle}
+              onFocus={focusRing}
+              onBlur={blurRing}
+            />
+          </Field>
+          <Field label="new password">
+            <input
+              id="new-password"
+              type="password"
+              value={newPw}
+              onChange={(e) => setNewPw(e.target.value)}
+              required
+              minLength={8}
+              style={kitInputStyle}
+              onFocus={focusRing}
+              onBlur={blurRing}
+            />
+          </Field>
+          <Field label="confirm new password">
+            <input
+              id="confirm-password"
+              type="password"
+              value={confirmPw}
+              onChange={(e) => setConfirmPw(e.target.value)}
+              required
+              style={kitInputStyle}
+              onFocus={focusRing}
+              onBlur={blurRing}
+            />
+          </Field>
+          {pwError && (
+            <div style={{ ...helpText, color: 'var(--accent-danger)', marginBottom: 8 }}>
+              {pwError}
+            </div>
+          )}
+          {pwSuccess && (
+            <div style={{ ...helpText, color: 'var(--accent-good)', marginBottom: 8 }}>
+              Password changed successfully.
+            </div>
+          )}
+          <Toolbar>
+            <button
+              type="submit"
+              disabled={pwLoading}
+              style={{ ...primaryBtn, opacity: pwLoading ? 0.6 : 1, cursor: pwLoading ? 'not-allowed' : 'pointer' }}
+            >
+              {pwLoading ? 'Changing…' : 'Change Password'}
+            </button>
+          </Toolbar>
+        </form>
+      </Section>
     </div>
   );
 }

--- a/packages/client/src/pages/AccountSettingsPage.tsx
+++ b/packages/client/src/pages/AccountSettingsPage.tsx
@@ -1,5 +1,21 @@
-import { useState, useCallback, FormEvent } from 'react';
+import { useState, useCallback, FormEvent, CSSProperties } from 'react';
 import { Settings, User, Fingerprint, Key, Shield, X, Palette } from 'lucide-react';
+
+const inputStyle: CSSProperties = {
+  background: 'var(--bg-2)',
+  borderColor: 'var(--line)',
+  color: 'var(--fg)',
+};
+const dialogStyle: CSSProperties = { background: 'var(--bg-1)' };
+const borderLine: CSSProperties = { borderColor: 'var(--line)' };
+const labelStyle: CSSProperties = { color: 'var(--fg-3)' };
+const headingStyle: CSSProperties = { color: 'var(--fg)' };
+const mutedStyle: CSSProperties = { color: 'var(--fg-3)' };
+const submitStyle: CSSProperties = {
+  background: 'var(--accent)',
+  color: 'var(--accent-fg)',
+};
+const ghostHoverBase: CSSProperties = { color: 'var(--fg-3)' };
 import { authApi } from '../lib/api';
 import { PasskeyManagerContent } from '../components/Security/PasskeyManager';
 import { ApiKeyManager } from '../components/ApiKeys/ApiKeyManager';
@@ -48,23 +64,26 @@ function ProfileSection() {
   return (
     <div className="max-w-sm space-y-4">
       <div>
-        <h3 className="text-sm font-medium text-gray-200 mb-1">Change Password</h3>
-        <p className="text-xs text-gray-500">Update your account password.</p>
+        <h3 className="text-sm font-medium mb-1" style={headingStyle}>Change Password</h3>
+        <p className="text-xs" style={mutedStyle}>Update your account password.</p>
       </div>
       <form onSubmit={handlePasswordChange} className="space-y-3">
         <div>
-          <label htmlFor="current-password" className="block text-xs text-gray-400 mb-1">Current Password</label>
+          <label htmlFor="current-password" className="block text-xs mb-1" style={labelStyle}>Current Password</label>
           <input
             id="current-password"
             type="password"
             value={currentPw}
             onChange={e => setCurrentPw(e.target.value)}
             required
-            className="w-full bg-surface-800 border border-gray-700/50 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500/50"
+            className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none"
+            style={inputStyle}
+            onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent-soft)'; }}
+            onBlur={e => { e.currentTarget.style.boxShadow = 'none'; }}
           />
         </div>
         <div>
-          <label htmlFor="new-password" className="block text-xs text-gray-400 mb-1">New Password</label>
+          <label htmlFor="new-password" className="block text-xs mb-1" style={labelStyle}>New Password</label>
           <input
             id="new-password"
             type="password"
@@ -72,18 +91,24 @@ function ProfileSection() {
             onChange={e => setNewPw(e.target.value)}
             required
             minLength={8}
-            className="w-full bg-surface-800 border border-gray-700/50 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500/50"
+            className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none"
+            style={inputStyle}
+            onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent-soft)'; }}
+            onBlur={e => { e.currentTarget.style.boxShadow = 'none'; }}
           />
         </div>
         <div>
-          <label htmlFor="confirm-password" className="block text-xs text-gray-400 mb-1">Confirm New Password</label>
+          <label htmlFor="confirm-password" className="block text-xs mb-1" style={labelStyle}>Confirm New Password</label>
           <input
             id="confirm-password"
             type="password"
             value={confirmPw}
             onChange={e => setConfirmPw(e.target.value)}
             required
-            className="w-full bg-surface-800 border border-gray-700/50 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500/50"
+            className="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none"
+            style={inputStyle}
+            onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent-soft)'; }}
+            onBlur={e => { e.currentTarget.style.boxShadow = 'none'; }}
           />
         </div>
         {pwError && <div className="text-red-400 text-xs">{pwError}</div>}
@@ -92,7 +117,8 @@ function ProfileSection() {
           <button
             type="submit"
             disabled={pwLoading}
-            className="flex-1 bg-violet-500 text-white rounded-lg py-2 text-sm font-medium hover:bg-violet-600 transition-colors disabled:opacity-50"
+            className="flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-50"
+            style={submitStyle}
           >
             {pwLoading ? 'Changing...' : 'Change Password'}
           </button>
@@ -114,34 +140,37 @@ export default function AccountSettingsPage({ onClose }: { onClose: () => void }
         role="dialog"
         aria-modal="true"
         aria-labelledby="account-settings-title"
-        className="bg-surface-900 rounded-xl shadow-2xl w-[90vw] max-w-2xl max-h-[85vh] overflow-hidden flex flex-col"
+        className="rounded-xl shadow-2xl w-[90vw] max-w-2xl max-h-[85vh] overflow-hidden flex flex-col"
+        style={dialogStyle}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-700/50">
+        <div className="flex items-center justify-between px-6 py-4 border-b" style={borderLine}>
           <div className="flex items-center gap-2">
-            <Settings size={18} className="text-violet-400" />
+            <Settings size={18} style={{ color: 'var(--accent)' }} />
             <h2 id="account-settings-title" className="text-lg font-semibold text-white">Account Settings</h2>
           </div>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg text-gray-400 hover:text-white hover:bg-gray-700/50 transition-colors"
+            className="p-1.5 rounded-lg transition-colors"
+            style={ghostHoverBase}
+            onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--fg)'; }}
+            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--fg-3)'; }}
           >
             <X size={18} />
           </button>
         </div>
 
         {/* Tabs */}
-        <div className="flex border-b border-gray-700/50 px-6">
+        <div className="flex border-b px-6" style={borderLine}>
           {TABS.map(t => (
             <button
               key={t.key}
               onClick={() => setTab(t.key)}
-              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-                tab === t.key
-                  ? 'border-violet-500 text-violet-400'
-                  : 'border-transparent text-gray-400 hover:text-gray-200'
-              }`}
+              className="flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors"
+              style={tab === t.key
+                ? { borderColor: 'var(--accent)', color: 'var(--accent)' }
+                : { borderColor: 'transparent', color: 'var(--fg-3)' }}
             >
               <t.icon size={16} />
               {t.label}

--- a/packages/client/src/pages/AccountSettingsPage.tsx
+++ b/packages/client/src/pages/AccountSettingsPage.tsx
@@ -9,14 +9,12 @@ import { PasskeyManagerContent } from '../components/Security/PasskeyManager';
 import { ApiKeyManager } from '../components/ApiKeys/ApiKeyManager';
 import { TwoFactorManager } from '../components/Security/TwoFactorManager';
 import { AppearanceSection } from '../components/Settings/AppearanceSection';
+import { Section, Field, Toolbar } from '../components/Settings/settings-kit';
 import {
-  Section,
-  Field,
-  Toolbar,
   inputStyle as kitInputStyle,
   primaryBtn,
   helpText,
-} from '../components/Settings/settings-kit';
+} from '../components/Settings/settings-kit-styles';
 
 type Tab = 'profile' | 'appearance' | 'passkeys' | 'api-keys' | '2fa';
 

--- a/packages/client/src/pages/AccountSettingsPage.tsx
+++ b/packages/client/src/pages/AccountSettingsPage.tsx
@@ -111,8 +111,8 @@ function ProfileSection() {
             onBlur={e => { e.currentTarget.style.boxShadow = 'none'; }}
           />
         </div>
-        {pwError && <div className="text-red-400 text-xs">{pwError}</div>}
-        {pwSuccess && <div className="text-green-400 text-xs">Password changed successfully!</div>}
+        {pwError && <div className="text-xs" style={{ color: 'var(--accent-danger)' }}>{pwError}</div>}
+        {pwSuccess && <div className="text-xs" style={{ color: 'var(--accent-good)' }}>Password changed successfully!</div>}
         <div className="flex gap-2 pt-1">
           <button
             type="submit"
@@ -133,7 +133,8 @@ export default function AccountSettingsPage({ onClose }: { onClose: () => void }
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center"
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'oklch(0 0 0 / 0.6)' }}
       onClick={onClose}
     >
       <div
@@ -148,7 +149,7 @@ export default function AccountSettingsPage({ onClose }: { onClose: () => void }
         <div className="flex items-center justify-between px-6 py-4 border-b" style={borderLine}>
           <div className="flex items-center gap-2">
             <Settings size={18} style={{ color: 'var(--accent)' }} />
-            <h2 id="account-settings-title" className="text-lg font-semibold text-white">Account Settings</h2>
+            <h2 id="account-settings-title" className="text-lg font-semibold" style={{ color: 'var(--fg)' }}>Account Settings</h2>
           </div>
           <button
             onClick={onClose}

--- a/packages/client/src/pages/AccountSettingsPage.tsx
+++ b/packages/client/src/pages/AccountSettingsPage.tsx
@@ -141,8 +141,11 @@ export default function AccountSettingsPage({ onClose }: { onClose: () => void }
         role="dialog"
         aria-modal="true"
         aria-labelledby="account-settings-title"
-        className="rounded-xl shadow-2xl w-[90vw] max-w-2xl max-h-[85vh] overflow-hidden flex flex-col"
-        style={dialogStyle}
+        className="rounded-xl shadow-2xl w-[90vw] max-w-2xl overflow-hidden flex flex-col"
+        // Fixed height (not max-height) so the header + tab strip stay
+        // anchored as the user switches between sections. The content
+        // panel scrolls within its own pane.
+        style={{ ...dialogStyle, height: 'min(640px, 85vh)' }}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}

--- a/packages/client/src/pages/AccountSettingsPage.tsx
+++ b/packages/client/src/pages/AccountSettingsPage.tsx
@@ -113,12 +113,12 @@ function ProfileSection() {
         </div>
         {pwError && <div className="text-xs" style={{ color: 'var(--accent-danger)' }}>{pwError}</div>}
         {pwSuccess && <div className="text-xs" style={{ color: 'var(--accent-good)' }}>Password changed successfully!</div>}
-        <div className="flex gap-2 pt-1">
+        <div className="flex pt-1">
           <button
             type="submit"
             disabled={pwLoading}
-            className="flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:opacity-50"
-            style={submitStyle}
+            className="rounded-md text-sm font-medium transition-colors disabled:opacity-50"
+            style={{ ...submitStyle, padding: '8px 16px' }}
           >
             {pwLoading ? 'Changing...' : 'Change Password'}
           </button>
@@ -162,19 +162,39 @@ export default function AccountSettingsPage({ onClose }: { onClose: () => void }
           </button>
         </div>
 
-        {/* Tabs — wider per-tab padding + explicit container gap so the
-            next tab's icon doesn't run into the previous tab's label. */}
-        <div className="flex border-b px-6 gap-4" style={borderLine}>
+        {/* Tabs — mode-pill pattern from prototype/app/graph.jsx: active tab
+            sits in an accent-soft tinted pill (no underline). Inactive tabs
+            are fg-3 with transparent bg. Container has its own subtle gap
+            and a single border-b for visual separation. */}
+        <div
+          className="flex items-center px-4 py-2 border-b"
+          style={{ ...borderLine, gap: 2 }}
+        >
           {TABS.map(t => (
             <button
               key={t.key}
               onClick={() => setTab(t.key)}
-              className="flex items-center gap-2 px-2 py-3 text-sm font-medium border-b-2 transition-colors"
-              style={tab === t.key
-                ? { borderColor: 'var(--accent)', color: 'var(--accent)' }
-                : { borderColor: 'transparent', color: 'var(--fg-3)' }}
+              className="flex items-center gap-1.5 text-sm font-medium transition-colors"
+              style={{
+                padding: '6px 10px',
+                borderRadius: 6,
+                background: tab === t.key ? 'var(--accent-soft)' : 'transparent',
+                color: tab === t.key ? 'var(--accent)' : 'var(--fg-3)',
+              }}
+              onMouseEnter={(e) => {
+                if (tab !== t.key) {
+                  e.currentTarget.style.background = 'var(--bg-hover)';
+                  e.currentTarget.style.color = 'var(--fg)';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (tab !== t.key) {
+                  e.currentTarget.style.background = 'transparent';
+                  e.currentTarget.style.color = 'var(--fg-3)';
+                }
+              }}
             >
-              <t.icon size={16} />
+              <t.icon size={14} />
               {t.label}
             </button>
           ))}

--- a/packages/client/src/pages/AccountSettingsPage.tsx
+++ b/packages/client/src/pages/AccountSettingsPage.tsx
@@ -13,7 +13,7 @@ const headingStyle: CSSProperties = { color: 'var(--fg)' };
 const mutedStyle: CSSProperties = { color: 'var(--fg-3)' };
 const submitStyle: CSSProperties = {
   background: 'var(--accent)',
-  color: 'var(--accent-fg)',
+  color: '#fff',
 };
 const ghostHoverBase: CSSProperties = { color: 'var(--fg-3)' };
 import { authApi } from '../lib/api';
@@ -162,13 +162,14 @@ export default function AccountSettingsPage({ onClose }: { onClose: () => void }
           </button>
         </div>
 
-        {/* Tabs */}
-        <div className="flex border-b px-6" style={borderLine}>
+        {/* Tabs — wider per-tab padding + explicit container gap so the
+            next tab's icon doesn't run into the previous tab's label. */}
+        <div className="flex border-b px-6 gap-4" style={borderLine}>
           {TABS.map(t => (
             <button
               key={t.key}
               onClick={() => setTab(t.key)}
-              className="flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors"
+              className="flex items-center gap-2 px-2 py-3 text-sm font-medium border-b-2 transition-colors"
               style={tab === t.key
                 ? { borderColor: 'var(--accent)', color: 'var(--accent)' }
                 : { borderColor: 'transparent', color: 'var(--fg-3)' }}

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -1,4 +1,17 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, CSSProperties } from 'react';
+
+const dialogStyle: CSSProperties = { background: 'var(--bg-1)' };
+const borderLine: CSSProperties = { borderColor: 'var(--line)' };
+const headingStyle: CSSProperties = { color: 'var(--fg)' };
+const mutedStyle: CSSProperties = { color: 'var(--fg-3)' };
+const cardStyle: CSSProperties = { background: 'var(--bg-2)', borderColor: 'var(--line)' };
+const inputSmallStyle: CSSProperties = {
+  background: 'var(--bg-2)',
+  borderColor: 'var(--line)',
+  color: 'var(--fg)',
+};
+const ghostBtnStyle: CSSProperties = { color: 'var(--fg-3)' };
+const accentBtnStyle: CSSProperties = { background: 'var(--accent)', color: 'var(--accent-fg)' };
 import { useAuth } from '../hooks/useAuth';
 import { request } from '../lib/api';
 import { X, Users, Ticket, Settings, Trash2, ShieldCheck, ShieldOff, UserX, UserCheck, Plus, Copy, Check, Key, Package } from 'lucide-react';
@@ -37,22 +50,26 @@ export default function AdminPage({ onClose }: { onClose: () => void }) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="admin-panel-title"
-        className="bg-surface-900 rounded-xl shadow-2xl w-[90vw] max-w-4xl max-h-[85vh] overflow-hidden flex flex-col"
+        className="rounded-xl shadow-2xl w-[90vw] max-w-4xl max-h-[85vh] overflow-hidden flex flex-col"
+        style={dialogStyle}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-700/50">
-          <h2 id="admin-panel-title" className="text-lg font-semibold text-white">Admin Panel</h2>
+        <div className="flex items-center justify-between px-6 py-4 border-b" style={borderLine}>
+          <h2 id="admin-panel-title" className="text-lg font-semibold" style={headingStyle}>Admin Panel</h2>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg text-gray-400 hover:text-white hover:bg-gray-700/50 transition-colors"
+            className="p-1.5 rounded-lg transition-colors"
+            style={ghostBtnStyle}
+            onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--fg)'; }}
+            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--fg-3)'; }}
           >
             <X size={18} />
           </button>
         </div>
 
         {/* Tabs */}
-        <div className="flex border-b border-gray-700/50 px-6">
+        <div className="flex border-b px-6" style={borderLine}>
           {([
             { key: 'users' as Tab, label: 'Users', icon: Users },
             { key: 'invites' as Tab, label: 'Invite Codes', icon: Ticket },
@@ -62,11 +79,10 @@ export default function AdminPage({ onClose }: { onClose: () => void }) {
             <button
               key={t.key}
               onClick={() => setTab(t.key)}
-              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-                tab === t.key
-                  ? 'border-violet-500 text-violet-400'
-                  : 'border-transparent text-gray-400 hover:text-gray-200'
-              }`}
+              className="flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors"
+              style={tab === t.key
+                ? { borderColor: 'var(--accent)', color: 'var(--accent)' }
+                : { borderColor: 'transparent', color: 'var(--fg-3)' }}
             >
               <t.icon size={16} />
               {t.label}
@@ -147,7 +163,7 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
   };
 
   if (loading) {
-    return <div className="text-gray-400 text-sm">Loading users...</div>;
+    return <div className="text-sm" style={mutedStyle}>Loading users...</div>;
   }
 
   return (
@@ -160,7 +176,7 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-left text-gray-400 border-b border-gray-700/50">
+            <tr className="text-left border-b" style={{ ...mutedStyle, ...borderLine }}>
               <th className="pb-3 font-medium">Name</th>
               <th className="pb-3 font-medium">Email</th>
               <th className="pb-3 font-medium">Role</th>
@@ -173,15 +189,16 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
             {users.map(u => {
               const isSelf = u.id === currentUserId;
               return (
-                <tr key={u.id} className="border-b border-gray-700/30">
-                  <td className="py-3 text-white">{u.name || '-'}</td>
-                  <td className="py-3 text-gray-300">{u.email}</td>
+                <tr key={u.id} className="border-b" style={borderLine}>
+                  <td className="py-3" style={headingStyle}>{u.name || '-'}</td>
+                  <td className="py-3" style={{ color: 'var(--fg)' }}>{u.email}</td>
                   <td className="py-3">
-                    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
-                      u.role === 'admin'
-                        ? 'bg-violet-500/20 text-violet-300'
-                        : 'bg-gray-700/50 text-gray-300'
-                    }`}>
+                    <span
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                      style={u.role === 'admin'
+                        ? { background: 'var(--accent-soft)', color: 'var(--accent)' }
+                        : { background: 'var(--bg-2)', color: 'var(--fg)' }}
+                    >
                       {u.role === 'admin' ? <ShieldCheck size={12} /> : null}
                       {u.role}
                     </span>
@@ -195,12 +212,12 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                       {u.disabled ? 'Disabled' : 'Active'}
                     </span>
                   </td>
-                  <td className="py-3 text-gray-400">
+                  <td className="py-3" style={mutedStyle}>
                     {new Date(u.createdAt).toLocaleDateString()}
                   </td>
                   <td className="py-3 text-right">
                     {isSelf ? (
-                      <span className="text-xs text-gray-500">(you)</span>
+                      <span className="text-xs" style={mutedStyle}>(you)</span>
                     ) : (
                       <div className="flex items-center justify-end gap-1">
                         <button
@@ -216,7 +233,8 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                         </button>
                         <button
                           onClick={() => toggleRole(u)}
-                          className="p-1.5 rounded-lg text-violet-400 hover:bg-violet-500/10 transition-colors"
+                          className="p-1.5 rounded-lg transition-colors"
+                          style={{ color: 'var(--accent)' }}
                           title={u.role === 'admin' ? 'Demote to user' : 'Promote to admin'}
                         >
                           {u.role === 'admin' ? <ShieldOff size={15} /> : <ShieldCheck size={15} />}
@@ -231,7 +249,8 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                             </button>
                             <button
                               onClick={() => setConfirmDelete(null)}
-                              className="px-2 py-1 rounded text-xs text-gray-400 hover:text-white transition-colors"
+                              className="px-2 py-1 rounded text-xs transition-colors"
+                              style={mutedStyle}
                             >
                               Cancel
                             </button>
@@ -248,9 +267,10 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                               }} className="flex items-center gap-1">
                                 <input type="password" value={resetPwValue} onChange={e => setResetPwValue(e.target.value)}
                                   placeholder="New password" minLength={8} required
-                                  className="w-24 bg-surface-800 border border-gray-700/50 rounded px-1.5 py-0.5 text-xs text-gray-100" />
+                                  className="w-24 border rounded px-1.5 py-0.5 text-xs"
+                                  style={inputSmallStyle} />
                                 <button type="submit" className="text-xs text-green-400 hover:text-green-300">Set</button>
-                                <button type="button" onClick={() => setResetPwUser(null)} className="text-xs text-gray-400">✕</button>
+                                <button type="button" onClick={() => setResetPwUser(null)} className="text-xs" style={mutedStyle}>✕</button>
                               </form>
                             ) : (
                               <button
@@ -280,7 +300,7 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
         </table>
       </div>
       {users.length === 0 && !loading && (
-        <div className="text-center text-gray-500 py-8 text-sm">No users found.</div>
+        <div className="text-center py-8 text-sm" style={mutedStyle}>No users found.</div>
       )}
     </div>
   );
@@ -341,8 +361,8 @@ function InvitesSection() {
     });
   };
 
-  const getStatus = (invite: InviteCode): { label: string; className: string } => {
-    if (invite.usedBy) return { label: 'Used', className: 'bg-gray-700/50 text-gray-400' };
+  const getStatus = (invite: InviteCode): { label: string; className: string; style?: CSSProperties } => {
+    if (invite.usedBy) return { label: 'Used', className: '', style: { background: 'var(--bg-2)', color: 'var(--fg-3)' } };
     if (invite.expiresAt && new Date(invite.expiresAt) < new Date()) {
       return { label: 'Expired', className: 'bg-red-500/20 text-red-300' };
     }
@@ -350,7 +370,7 @@ function InvitesSection() {
   };
 
   if (loading) {
-    return <div className="text-gray-400 text-sm">Loading invite codes...</div>;
+    return <div className="text-sm" style={mutedStyle}>Loading invite codes...</div>;
   }
 
   return (
@@ -364,7 +384,8 @@ function InvitesSection() {
         <button
           onClick={createInvite}
           disabled={creating}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-violet-600 text-white text-sm font-medium hover:bg-violet-500 disabled:opacity-50 transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50 transition-colors"
+          style={accentBtnStyle}
         >
           <Plus size={16} />
           {creating ? 'Creating...' : 'Create Invite'}
@@ -376,23 +397,25 @@ function InvitesSection() {
           return (
             <div
               key={invite.id}
-              className="flex items-center justify-between px-4 py-3 rounded-lg bg-surface-800 border border-gray-700/30"
+              className="flex items-center justify-between px-4 py-3 rounded-lg border"
+              style={cardStyle}
             >
               <div className="flex items-center gap-4">
-                <code className="text-sm font-mono text-white bg-gray-700/50 px-2.5 py-1 rounded">
+                <code className="text-sm font-mono px-2.5 py-1 rounded" style={{ color: 'var(--fg)', background: 'var(--bg-2)' }}>
                   {invite.code}
                 </code>
                 <button
                   onClick={() => copyCode(invite)}
-                  className="p-1 text-gray-400 hover:text-white transition-colors"
+                  className="p-1 transition-colors"
+                  style={ghostBtnStyle}
                   title="Copy code"
                 >
                   {copiedId === invite.id ? <Check size={14} className="text-green-400" /> : <Copy size={14} />}
                 </button>
-                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${status.className}`}>
+                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${status.className}`} style={status.style}>
                   {status.label}
                 </span>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs" style={mutedStyle}>
                   Created {new Date(invite.createdAt).toLocaleDateString()}
                 </span>
               </div>
@@ -408,7 +431,7 @@ function InvitesSection() {
         })}
       </div>
       {invites.length === 0 && !loading && (
-        <div className="text-center text-gray-500 py-8 text-sm">No invite codes yet.</div>
+        <div className="text-center py-8 text-sm" style={mutedStyle}>No invite codes yet.</div>
       )}
     </div>
   );
@@ -451,7 +474,7 @@ function SettingsSection() {
   };
 
   if (loading) {
-    return <div className="text-gray-400 text-sm">Loading settings...</div>;
+    return <div className="text-sm" style={mutedStyle}>Loading settings...</div>;
   }
 
   return (
@@ -461,20 +484,19 @@ function SettingsSection() {
           {error}
         </div>
       )}
-      <div className="bg-surface-800 rounded-lg border border-gray-700/30 p-6">
-        <h3 className="text-white font-medium mb-1">Registration Mode</h3>
-        <p className="text-sm text-gray-400 mb-4">
+      <div className="rounded-lg border p-6" style={cardStyle}>
+        <h3 className="font-medium mb-1" style={headingStyle}>Registration Mode</h3>
+        <p className="text-sm mb-4" style={mutedStyle}>
           Control how new users can sign up for the application.
         </p>
         <div className="flex gap-3">
           <button
             onClick={() => updateMode('open')}
             disabled={saving}
-            className={`flex-1 px-4 py-3 rounded-lg border text-sm font-medium transition-colors ${
-              mode === 'open'
-                ? 'border-violet-500 bg-violet-500/10 text-violet-300'
-                : 'border-gray-700/50 text-gray-400 hover:border-gray-600 hover:text-gray-300'
-            } disabled:opacity-50`}
+            className="flex-1 px-4 py-3 rounded-lg border text-sm font-medium transition-colors disabled:opacity-50"
+            style={mode === 'open'
+              ? { borderColor: 'var(--accent)', background: 'var(--accent-soft)', color: 'var(--accent)' }
+              : { borderColor: 'var(--line)', color: 'var(--fg-3)' }}
           >
             <div className="font-medium mb-0.5">Open Registration</div>
             <div className="text-xs opacity-70">Anyone can create an account</div>
@@ -482,17 +504,16 @@ function SettingsSection() {
           <button
             onClick={() => updateMode('invite-only')}
             disabled={saving}
-            className={`flex-1 px-4 py-3 rounded-lg border text-sm font-medium transition-colors ${
-              mode === 'invite-only'
-                ? 'border-violet-500 bg-violet-500/10 text-violet-300'
-                : 'border-gray-700/50 text-gray-400 hover:border-gray-600 hover:text-gray-300'
-            } disabled:opacity-50`}
+            className="flex-1 px-4 py-3 rounded-lg border text-sm font-medium transition-colors disabled:opacity-50"
+            style={mode === 'invite-only'
+              ? { borderColor: 'var(--accent)', background: 'var(--accent-soft)', color: 'var(--accent)' }
+              : { borderColor: 'var(--line)', color: 'var(--fg-3)' }}
           >
             <div className="font-medium mb-0.5">Invite Only</div>
             <div className="text-xs opacity-70">Requires a valid invite code</div>
           </button>
         </div>
-        {saving && <p className="text-xs text-gray-500 mt-3">Saving...</p>}
+        {saving && <p className="text-xs mt-3" style={mutedStyle}>Saving...</p>}
       </div>
     </div>
   );

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -43,7 +43,8 @@ export default function AdminPage({ onClose }: { onClose: () => void }) {
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center"
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'oklch(0 0 0 / 0.6)' }}
       onClick={onClose}
     >
       <div
@@ -169,7 +170,10 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
   return (
     <div>
       {error && (
-        <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">
+        <div
+          className="mb-4 px-3 py-2 border rounded-lg text-sm"
+          style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
+        >
           {error}
         </div>
       )}
@@ -204,11 +208,12 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                     </span>
                   </td>
                   <td className="py-3">
-                    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
-                      u.disabled
-                        ? 'bg-red-500/20 text-red-300'
-                        : 'bg-green-500/20 text-green-300'
-                    }`}>
+                    <span
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                      style={u.disabled
+                        ? { background: 'color-mix(in oklch, var(--accent-danger) 20%, transparent)', color: 'var(--accent-danger)' }
+                        : { background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' }}
+                    >
                       {u.disabled ? 'Disabled' : 'Active'}
                     </span>
                   </td>
@@ -222,11 +227,12 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                       <div className="flex items-center justify-end gap-1">
                         <button
                           onClick={() => toggleDisabled(u)}
-                          className={`p-1.5 rounded-lg transition-colors ${
-                            u.disabled
-                              ? 'text-green-400 hover:bg-green-500/10'
-                              : 'text-yellow-400 hover:bg-yellow-500/10'
-                          }`}
+                          className="p-1.5 rounded-lg transition-colors"
+                          style={{ color: u.disabled ? 'var(--accent-good)' : 'var(--accent-warn)' }}
+                          onMouseEnter={e => { e.currentTarget.style.background = u.disabled
+                            ? 'color-mix(in oklch, var(--accent-good) 10%, transparent)'
+                            : 'color-mix(in oklch, var(--accent-warn) 10%, transparent)'; }}
+                          onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                           title={u.disabled ? 'Enable user' : 'Disable user'}
                         >
                           {u.disabled ? <UserCheck size={15} /> : <UserX size={15} />}
@@ -243,7 +249,8 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                           <div className="flex items-center gap-1">
                             <button
                               onClick={() => deleteUser(u.id)}
-                              className="px-2 py-1 rounded text-xs bg-red-500 text-white hover:bg-red-600 transition-colors"
+                              className="px-2 py-1 rounded text-xs transition-colors"
+                              style={{ background: 'var(--accent-danger)', color: 'var(--fg)' }}
                             >
                               Confirm
                             </button>
@@ -269,13 +276,16 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                                   placeholder="New password" minLength={8} required
                                   className="w-24 border rounded px-1.5 py-0.5 text-xs"
                                   style={inputSmallStyle} />
-                                <button type="submit" className="text-xs text-green-400 hover:text-green-300">Set</button>
+                                <button type="submit" className="text-xs" style={{ color: 'var(--accent-good)' }}>Set</button>
                                 <button type="button" onClick={() => setResetPwUser(null)} className="text-xs" style={mutedStyle}>✕</button>
                               </form>
                             ) : (
                               <button
                                 onClick={() => { setResetPwUser(u.id); setResetPwValue(''); }}
-                                className="p-1.5 rounded-lg text-yellow-400 hover:bg-yellow-500/10 transition-colors"
+                                className="p-1.5 rounded-lg transition-colors"
+                                style={{ color: 'var(--accent-warn)' }}
+                                onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-warn) 10%, transparent)'; }}
+                                onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                                 title="Reset password"
                               >
                                 <Key size={15} />
@@ -283,7 +293,10 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
                             )}
                             <button
                               onClick={() => setConfirmDelete(u.id)}
-                              className="p-1.5 rounded-lg text-red-400 hover:bg-red-500/10 transition-colors"
+                              className="p-1.5 rounded-lg transition-colors"
+                              style={{ color: 'var(--accent-danger)' }}
+                              onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-danger) 10%, transparent)'; }}
+                              onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                               title="Delete user"
                             >
                               <Trash2 size={15} />
@@ -361,12 +374,12 @@ function InvitesSection() {
     });
   };
 
-  const getStatus = (invite: InviteCode): { label: string; className: string; style?: CSSProperties } => {
-    if (invite.usedBy) return { label: 'Used', className: '', style: { background: 'var(--bg-2)', color: 'var(--fg-3)' } };
+  const getStatus = (invite: InviteCode): { label: string; style: CSSProperties } => {
+    if (invite.usedBy) return { label: 'Used', style: { background: 'var(--bg-2)', color: 'var(--fg-3)' } };
     if (invite.expiresAt && new Date(invite.expiresAt) < new Date()) {
-      return { label: 'Expired', className: 'bg-red-500/20 text-red-300' };
+      return { label: 'Expired', style: { background: 'color-mix(in oklch, var(--accent-danger) 20%, transparent)', color: 'var(--accent-danger)' } };
     }
-    return { label: 'Unused', className: 'bg-green-500/20 text-green-300' };
+    return { label: 'Unused', style: { background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' } };
   };
 
   if (loading) {
@@ -376,7 +389,10 @@ function InvitesSection() {
   return (
     <div>
       {error && (
-        <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">
+        <div
+          className="mb-4 px-3 py-2 border rounded-lg text-sm"
+          style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
+        >
           {error}
         </div>
       )}
@@ -410,9 +426,9 @@ function InvitesSection() {
                   style={ghostBtnStyle}
                   title="Copy code"
                 >
-                  {copiedId === invite.id ? <Check size={14} className="text-green-400" /> : <Copy size={14} />}
+                  {copiedId === invite.id ? <Check size={14} style={{ color: 'var(--accent-good)' }} /> : <Copy size={14} />}
                 </button>
-                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${status.className}`} style={status.style}>
+                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" style={status.style}>
                   {status.label}
                 </span>
                 <span className="text-xs" style={mutedStyle}>
@@ -421,7 +437,10 @@ function InvitesSection() {
               </div>
               <button
                 onClick={() => deleteInvite(invite.id)}
-                className="p-1.5 rounded-lg text-red-400 hover:bg-red-500/10 transition-colors"
+                className="p-1.5 rounded-lg transition-colors"
+                style={{ color: 'var(--accent-danger)' }}
+                onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-danger) 10%, transparent)'; }}
+                onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                 title="Delete invite"
               >
                 <Trash2 size={15} />
@@ -480,7 +499,10 @@ function SettingsSection() {
   return (
     <div>
       {error && (
-        <div className="mb-4 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm">
+        <div
+          className="mb-4 px-3 py-2 border rounded-lg text-sm"
+          style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
+        >
           {error}
         </div>
       )}

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -11,7 +11,7 @@ const inputSmallStyle: CSSProperties = {
   color: 'var(--fg)',
 };
 const ghostBtnStyle: CSSProperties = { color: 'var(--fg-3)' };
-const accentBtnStyle: CSSProperties = { background: 'var(--accent)', color: 'var(--accent-fg)' };
+const accentBtnStyle: CSSProperties = { background: 'var(--accent)', color: '#fff' };
 import { useAuth } from '../hooks/useAuth';
 import { request } from '../lib/api';
 import { X, Users, Ticket, Settings, Trash2, ShieldCheck, ShieldOff, UserX, UserCheck, Plus, Copy, Check, Key, Package } from 'lucide-react';

--- a/packages/client/src/pages/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage.tsx
@@ -65,7 +65,7 @@ const primaryBtnStyle: CSSProperties = {
   padding: '10px 16px',
   borderRadius: 6,
   background: 'var(--accent)',
-  color: 'var(--accent-fg)',
+  color: '#fff',
   fontFamily: monoFamily,
   fontSize: 12.5,
   fontWeight: 600,

--- a/packages/client/src/pages/PluginsTab.tsx
+++ b/packages/client/src/pages/PluginsTab.tsx
@@ -227,9 +227,12 @@ function RegistryBrowse({
 
   if (error) {
     return (
-      <div className="px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm flex items-center justify-between">
+      <div
+        className="px-4 py-3 border rounded-lg text-sm flex items-center justify-between"
+        style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
+      >
         <span>{error}</span>
-        <button onClick={fetchRegistry} className="ml-3 text-red-300 hover:text-red-200 underline text-xs">
+        <button onClick={fetchRegistry} className="ml-3 underline text-xs" style={{ color: 'var(--accent-danger)' }}>
           Retry
         </button>
       </div>
@@ -391,13 +394,19 @@ function PluginCard({
             <span className="text-xs" style={{ color: 'var(--fg-4)' }}>v{plugin.version}</span>
             <span className="text-xs" style={{ color: 'var(--fg-4)' }}>by {plugin.author}</span>
             {isInstalled && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-500/20 text-green-300">
+              <span
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                style={{ background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' }}
+              >
                 <CheckCircle size={10} />
                 Installed
               </span>
             )}
             {incompatible && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/20 text-amber-300">
+              <span
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                style={{ background: 'color-mix(in oklch, var(--accent-warn) 20%, transparent)', color: 'var(--accent-warn)' }}
+              >
                 <AlertCircle size={10} />
                 Requires v{plugin.minKrytonVersion}
               </span>
@@ -418,7 +427,7 @@ function PluginCard({
             </div>
           )}
           {err && (
-            <p className="text-xs text-red-400 mt-1">{err}</p>
+            <p className="text-xs mt-1" style={{ color: 'var(--accent-danger)' }}>{err}</p>
           )}
         </div>
       </div>
@@ -532,9 +541,12 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
 
   if (error) {
     return (
-      <div className="px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm flex items-center justify-between">
+      <div
+        className="px-4 py-3 border rounded-lg text-sm flex items-center justify-between"
+        style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
+      >
         <span>{error}</span>
-        <button onClick={fetchAll} className="ml-3 text-red-300 hover:text-red-200 underline text-xs">
+        <button onClick={fetchAll} className="ml-3 underline text-xs" style={{ color: 'var(--accent-danger)' }}>
           Retry
         </button>
       </div>
@@ -586,7 +598,10 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                       <span className="text-xs" style={{ color: 'var(--fg-4)' }}>by {plugin.author}</span>
                       <StateLabel state={plugin.state} />
                       {update && (
-                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/20 text-amber-300">
+                        <span
+                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                          style={{ background: 'color-mix(in oklch, var(--accent-warn) 20%, transparent)', color: 'var(--accent-warn)' }}
+                        >
                           <AlertCircle size={10} />
                           v{update.latestVersion} available
                         </span>
@@ -594,10 +609,10 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                     </div>
                     <p className="text-xs mt-0.5 leading-relaxed" style={{ color: 'var(--fg-3)' }}>{plugin.description}</p>
                     {isError && plugin.error && (
-                      <p className="text-xs text-red-400 mt-1 font-mono">{plugin.error}</p>
+                      <p className="text-xs mt-1 font-mono" style={{ color: 'var(--accent-danger)' }}>{plugin.error}</p>
                     )}
                     {err && (
-                      <p className="text-xs text-red-400 mt-1">{err}</p>
+                      <p className="text-xs mt-1" style={{ color: 'var(--accent-danger)' }}>{err}</p>
                     )}
                     {busy && (
                       <p className="text-xs mt-1" style={{ color: 'var(--fg-4)' }}>{busy}...</p>
@@ -621,7 +636,10 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                     <button
                       onClick={() => doAction(plugin.id, 'Enabling', () => api.enablePlugin(plugin.id))}
                       disabled={!!busy}
-                      className="p-1.5 rounded-lg text-green-400 hover:bg-green-500/10 transition-colors disabled:opacity-50"
+                      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
+                      style={{ color: 'var(--accent-good)' }}
+                      onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-good) 10%, transparent)'; }}
+                      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                       title="Enable plugin"
                     >
                       <ToggleLeft size={15} />
@@ -646,7 +664,10 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                     <button
                       onClick={() => doAction(plugin.id, 'Updating', () => api.updatePlugin(plugin.id))}
                       disabled={!!busy}
-                      className="p-1.5 rounded-lg text-amber-400 hover:bg-amber-500/10 transition-colors disabled:opacity-50"
+                      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
+                      style={{ color: 'var(--accent-warn)' }}
+                      onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-warn) 10%, transparent)'; }}
+                      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                       title={`Update to v${update.latestVersion}`}
                     >
                       <RefreshCw size={15} />
@@ -658,7 +679,8 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                     <div className="flex items-center gap-1">
                       <button
                         onClick={() => uninstall(plugin.id)}
-                        className="px-2 py-1 rounded text-xs bg-red-500 text-white hover:bg-red-600 transition-colors"
+                        className="px-2 py-1 rounded text-xs transition-colors"
+                        style={{ background: 'var(--accent-danger)', color: 'var(--fg)' }}
                       >
                         Confirm
                       </button>
@@ -668,7 +690,10 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                     <button
                       onClick={() => setConfirmUninstall(plugin.id)}
                       disabled={!!busy}
-                      className="p-1.5 rounded-lg text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+                      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
+                      style={{ color: 'var(--accent-danger)' }}
+                      onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-danger) 10%, transparent)'; }}
+                      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                       title="Uninstall plugin"
                     >
                       <Trash2 size={15} />
@@ -725,9 +750,12 @@ function DisableButton({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       disabled={disabled}
-      className="p-1.5 rounded-lg hover:text-yellow-400 hover:bg-yellow-500/10 transition-colors disabled:opacity-50"
+      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
       title="Disable plugin"
-      style={{ color: hovered ? undefined : 'var(--fg-3)' }}
+      style={{
+        color: hovered ? 'var(--accent-warn)' : 'var(--fg-3)',
+        background: hovered ? 'color-mix(in oklch, var(--accent-warn) 10%, transparent)' : 'transparent',
+      }}
     >
       <ToggleRight size={15} />
     </button>
@@ -779,10 +807,10 @@ function CancelButton({ onClick }: { onClick: () => void }) {
 
 function StatusDot({ state }: { state: InstalledPlugin['state'] }) {
   if (state === 'active') {
-    return <span className="inline-block w-2 h-2 rounded-full bg-green-400 mt-1" />;
+    return <span className="inline-block w-2 h-2 rounded-full mt-1" style={{ background: 'var(--accent-good)' }} />;
   }
   if (state === 'error') {
-    return <span className="inline-block w-2 h-2 rounded-full bg-red-400 mt-1" />;
+    return <span className="inline-block w-2 h-2 rounded-full mt-1" style={{ background: 'var(--accent-danger)' }} />;
   }
   return (
     <span
@@ -795,7 +823,10 @@ function StatusDot({ state }: { state: InstalledPlugin['state'] }) {
 function StateLabel({ state }: { state: InstalledPlugin['state'] }) {
   if (state === 'active') {
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-500/20 text-green-300">
+      <span
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+        style={{ background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' }}
+      >
         <CheckCircle size={10} />
         Active
       </span>
@@ -803,7 +834,10 @@ function StateLabel({ state }: { state: InstalledPlugin['state'] }) {
   }
   if (state === 'error') {
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-500/20 text-red-300">
+      <span
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+        style={{ background: 'color-mix(in oklch, var(--accent-danger) 20%, transparent)', color: 'var(--accent-danger)' }}
+      >
         <XCircle size={10} />
         Error
       </span>
@@ -924,7 +958,10 @@ function PluginSettingsPanel({
       {expanded && (
         <div className="px-4 pb-4">
           {error && (
-            <div className="mb-3 px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-xs">
+            <div
+              className="mb-3 px-3 py-2 border rounded-lg text-xs"
+              style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
+            >
               {error}
             </div>
           )}
@@ -963,7 +1000,7 @@ function PluginSettingsPanel({
                   {saving ? 'Saving...' : 'Save'}
                 </button>
                 {saved && (
-                  <span className="text-xs text-green-400 flex items-center gap-1">
+                  <span className="text-xs flex items-center gap-1" style={{ color: 'var(--accent-good)' }}>
                     <CheckCircle size={12} /> Saved
                   </span>
                 )}
@@ -1031,9 +1068,10 @@ function SettingField({
           style={{ background: checked ? 'var(--accent)' : 'var(--fg-4)' }}
         >
           <span
-            className={`inline-block h-3.5 w-3.5 rounded-full bg-white transform transition-transform ${
+            className={`inline-block h-3.5 w-3.5 rounded-full transform transition-transform ${
               checked ? 'translate-x-4' : 'translate-x-0.5'
             }`}
+            style={{ background: 'var(--fg)' }}
           />
         </button>
       </label>

--- a/packages/client/src/pages/PluginsTab.tsx
+++ b/packages/client/src/pages/PluginsTab.tsx
@@ -58,7 +58,7 @@ const inputStyle: CSSProperties = {
 
 const tabActiveStyle: CSSProperties = {
   background: 'var(--accent)',
-  color: 'var(--accent-fg)',
+  color: '#fff',
 };
 
 const tabInactiveStyle: CSSProperties = {
@@ -458,7 +458,7 @@ function InstallButton({
       onClick={onClick}
       disabled={disabled}
       className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-      style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+      style={{ background: 'var(--accent)', color: '#fff' }}
     >
       <Download size={13} />
       {label}
@@ -994,7 +994,7 @@ function PluginSettingsPanel({
                   onClick={save}
                   disabled={saving}
                   className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50 transition-colors"
-                  style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+                  style={{ background: 'var(--accent)', color: '#fff' }}
                 >
                   <Save size={14} />
                   {saving ? 'Saving...' : 'Save'}

--- a/packages/client/src/pages/PluginsTab.tsx
+++ b/packages/client/src/pages/PluginsTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import type { CSSProperties } from 'react';
 import {
   Search, Package, Download, RefreshCw, Trash2, Settings,
   CheckCircle, XCircle, AlertCircle, ChevronRight, ChevronDown,
@@ -42,6 +43,30 @@ function semverGt(a: string, b: string): boolean {
   return false;
 }
 
+/* ─────────────────────────── shared styles ─────────────────────────── */
+
+const surfaceBox: CSSProperties = {
+  background: 'var(--bg-2)',
+  borderColor: 'var(--line)',
+};
+
+const inputStyle: CSSProperties = {
+  background: 'var(--bg-2)',
+  borderColor: 'var(--line)',
+  color: 'var(--fg)',
+};
+
+const tabActiveStyle: CSSProperties = {
+  background: 'var(--accent)',
+  color: 'var(--accent-fg)',
+};
+
+const tabInactiveStyle: CSSProperties = {
+  background: 'var(--bg-2)',
+  color: 'var(--fg-3)',
+  borderColor: 'var(--line)',
+};
+
 /* ═══════════════════════════════════════════════════════════════
    Main PluginsTab — sub-view switcher
 ═══════════════════════════════════════════════════════════════ */
@@ -64,26 +89,16 @@ export function PluginsTab() {
     <div>
       {/* Sub-view toggle */}
       <div className="flex gap-2 mb-6">
-        <button
+        <TabButton
+          active={subView === 'installed'}
           onClick={() => setSubView('installed')}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-            subView === 'installed'
-              ? 'bg-violet-600 text-white'
-              : 'bg-surface-800 text-gray-400 hover:text-gray-200 border border-gray-700/50'
-          }`}
-        >
-          Installed
-        </button>
-        <button
+          label="Installed"
+        />
+        <TabButton
+          active={subView === 'browse'}
           onClick={() => setSubView('browse')}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-            subView === 'browse'
-              ? 'bg-violet-600 text-white'
-              : 'bg-surface-800 text-gray-400 hover:text-gray-200 border border-gray-700/50'
-          }`}
-        >
-          Browse Registry
-        </button>
+          label="Browse Registry"
+        />
       </div>
 
       {subView === 'browse' && (
@@ -96,6 +111,32 @@ export function PluginsTab() {
         <InstalledPlugins onUninstalled={refreshInstalledIds} />
       )}
     </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const style: CSSProperties = active
+    ? tabActiveStyle
+    : { ...tabInactiveStyle, color: hovered ? 'var(--fg)' : 'var(--fg-3)' };
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${active ? '' : 'border'}`}
+      style={style}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -117,6 +158,8 @@ function RegistryBrowse({
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [installing, setInstalling] = useState<Set<string>>(new Set());
   const [installError, setInstallError] = useState<Record<string, string>>({});
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [clearHovered, setClearHovered] = useState(false);
 
   const fetchRegistry = useCallback(async () => {
     try {
@@ -172,7 +215,11 @@ function RegistryBrowse({
     return (
       <div className="space-y-3">
         {[1, 2, 3].map(i => (
-          <div key={i} className="h-24 rounded-lg bg-surface-800 animate-pulse border border-gray-700/30" />
+          <div
+            key={i}
+            className="h-24 rounded-lg animate-pulse border"
+            style={surfaceBox}
+          />
         ))}
       </div>
     );
@@ -194,18 +241,31 @@ function RegistryBrowse({
       {/* Search + tag filters */}
       <div className="mb-4 flex flex-col gap-3">
         <div className="relative">
-          <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <Search
+            size={15}
+            className="absolute left-3 top-1/2 -translate-y-1/2"
+            style={{ color: 'var(--fg-3)' }}
+          />
           <input
             type="text"
             value={query}
             onChange={e => setQuery(e.target.value)}
+            onFocus={() => setSearchFocused(true)}
+            onBlur={() => setSearchFocused(false)}
             placeholder="Search plugins..."
-            className="w-full pl-9 pr-4 py-2 bg-surface-800 border border-gray-700/50 rounded-lg text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-violet-500/50"
+            className="w-full pl-9 pr-4 py-2 border rounded-lg text-sm focus:outline-none transition-colors"
+            style={{
+              ...inputStyle,
+              borderColor: searchFocused ? 'var(--accent)' : 'var(--line)',
+            }}
           />
           {query && (
             <button
               onClick={() => setQuery('')}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
+              onMouseEnter={() => setClearHovered(true)}
+              onMouseLeave={() => setClearHovered(false)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 transition-colors"
+              style={{ color: clearHovered ? 'var(--fg)' : 'var(--fg-3)' }}
             >
               <X size={13} />
             </button>
@@ -214,18 +274,12 @@ function RegistryBrowse({
         {allTags.length > 0 && (
           <div className="flex flex-wrap gap-2">
             {allTags.map(tag => (
-              <button
+              <TagChip
                 key={tag}
+                tag={tag}
+                active={activeTag === tag}
                 onClick={() => setActiveTag(activeTag === tag ? null : tag)}
-                className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
-                  activeTag === tag
-                    ? 'bg-violet-500/30 text-violet-300 border border-violet-500/50'
-                    : 'bg-gray-700/50 text-gray-400 border border-gray-700/30 hover:border-gray-600 hover:text-gray-300'
-                }`}
-              >
-                <Tag size={10} />
-                {tag}
-              </button>
+              />
             ))}
           </div>
         )}
@@ -233,7 +287,7 @@ function RegistryBrowse({
 
       {/* Plugin cards */}
       {filtered.length === 0 ? (
-        <div className="text-center text-gray-500 py-12 text-sm">
+        <div className="text-center py-12 text-sm" style={{ color: 'var(--fg-4)' }}>
           No plugins match your search.
         </div>
       ) : (
@@ -245,65 +299,161 @@ function RegistryBrowse({
             const incompatible = semverGt(plugin.minKrytonVersion, KRYTON_VERSION);
 
             return (
-              <div
+              <PluginCard
                 key={plugin.id}
-                className="flex items-start justify-between px-4 py-4 rounded-lg bg-surface-800 border border-gray-700/30 hover:border-gray-600/50 transition-colors"
-              >
-                <div className="flex items-start gap-3 flex-1 min-w-0">
-                  <div className="mt-0.5 p-2 rounded-lg bg-violet-500/10 text-violet-400 shrink-0">
-                    <Package size={16} />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-sm font-medium text-white">{plugin.name}</span>
-                      <span className="text-xs text-gray-500">v{plugin.version}</span>
-                      <span className="text-xs text-gray-500">by {plugin.author}</span>
-                      {isInstalled && (
-                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-500/20 text-green-300">
-                          <CheckCircle size={10} />
-                          Installed
-                        </span>
-                      )}
-                      {incompatible && (
-                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/20 text-amber-300">
-                          <AlertCircle size={10} />
-                          Requires v{plugin.minKrytonVersion}
-                        </span>
-                      )}
-                    </div>
-                    <p className="text-xs text-gray-400 mt-1 leading-relaxed">{plugin.description}</p>
-                    {plugin.tags.length > 0 && (
-                      <div className="flex flex-wrap gap-1.5 mt-2">
-                        {plugin.tags.map(tag => (
-                          <span key={tag} className="px-1.5 py-0.5 rounded text-xs bg-gray-700/50 text-gray-400">
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    {err && (
-                      <p className="text-xs text-red-400 mt-1">{err}</p>
-                    )}
-                  </div>
-                </div>
-                <div className="ml-4 shrink-0">
-                  {!isInstalled && (
-                    <button
-                      onClick={() => install(plugin.id)}
-                      disabled={isInstalling || incompatible}
-                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 text-white text-xs font-medium hover:bg-violet-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    >
-                      <Download size={13} />
-                      {isInstalling ? 'Installing...' : 'Install'}
-                    </button>
-                  )}
-                </div>
-              </div>
+                plugin={plugin}
+                isInstalled={isInstalled}
+                isInstalling={isInstalling}
+                err={err}
+                incompatible={incompatible}
+                onInstall={() => install(plugin.id)}
+              />
             );
           })}
         </div>
       )}
     </div>
+  );
+}
+
+function TagChip({
+  tag,
+  active,
+  onClick,
+}: {
+  tag: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const baseClass = 'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border';
+  const style: CSSProperties = active
+    ? {
+      background: 'var(--accent-soft)',
+      color: 'var(--accent)',
+      borderColor: 'var(--accent)',
+    }
+    : {
+      background: 'var(--bg-2)',
+      color: hovered ? 'var(--fg)' : 'var(--fg-3)',
+      borderColor: hovered ? 'var(--line-strong)' : 'var(--line)',
+    };
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className={baseClass}
+      style={style}
+    >
+      <Tag size={10} />
+      {tag}
+    </button>
+  );
+}
+
+function PluginCard({
+  plugin,
+  isInstalled,
+  isInstalling,
+  err,
+  incompatible,
+  onInstall,
+}: {
+  plugin: RegistryPlugin;
+  isInstalled: boolean;
+  isInstalling: boolean;
+  err?: string;
+  incompatible: boolean;
+  onInstall: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className="flex items-start justify-between px-4 py-4 rounded-lg border transition-colors"
+      style={{
+        background: 'var(--bg-2)',
+        borderColor: hovered ? 'var(--line-strong)' : 'var(--line)',
+      }}
+    >
+      <div className="flex items-start gap-3 flex-1 min-w-0">
+        <div
+          className="mt-0.5 p-2 rounded-lg shrink-0"
+          style={{ background: 'var(--accent-soft)', color: 'var(--accent)' }}
+        >
+          <Package size={16} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium" style={{ color: 'var(--fg)' }}>{plugin.name}</span>
+            <span className="text-xs" style={{ color: 'var(--fg-4)' }}>v{plugin.version}</span>
+            <span className="text-xs" style={{ color: 'var(--fg-4)' }}>by {plugin.author}</span>
+            {isInstalled && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-500/20 text-green-300">
+                <CheckCircle size={10} />
+                Installed
+              </span>
+            )}
+            {incompatible && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/20 text-amber-300">
+                <AlertCircle size={10} />
+                Requires v{plugin.minKrytonVersion}
+              </span>
+            )}
+          </div>
+          <p className="text-xs mt-1 leading-relaxed" style={{ color: 'var(--fg-3)' }}>{plugin.description}</p>
+          {plugin.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {plugin.tags.map(tag => (
+                <span
+                  key={tag}
+                  className="px-1.5 py-0.5 rounded text-xs"
+                  style={{ background: 'var(--bg-2)', color: 'var(--fg-3)' }}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+          {err && (
+            <p className="text-xs text-red-400 mt-1">{err}</p>
+          )}
+        </div>
+      </div>
+      <div className="ml-4 shrink-0">
+        {!isInstalled && (
+          <InstallButton
+            onClick={onInstall}
+            disabled={isInstalling || incompatible}
+            label={isInstalling ? 'Installing...' : 'Install'}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function InstallButton({
+  onClick,
+  disabled,
+  label,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  label: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
+    >
+      <Download size={13} />
+      {label}
+    </button>
   );
 }
 
@@ -370,7 +520,11 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
     return (
       <div className="space-y-3">
         {[1, 2].map(i => (
-          <div key={i} className="h-20 rounded-lg bg-surface-800 animate-pulse border border-gray-700/30" />
+          <div
+            key={i}
+            className="h-20 rounded-lg animate-pulse border"
+            style={surfaceBox}
+          />
         ))}
       </div>
     );
@@ -389,7 +543,7 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
 
   if (plugins.length === 0) {
     return (
-      <div className="text-center text-gray-500 py-12 text-sm">
+      <div className="text-center py-12 text-sm" style={{ color: 'var(--fg-4)' }}>
         No plugins installed yet. Browse the registry to find plugins.
       </div>
     );
@@ -416,7 +570,8 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
           return (
             <div
               key={plugin.id}
-              className="px-4 py-4 rounded-lg bg-surface-800 border border-gray-700/30"
+              className="px-4 py-4 rounded-lg border"
+              style={surfaceBox}
             >
               <div className="flex items-start justify-between gap-3">
                 {/* Left: status dot + info */}
@@ -426,9 +581,9 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-sm font-medium text-white">{plugin.name}</span>
-                      <span className="text-xs text-gray-500">v{plugin.version}</span>
-                      <span className="text-xs text-gray-500">by {plugin.author}</span>
+                      <span className="text-sm font-medium" style={{ color: 'var(--fg)' }}>{plugin.name}</span>
+                      <span className="text-xs" style={{ color: 'var(--fg-4)' }}>v{plugin.version}</span>
+                      <span className="text-xs" style={{ color: 'var(--fg-4)' }}>by {plugin.author}</span>
                       <StateLabel state={plugin.state} />
                       {update && (
                         <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/20 text-amber-300">
@@ -437,7 +592,7 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                         </span>
                       )}
                     </div>
-                    <p className="text-xs text-gray-400 mt-0.5 leading-relaxed">{plugin.description}</p>
+                    <p className="text-xs mt-0.5 leading-relaxed" style={{ color: 'var(--fg-3)' }}>{plugin.description}</p>
                     {isError && plugin.error && (
                       <p className="text-xs text-red-400 mt-1 font-mono">{plugin.error}</p>
                     )}
@@ -445,7 +600,7 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                       <p className="text-xs text-red-400 mt-1">{err}</p>
                     )}
                     {busy && (
-                      <p className="text-xs text-gray-500 mt-1">{busy}...</p>
+                      <p className="text-xs mt-1" style={{ color: 'var(--fg-4)' }}>{busy}...</p>
                     )}
                   </div>
                 </div>
@@ -454,13 +609,11 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                 <div className="flex items-center gap-1 shrink-0">
                   {/* Settings (only if plugin has settings) */}
                   {plugin.settings && plugin.settings.length > 0 && (
-                    <button
+                    <IconActionButton
                       onClick={() => setSettingsPlugin(plugin)}
-                      className="p-1.5 rounded-lg text-gray-400 hover:text-white hover:bg-gray-700/50 transition-colors"
                       title="Plugin settings"
-                    >
-                      <Settings size={15} />
-                    </button>
+                      icon={<Settings size={15} />}
+                    />
                   )}
 
                   {/* Enable / Disable toggle */}
@@ -474,26 +627,18 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                       <ToggleLeft size={15} />
                     </button>
                   ) : (
-                    <button
+                    <DisableButton
                       onClick={() => doAction(plugin.id, 'Disabling', () => api.disablePlugin(plugin.id))}
                       disabled={!!busy}
-                      className="p-1.5 rounded-lg text-gray-400 hover:text-yellow-400 hover:bg-yellow-500/10 transition-colors disabled:opacity-50"
-                      title="Disable plugin"
-                    >
-                      <ToggleRight size={15} />
-                    </button>
+                    />
                   )}
 
                   {/* Reload */}
                   {isActive && (
-                    <button
+                    <ReloadButton
                       onClick={() => doAction(plugin.id, 'Reloading', () => api.reloadPlugin(plugin.id))}
                       disabled={!!busy}
-                      className="p-1.5 rounded-lg text-gray-400 hover:text-violet-400 hover:bg-violet-500/10 transition-colors disabled:opacity-50"
-                      title="Reload plugin"
-                    >
-                      <RotateCcw size={15} />
-                    </button>
+                    />
                   )}
 
                   {/* Update */}
@@ -517,12 +662,7 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
                       >
                         Confirm
                       </button>
-                      <button
-                        onClick={() => setConfirmUninstall(null)}
-                        className="px-2 py-1 rounded text-xs text-gray-400 hover:text-white transition-colors"
-                      >
-                        Cancel
-                      </button>
+                      <CancelButton onClick={() => setConfirmUninstall(null)} />
                     </div>
                   ) : (
                     <button
@@ -544,6 +684,97 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
   );
 }
 
+function IconActionButton({
+  onClick,
+  title,
+  icon,
+}: {
+  onClick: () => void;
+  title: string;
+  icon: React.ReactNode;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className="p-1.5 rounded-lg transition-colors"
+      title={title}
+      style={{
+        color: hovered ? 'var(--fg)' : 'var(--fg-3)',
+        background: hovered ? 'var(--bg-hover)' : 'transparent',
+      }}
+    >
+      {icon}
+    </button>
+  );
+}
+
+function DisableButton({
+  onClick,
+  disabled,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      disabled={disabled}
+      className="p-1.5 rounded-lg hover:text-yellow-400 hover:bg-yellow-500/10 transition-colors disabled:opacity-50"
+      title="Disable plugin"
+      style={{ color: hovered ? undefined : 'var(--fg-3)' }}
+    >
+      <ToggleRight size={15} />
+    </button>
+  );
+}
+
+function ReloadButton({
+  onClick,
+  disabled,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      disabled={disabled}
+      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
+      title="Reload plugin"
+      style={{
+        color: hovered ? 'var(--accent)' : 'var(--fg-3)',
+        background: hovered ? 'var(--accent-soft)' : 'transparent',
+      }}
+    >
+      <RotateCcw size={15} />
+    </button>
+  );
+}
+
+function CancelButton({ onClick }: { onClick: () => void }) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <button
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className="px-2 py-1 rounded text-xs transition-colors"
+      style={{ color: hovered ? 'var(--fg)' : 'var(--fg-3)' }}
+    >
+      Cancel
+    </button>
+  );
+}
+
 /* ─── Status dot ─── */
 
 function StatusDot({ state }: { state: InstalledPlugin['state'] }) {
@@ -553,7 +784,12 @@ function StatusDot({ state }: { state: InstalledPlugin['state'] }) {
   if (state === 'error') {
     return <span className="inline-block w-2 h-2 rounded-full bg-red-400 mt-1" />;
   }
-  return <span className="inline-block w-2 h-2 rounded-full bg-gray-500 mt-1" />;
+  return (
+    <span
+      className="inline-block w-2 h-2 rounded-full mt-1"
+      style={{ background: 'var(--fg-4)' }}
+    />
+  );
 }
 
 function StateLabel({ state }: { state: InstalledPlugin['state'] }) {
@@ -575,7 +811,10 @@ function StateLabel({ state }: { state: InstalledPlugin['state'] }) {
   }
   if (state === 'disabled' || state === 'unloaded') {
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-700/50 text-gray-400">
+      <span
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+        style={{ background: 'var(--bg-2)', color: 'var(--fg-3)' }}
+      >
         Disabled
       </span>
     );
@@ -600,6 +839,8 @@ function PluginSettingsPanel({
   const [error, setError] = useState('');
   const [saved, setSaved] = useState(false);
   const [expanded, setExpanded] = useState(true);
+  const [headerHovered, setHeaderHovered] = useState(false);
+  const [closeHovered, setCloseHovered] = useState(false);
 
   const adminSettings = plugin.settings.filter(s => !s.perUser);
   const userSettings = plugin.settings.filter(s => s.perUser);
@@ -650,11 +891,17 @@ function PluginSettingsPanel({
   };
 
   return (
-    <div className="mb-4 rounded-lg border border-violet-500/30 bg-violet-500/5">
+    <div
+      className="mb-4 rounded-lg border"
+      style={{ borderColor: 'var(--accent)', background: 'var(--accent-soft)' }}
+    >
       {/* Panel header */}
       <button
         onClick={() => setExpanded(v => !v)}
-        className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-violet-300 hover:text-white transition-colors"
+        onMouseEnter={() => setHeaderHovered(true)}
+        onMouseLeave={() => setHeaderHovered(false)}
+        className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium transition-colors"
+        style={{ color: headerHovered ? 'var(--fg)' : 'var(--accent)' }}
       >
         <div className="flex items-center gap-2">
           <Settings size={15} />
@@ -663,7 +910,10 @@ function PluginSettingsPanel({
         <div className="flex items-center gap-2">
           <button
             onClick={e => { e.stopPropagation(); onClose(); }}
-            className="p-0.5 rounded text-gray-400 hover:text-white transition-colors"
+            onMouseEnter={() => setCloseHovered(true)}
+            onMouseLeave={() => setCloseHovered(false)}
+            className="p-0.5 rounded transition-colors"
+            style={{ color: closeHovered ? 'var(--fg)' : 'var(--fg-3)' }}
           >
             <X size={14} />
           </button>
@@ -680,7 +930,7 @@ function PluginSettingsPanel({
           )}
 
           {loading ? (
-            <div className="text-gray-400 text-sm py-2">Loading settings...</div>
+            <div className="text-sm py-2" style={{ color: 'var(--fg-3)' }}>Loading settings...</div>
           ) : (
             <>
               {adminSettings.length > 0 && (
@@ -706,7 +956,8 @@ function PluginSettingsPanel({
                 <button
                   onClick={save}
                   disabled={saving}
-                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-violet-600 text-white text-sm font-medium hover:bg-violet-500 disabled:opacity-50 transition-colors"
+                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50 transition-colors"
+                  style={{ background: 'var(--accent)', color: 'var(--accent-fg)' }}
                 >
                   <Save size={14} />
                   {saving ? 'Saving...' : 'Save'}
@@ -741,8 +992,8 @@ function SettingsGroup({
   return (
     <div className="mb-4">
       <div className="mb-2">
-        <p className="text-xs font-semibold text-gray-300 uppercase tracking-wider">{title}</p>
-        <p className="text-xs text-gray-500">{subtitle}</p>
+        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--fg)' }}>{title}</p>
+        <p className="text-xs" style={{ color: 'var(--fg-4)' }}>{subtitle}</p>
       </div>
       <div className="space-y-3">
         {settings.map(s => (
@@ -762,19 +1013,22 @@ function SettingField({
   value: unknown;
   onChange: (v: unknown) => void;
 }) {
-  const inputBase =
-    'bg-surface-800 border border-gray-700/50 rounded-lg px-3 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-violet-500/50';
+  const [focused, setFocused] = useState(false);
+  const inputClass = 'border rounded-lg px-3 py-1.5 text-sm focus:outline-none transition-colors';
+  const inputDynamicStyle: CSSProperties = {
+    ...inputStyle,
+    borderColor: focused ? 'var(--accent)' : 'var(--line)',
+  };
 
   if (decl.type === 'boolean') {
     const checked = Boolean(value);
     return (
       <label className="flex items-center justify-between gap-3 cursor-pointer">
-        <span className="text-sm text-gray-300">{decl.label}</span>
+        <span className="text-sm" style={{ color: 'var(--fg)' }}>{decl.label}</span>
         <button
           onClick={() => onChange(!checked)}
-          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-            checked ? 'bg-violet-600' : 'bg-gray-600'
-          }`}
+          className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors"
+          style={{ background: checked ? 'var(--accent)' : 'var(--fg-4)' }}
         >
           <span
             className={`inline-block h-3.5 w-3.5 rounded-full bg-white transform transition-transform ${
@@ -789,12 +1043,15 @@ function SettingField({
   if (decl.type === 'number') {
     return (
       <div className="flex items-center justify-between gap-3">
-        <label className="text-sm text-gray-300">{decl.label}</label>
+        <label className="text-sm" style={{ color: 'var(--fg)' }}>{decl.label}</label>
         <input
           type="number"
           value={value as number ?? 0}
           onChange={e => onChange(Number(e.target.value))}
-          className={`w-28 text-right ${inputBase}`}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          className={`w-28 text-right ${inputClass}`}
+          style={inputDynamicStyle}
         />
       </div>
     );
@@ -803,12 +1060,15 @@ function SettingField({
   // string (default)
   return (
     <div className="flex flex-col gap-1.5">
-      <label className="text-sm text-gray-300">{decl.label}</label>
+      <label className="text-sm" style={{ color: 'var(--fg)' }}>{decl.label}</label>
       <input
         type="text"
         value={value as string ?? ''}
         onChange={e => onChange(e.target.value)}
-        className={`w-full ${inputBase}`}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        className={`w-full ${inputClass}`}
+        style={inputDynamicStyle}
       />
     </div>
   );

--- a/packages/client/src/stores/uiStore.ts
+++ b/packages/client/src/stores/uiStore.ts
@@ -33,6 +33,10 @@ interface UIState {
   /** Per-note version-history dropdown — toggled by the top-bar History
    *  button when a note is active; consumed by PreviewModeView. */
   showNoteHistory: boolean;
+  /** Ordered list of note paths currently open in the tab strip.
+   *  Opening a note adds it (if absent) and makes it active; closing a tab
+   *  removes its path and falls back to the previous tab as active. */
+  openTabs: string[];
 
   // Editor
   cursorState: { line: number; col: number; wordCount: number };
@@ -57,6 +61,10 @@ interface UIState {
   setShowAccessRequests: SetState<boolean>;
   setShowAccountSettings: SetState<boolean>;
   setShowNoteHistory: SetState<boolean>;
+  /** Open or focus a tab for `path`. Appends if absent; idempotent. */
+  openTab: (path: string) => void;
+  /** Close the tab for `path`. Returns the next path to activate (or null). */
+  closeTab: (path: string) => string | null;
 
   // Compound actions
   enterEditMode: (content: string) => void;
@@ -92,6 +100,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   showAccessRequests: false,
   showAccountSettings: false,
   showNoteHistory: false,
+  openTabs: [],
   cursorState: { line: 1, col: 1, wordCount: 0 },
 
   // Setters — all support updater functions
@@ -115,6 +124,23 @@ export const useUIStore = create<UIState>((set, get) => ({
   setShowAccountSettings: (v) => set({ showAccountSettings: resolve(v, get().showAccountSettings) }),
   setShowNoteHistory: (v) => set({ showNoteHistory: resolve(v, get().showNoteHistory) }),
 
+  openTab: (path) => {
+    const tabs = get().openTabs;
+    if (tabs.includes(path)) return;
+    set({ openTabs: [...tabs, path] });
+  },
+  closeTab: (path) => {
+    const tabs = get().openTabs;
+    const idx = tabs.indexOf(path);
+    if (idx === -1) return null;
+    const next = tabs.filter((p) => p !== path);
+    set({ openTabs: next });
+    // Activate neighbour (prefer left, fall back to right) so the user
+    // doesn't drop into an empty view when closing the focused tab.
+    if (next.length === 0) return null;
+    return next[Math.max(0, idx - 1)] ?? next[0];
+  },
+
   enterEditMode: (content) => set({ editing: true, editContent: content, originalContent: content }),
   cancelEdit: () => set({ editing: false, editContent: null, originalContent: null }),
   reset: () => set({
@@ -135,6 +161,7 @@ export const useUIStore = create<UIState>((set, get) => ({
     showAccessRequests: false,
     showAccountSettings: false,
     showNoteHistory: false,
+    openTabs: [],
     cursorState: { line: 1, col: 1, wordCount: 0 },
   }),
 }));

--- a/packages/client/src/stores/uiStore.ts
+++ b/packages/client/src/stores/uiStore.ts
@@ -30,6 +30,9 @@ interface UIState {
   shareTarget: { path: string; isFolder: boolean } | null;
   showAccessRequests: boolean;
   showAccountSettings: boolean;
+  /** Per-note version-history dropdown — toggled by the top-bar History
+   *  button when a note is active; consumed by PreviewModeView. */
+  showNoteHistory: boolean;
 
   // Editor
   cursorState: { line: number; col: number; wordCount: number };
@@ -53,6 +56,7 @@ interface UIState {
   setShareTarget: SetState<{ path: string; isFolder: boolean } | null>;
   setShowAccessRequests: SetState<boolean>;
   setShowAccountSettings: SetState<boolean>;
+  setShowNoteHistory: SetState<boolean>;
 
   // Compound actions
   enterEditMode: (content: string) => void;
@@ -87,6 +91,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   shareTarget: null,
   showAccessRequests: false,
   showAccountSettings: false,
+  showNoteHistory: false,
   cursorState: { line: 1, col: 1, wordCount: 0 },
 
   // Setters — all support updater functions
@@ -108,6 +113,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   setShareTarget: (v) => set({ shareTarget: resolve(v, get().shareTarget) }),
   setShowAccessRequests: (v) => set({ showAccessRequests: resolve(v, get().showAccessRequests) }),
   setShowAccountSettings: (v) => set({ showAccountSettings: resolve(v, get().showAccountSettings) }),
+  setShowNoteHistory: (v) => set({ showNoteHistory: resolve(v, get().showNoteHistory) }),
 
   enterEditMode: (content) => set({ editing: true, editContent: content, originalContent: content }),
   cancelEdit: () => set({ editing: false, editContent: null, originalContent: null }),
@@ -128,6 +134,7 @@ export const useUIStore = create<UIState>((set, get) => ({
     shareTarget: null,
     showAccessRequests: false,
     showAccountSettings: false,
+    showNoteHistory: false,
     cursorState: { line: 1, col: 1, wordCount: 0 },
   }),
 }));

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -8,11 +8,11 @@
 @source "../../../ui/src";
 @source "../../../ui/dist";
 
-@custom-variant dark (&:where(.dark, .dark *));
+@custom-variant dark ([data-theme="dark"] &);
 
 @theme {
-  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 
   --color-surface-50: #fafafa;
   --color-surface-100: #f5f5f5;
@@ -28,10 +28,6 @@
 @layer base {
   :root {
     --sidebar-width: 260px;
-  }
-  /* Default border tracks the design-system line token. */
-  * {
-    border-color: var(--line);
   }
 }
 
@@ -95,12 +91,12 @@
 /* Markdown decoration spans rendered inline (the Lezer-emitted ranges). The
    tokens — including the `# ` mark for headings — stay visible in edit mode
    so the user always sees raw markdown; we only restyle. */
-.ed-h1 { font-family: var(--font-display); font-size: 22px; font-weight: 600; letter-spacing: -0.4px; color: var(--fg); }
-.ed-h2 { font-family: var(--font-display); font-size: 18px; font-weight: 600; letter-spacing: -0.2px; color: var(--fg); }
-.ed-h3 { font-family: var(--font-display); font-size: 16px; font-weight: 600; color: var(--fg); }
-.ed-h4 { font-family: var(--font-display); font-size: 15px; font-weight: 600; color: var(--fg); }
-.ed-h5 { font-family: var(--font-display); font-size: 14px; font-weight: 600; color: var(--fg); }
-.ed-h6 { font-family: var(--font-display); font-size: 13px; font-weight: 600; color: var(--fg-2); }
+.ed-h1 { color: var(--fg); font-weight: 600; }
+.ed-h2 { color: var(--fg); font-weight: 600; }
+.ed-h3 { color: var(--fg); font-weight: 600; }
+.ed-h4 { color: var(--fg); font-weight: 600; }
+.ed-h5 { color: var(--fg); font-weight: 600; }
+.ed-h6 { color: var(--fg); font-weight: 600; }
 
 /* Bold uses --accent-warn (amber) per editor.jsx MdInline so emphasis pops
    inside the mono surface; the body --fg already gives normal text contrast. */

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -10,42 +10,17 @@
 
 @custom-variant dark ([data-theme="dark"] &);
 
+/* Tailwind only learns about the bible's font stacks here; everything else
+   (colours, surfaces, borders) lives in tokens.css and is consumed inline. */
 @theme {
   --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-
-  --color-surface-50: #fafafa;
-  --color-surface-100: #f5f5f5;
-  --color-surface-200: #e5e5e5;
-  --color-surface-300: #d4d4d4;
-  --color-surface-700: #374151;
-  --color-surface-800: #1f2937;
-  --color-surface-850: #1a1f2e;
-  --color-surface-900: #111827;
-  --color-surface-950: #0d1117;
 }
 
 @layer base {
   :root {
     --sidebar-width: 260px;
   }
-}
-
-@utility btn {
-  @apply inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-150;
-  @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950;
-}
-
-@utility btn-primary {
-  @apply btn bg-violet-500 text-white hover:bg-violet-600 active:bg-violet-700;
-}
-
-@utility btn-ghost {
-  @apply btn text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 active:bg-gray-200 dark:active:bg-gray-700;
-}
-
-@utility btn-danger {
-  @apply btn text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 active:bg-red-100 dark:active:bg-red-900/30;
 }
 
 /* In-house editor (EditorView.web.tsx) — outer .ed-shell is a 2-column grid

--- a/packages/server/data
+++ b/packages/server/data
@@ -1,0 +1,1 @@
+/Users/pascal/Development/Kryton/kryton/packages/server/data

--- a/packages/server/data
+++ b/packages/server/data
@@ -1,1 +1,0 @@
-/Users/pascal/Development/Kryton/kryton/packages/server/data

--- a/packages/server/openapi.snapshot.json
+++ b/packages/server/openapi.snapshot.json
@@ -1566,6 +1566,123 @@
         ]
       }
     },
+    "/api/agents/mcp-health": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "status": {
+                      "enum": [
+                        "ok"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "MCP transport reachability probe",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/api/agents/online": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "clients": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "lastActivity": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "sessionId": {
+                            "type": "string"
+                          },
+                          "startedAt": {
+                            "type": "number"
+                          },
+                          "transport": {
+                            "enum": [
+                              "sse",
+                              "streamable"
+                            ],
+                            "type": "string"
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "sessionId",
+                          "name",
+                          "version",
+                          "transport",
+                          "startedAt",
+                          "lastActivity"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "count",
+                    "clients"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "List MCP sessions currently connected for the calling user",
+        "tags": [
+          "agents"
+        ]
+      }
+    },
     "/api/agents/tokens/{tokenId}/revoke": {
       "post": {
         "parameters": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,7 @@
     "@prisma/client": "^7.5.0",
     "better-auth": "^1.5.6",
     "better-sqlite3": "^12.8.0",
+    "chokidar": "^4.0.3",
     "date-fns": "^4.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.2.0",

--- a/packages/server/src/modules/agents/index.ts
+++ b/packages/server/src/modules/agents/index.ts
@@ -2,6 +2,7 @@ import fp from "fastify-plugin";
 import type { FastifyPluginAsync } from "fastify";
 import { AgentService } from "./services/agent.service.js";
 import { agentsRoutes } from "./routes/agents.routes.js";
+import { agentsOnlineRoutes } from "./routes/agents-online.routes.js";
 import { sseMcpRoutes, streamableMcpRoutes } from "./mcp/server.js";
 
 declare module "fastify" {
@@ -17,6 +18,8 @@ const agentsModuleImpl: FastifyPluginAsync = async (app) => {
   app.decorate("agents", { service: agentService });
 
   await app.register(agentsRoutes({ agentService }), { prefix: "/api/agents" });
+  // Live MCP-session indicators for the sidebar agents-online footer.
+  await app.register(agentsOnlineRoutes, { prefix: "/api/agents" });
   // MCP transports — Streamable HTTP + SSE share /api/mcp.
   // Streamable HTTP owns POST/GET/DELETE on the bare prefix; SSE adds
   // GET /sse and POST /messages.

--- a/packages/server/src/modules/agents/mcp/active-sessions.ts
+++ b/packages/server/src/modules/agents/mcp/active-sessions.ts
@@ -1,0 +1,70 @@
+/**
+ * Process-wide registry of live MCP sessions, shared by every transport
+ * (SSE + Streamable HTTP). Each transport calls `register` on session create
+ * and `unregister` on session close / reap.
+ *
+ * Used by `/api/agents/online` to drive the sidebar "agents online" indicator
+ * — turns the previously-static "2 agents online" mock into a real count.
+ *
+ * Process-local by design: an MCP session lives only as long as the Node
+ * process that opened it, so a single in-memory map matches its lifetime
+ * exactly. Horizontal-scale deployments would replace this with Redis.
+ */
+
+export type McpTransport = "sse" | "streamable";
+
+export interface ActiveSession {
+  /** Unique session id (UUID). */
+  sessionId: string;
+  /** Authenticated user the session belongs to. */
+  userId: string;
+  /** Transport family — display this in the agents-online UI if useful. */
+  transport: McpTransport;
+  /** Optional client name reported via the MCP initialize handshake. */
+  clientName?: string;
+  /** Optional client version reported via the MCP initialize handshake. */
+  clientVersion?: string;
+  /** Wall-clock ms when the session was opened. */
+  startedAt: number;
+  /** Wall-clock ms of the last JSON-RPC activity (updated by transports). */
+  lastActivity: number;
+}
+
+const sessions = new Map<string, ActiveSession>();
+
+export function register(entry: ActiveSession): void {
+  sessions.set(entry.sessionId, entry);
+}
+
+export function unregister(sessionId: string): void {
+  sessions.delete(sessionId);
+}
+
+export function touch(sessionId: string): void {
+  const s = sessions.get(sessionId);
+  if (s) s.lastActivity = Date.now();
+}
+
+export function updateClientInfo(
+  sessionId: string,
+  info: { clientName?: string; clientVersion?: string },
+): void {
+  const s = sessions.get(sessionId);
+  if (!s) return;
+  if (info.clientName) s.clientName = info.clientName;
+  if (info.clientVersion) s.clientVersion = info.clientVersion;
+}
+
+/** Snapshot of every active session for `userId`. */
+export function listForUser(userId: string): ActiveSession[] {
+  const out: ActiveSession[] = [];
+  for (const s of sessions.values()) {
+    if (s.userId === userId) out.push({ ...s });
+  }
+  return out;
+}
+
+/** Snapshot of every active session — admin-only consumers. */
+export function listAll(): ActiveSession[] {
+  return [...sessions.values()].map((s) => ({ ...s }));
+}

--- a/packages/server/src/modules/agents/mcp/sse.ts
+++ b/packages/server/src/modules/agents/mcp/sse.ts
@@ -12,6 +12,7 @@ import type { FastifyPluginAsync, FastifyRequest } from "fastify";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { buildMcpServer } from "./build-server.js";
 import { authenticateMcpRequest } from "./auth.js";
+import * as activeSessions from "./active-sessions.js";
 import { createLogger } from "../../../lib/logger.js";
 
 const log = createLogger("mcp-sse");
@@ -52,6 +53,7 @@ export const sseMcpRoutes: FastifyPluginAsync = async (app) => {
     const s = sessions.get(sid);
     if (!s) return;
     sessions.delete(sid);
+    activeSessions.unregister(sid);
     clearInterval(s.keepalive);
     try {
       await s.mcpServer.close();
@@ -124,6 +126,15 @@ export const sseMcpRoutes: FastifyPluginAsync = async (app) => {
         keepalive,
       };
       sessions.set(sessionId, entry);
+      // clientInfo for SSE arrives in the POST /messages initialize call;
+      // we register with no name now and updateClientInfo when it arrives.
+      activeSessions.register({
+        sessionId,
+        userId: auth.userId,
+        transport: "sse",
+        startedAt: Date.now(),
+        lastActivity: Date.now(),
+      });
 
       const teardown = (): void => {
         void closeSession(sessionId);
@@ -157,6 +168,26 @@ export const sseMcpRoutes: FastifyPluginAsync = async (app) => {
         return;
       }
       entry.lastActivity = Date.now();
+      activeSessions.touch(sid);
+      // Initialize message carries clientInfo — capture it for the
+      // agents-online indicator (Claude Desktop, Cursor, …).
+      const body = request.body;
+      if (body && typeof body === "object" && !Array.isArray(body)) {
+        const method = (body as { method?: unknown }).method;
+        if (method === "initialize") {
+          const params = (body as { params?: unknown }).params;
+          if (params && typeof params === "object" && !Array.isArray(params)) {
+            const info = (params as { clientInfo?: unknown }).clientInfo;
+            if (info && typeof info === "object" && !Array.isArray(info)) {
+              const { name, version } = info as { name?: unknown; version?: unknown };
+              activeSessions.updateClientInfo(sid, {
+                clientName: typeof name === "string" ? name : undefined,
+                clientVersion: typeof version === "string" ? version : undefined,
+              });
+            }
+          }
+        }
+      }
 
       reply.hijack();
       try {

--- a/packages/server/src/modules/agents/mcp/streamable.ts
+++ b/packages/server/src/modules/agents/mcp/streamable.ts
@@ -14,6 +14,7 @@ import type { FastifyPluginAsync, FastifyRequest } from "fastify";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { buildMcpServer } from "./build-server.js";
 import { authenticateMcpRequest } from "./auth.js";
+import * as activeSessions from "./active-sessions.js";
 import { createLogger } from "../../../lib/logger.js";
 
 const log = createLogger("mcp-streamable");
@@ -40,6 +41,31 @@ function isInitializeRequest(body: unknown): boolean {
   return m === "initialize";
 }
 
+/**
+ * The MCP `initialize` JSON-RPC payload looks like:
+ *   { method: "initialize", params: { clientInfo: { name, version }, ... } }
+ * Extract name/version so we can surface "Claude Desktop", "Cursor", etc. in
+ * the sidebar — falling back to `undefined` for anonymous/older clients.
+ */
+function extractClientInfo(body: unknown): { name?: string; version?: string } {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return {};
+  const params = (body as { params?: unknown }).params;
+  if (!params || typeof params !== "object" || Array.isArray(params)) return {};
+  const info = (params as { clientInfo?: unknown }).clientInfo;
+  if (!info || typeof info !== "object" || Array.isArray(info)) return {};
+  const { name, version } = info as { name?: unknown; version?: unknown };
+  return {
+    name: typeof name === "string" ? name : undefined,
+    version: typeof version === "string" ? version : undefined,
+  };
+}
+function extractClientName(body: unknown): string | undefined {
+  return extractClientInfo(body).name;
+}
+function extractClientVersion(body: unknown): string | undefined {
+  return extractClientInfo(body).version;
+}
+
 export const streamableMcpRoutes: FastifyPluginAsync = async (app) => {
   const sessions = new Map<string, SessionEntry>();
 
@@ -53,6 +79,7 @@ export const streamableMcpRoutes: FastifyPluginAsync = async (app) => {
     const s = sessions.get(sid);
     if (!s) return;
     sessions.delete(sid);
+    activeSessions.unregister(sid);
     try {
       await s.transport.close();
     } catch {
@@ -104,6 +131,7 @@ export const streamableMcpRoutes: FastifyPluginAsync = async (app) => {
           return;
         }
         entry.lastActivity = Date.now();
+        activeSessions.touch(sid);
         reply.hijack();
         try {
           await entry.transport.handleRequest(request.raw, reply.raw, request.body);
@@ -149,9 +177,19 @@ export const streamableMcpRoutes: FastifyPluginAsync = async (app) => {
         lastActivity: Date.now(),
       };
       sessions.set(newId, entry);
+      activeSessions.register({
+        sessionId: newId,
+        userId: auth.userId,
+        transport: "streamable",
+        clientName: extractClientName(request.body),
+        clientVersion: extractClientVersion(request.body),
+        startedAt: Date.now(),
+        lastActivity: Date.now(),
+      });
 
       transport.onclose = (): void => {
         sessions.delete(newId);
+        activeSessions.unregister(newId);
       };
 
       reply.hijack();

--- a/packages/server/src/modules/agents/routes/agents-online.routes.ts
+++ b/packages/server/src/modules/agents/routes/agents-online.routes.ts
@@ -1,0 +1,78 @@
+/**
+ * Live MCP-session indicators consumed by the sidebar's "agents online"
+ * footer. Two endpoints, both session-authenticated:
+ *
+ *   GET /api/agents/online        → { count, clients: [{ name, transport, sessionId }] }
+ *   GET /api/agents/mcp-health    → { status: "ok" }
+ *
+ * `mcp-health` is a trivial reachability probe — the MCP module is part of
+ * the same Fastify app, so if this route responds the MCP transport plugin
+ * is necessarily registered. Surfacing it as its own URL lets the client
+ * poll a stable endpoint independent of any specific MCP request shape.
+ */
+import type { FastifyPluginAsync } from "fastify";
+import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { z } from "zod";
+import * as activeSessions from "../mcp/active-sessions.js";
+
+const clientSchema = z.object({
+  sessionId: z.string(),
+  name: z.string().nullable(),
+  version: z.string().nullable(),
+  transport: z.enum(["sse", "streamable"]),
+  startedAt: z.number(),
+  lastActivity: z.number(),
+});
+
+const onlineSchema = z.object({
+  count: z.number().int().nonnegative(),
+  clients: z.array(clientSchema),
+});
+
+const healthSchema = z.object({
+  status: z.literal("ok"),
+});
+
+export const agentsOnlineRoutes: FastifyPluginAsync = async (app) => {
+  const typed = app.withTypeProvider<ZodTypeProvider>();
+
+  typed.get(
+    "/online",
+    {
+      preHandler: [async (req) => { await app.auth.requireUser(req); }],
+      schema: {
+        tags: ["agents"],
+        summary: "List MCP sessions currently connected for the calling user",
+        response: { 200: onlineSchema },
+      },
+    },
+    async (req) => {
+      const user = await app.auth.requireUser(req);
+      const sessions = activeSessions.listForUser(user.id);
+      return {
+        count: sessions.length,
+        clients: sessions.map((s) => ({
+          sessionId: s.sessionId,
+          name: s.clientName ?? null,
+          version: s.clientVersion ?? null,
+          transport: s.transport,
+          startedAt: s.startedAt,
+          lastActivity: s.lastActivity,
+        })),
+      };
+    },
+  );
+
+  typed.get(
+    "/mcp-health",
+    {
+      preHandler: [async (req) => { await app.auth.requireUser(req); }],
+      schema: {
+        tags: ["agents"],
+        summary: "MCP transport reachability probe",
+        response: { 200: healthSchema },
+      },
+    },
+    async () => ({ status: "ok" as const }),
+  );
+};

--- a/packages/server/src/modules/notes/index.ts
+++ b/packages/server/src/modules/notes/index.ts
@@ -3,6 +3,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { backfillFolders } from "./services/backfill/folders-backfill.js";
 import { backfillTags } from "./services/backfill/tags-backfill.js";
 import { reconcileSearchIndex } from "./services/backfill/search-index-reconcile.js";
+import { ensureNotesWatcher } from "./services/notes-watcher.js";
 import { NoteService } from "./services/note.service.js";
 import { getUserNotesDir } from "./services/user-notes-dir.service.js";
 import {
@@ -98,10 +99,14 @@ export const notesModule: FastifyPluginAsync = async (app) => {
       await backfillFolders(app, notesDir, userId);
       await backfillTags(app, userId);
       // Drop searchIndex/graphEdge rows for notes that no longer exist on
-      // disk — keeps the graph view from rendering phantom nodes when the
-      // notes dir was rebased, the user deleted files out-of-band, or a
-      // dev worktree points at a different notes root.
+      // disk — handles the cold-start case where the notes dir was rebased,
+      // the user deleted files out-of-band, or a dev worktree points at a
+      // different notes root.
       await reconcileSearchIndex(app, notesDir, userId);
+      // Start a live chokidar watcher so subsequent out-of-band changes
+      // (filesystem rm, Finder, git checkout) keep the index in sync
+      // without the user having to restart the server.
+      await ensureNotesWatcher(app, notesDir, userId);
     } catch (err) {
       // Non-fatal: log and allow retry on the next request.
       app.log.warn({ err, userId }, "backfill failed for user");
@@ -110,6 +115,31 @@ export const notesModule: FastifyPluginAsync = async (app) => {
   };
 
   const deps = { notesDir, noteService, ensureBackfilled };
+
+  // Warm-start watchers + reconcile for every existing user dir at boot so
+  // out-of-band changes (filesystem rm, git checkout, manual edit) are
+  // picked up without requiring the user to send a request first. Without
+  // this, a file dropped on disk before the user reloads the UI would sit
+  // unindexed until ensureBackfilled fires on their first authenticated call.
+  app.addHook("onReady", async () => {
+    try {
+      const fs = await import("node:fs/promises");
+      let entries: { name: string; isDirectory: () => boolean }[];
+      try {
+        entries = await fs.readdir(notesDir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name.startsWith(".")) continue;
+        // Schedule but don't block onReady — backfill+reconcile can be slow.
+        void ensureBackfilled(entry.name);
+      }
+    } catch (err) {
+      app.log.warn({ err }, "warm-start watchers failed");
+    }
+  });
 
   // Mount shared-notes BEFORE /api/notes so the prefix is matched first.
   await app.register(sharedNotesRoutes(deps), { prefix: "/api/notes/shared" });

--- a/packages/server/src/modules/notes/index.ts
+++ b/packages/server/src/modules/notes/index.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import type { FastifyPluginAsync } from "fastify";
 import { backfillFolders } from "./services/backfill/folders-backfill.js";
 import { backfillTags } from "./services/backfill/tags-backfill.js";
+import { reconcileSearchIndex } from "./services/backfill/search-index-reconcile.js";
 import { NoteService } from "./services/note.service.js";
 import { getUserNotesDir } from "./services/user-notes-dir.service.js";
 import {
@@ -96,6 +97,11 @@ export const notesModule: FastifyPluginAsync = async (app) => {
     try {
       await backfillFolders(app, notesDir, userId);
       await backfillTags(app, userId);
+      // Drop searchIndex/graphEdge rows for notes that no longer exist on
+      // disk — keeps the graph view from rendering phantom nodes when the
+      // notes dir was rebased, the user deleted files out-of-band, or a
+      // dev worktree points at a different notes root.
+      await reconcileSearchIndex(app, notesDir, userId);
     } catch (err) {
       // Non-fatal: log and allow retry on the next request.
       app.log.warn({ err, userId }, "backfill failed for user");

--- a/packages/server/src/modules/notes/services/backfill/search-index-reconcile.ts
+++ b/packages/server/src/modules/notes/services/backfill/search-index-reconcile.ts
@@ -1,0 +1,72 @@
+/**
+ * Drop SearchIndex rows whose underlying .md file no longer exists on disk.
+ * Without this, deleting a note out-of-band (filesystem rm, dev worktree
+ * pointing at a different notes/ root, etc.) leaves phantom graph nodes
+ * and tag entries that never go away — the user sees "6 graph nodes" when
+ * their tree only has 2.
+ *
+ * Cheap to run: one Prisma read per user (their searchIndex rows), one
+ * fs.stat per row, then a single deleteMany. Called once per user per
+ * process from `ensureBackfilled`.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { FastifyInstance } from "fastify";
+
+export async function reconcileSearchIndex(
+  app: FastifyInstance,
+  notesRoot: string,
+  userId: string,
+): Promise<number> {
+  const userRoot = path.join(notesRoot, userId);
+  let exists = false;
+  try {
+    const s = await fs.stat(userRoot);
+    exists = s.isDirectory();
+  } catch {
+    // User dir missing; treat every searchIndex row as stale.
+  }
+
+  const rows = await app.prisma.searchIndex.findMany({
+    where: { userId },
+    select: { notePath: true },
+  });
+  if (rows.length === 0) return 0;
+
+  // If the user has no notes dir at all, drop every row.
+  if (!exists) {
+    await app.prisma.searchIndex.deleteMany({ where: { userId } });
+    // Mirror onto graphEdge so half-pruned graphs don't carry stale edges.
+    await app.prisma.graphEdge.deleteMany({ where: { userId } });
+    return rows.length;
+  }
+
+  const stale: string[] = [];
+  for (const r of rows) {
+    const full = path.join(userRoot, r.notePath);
+    try {
+      await fs.stat(full);
+    } catch {
+      stale.push(r.notePath);
+    }
+  }
+  if (stale.length === 0) return 0;
+
+  // Delete in one round-trip. graphEdge rows reference notePath via
+  // fromPath/toPath; clear the stale endpoints there too so the graph
+  // doesn't render dangling edges.
+  await app.prisma.$transaction([
+    app.prisma.searchIndex.deleteMany({
+      where: { userId, notePath: { in: stale } },
+    }),
+    app.prisma.graphEdge.deleteMany({
+      where: { userId, OR: [{ fromPath: { in: stale } }, { toPath: { in: stale } }] },
+    }),
+  ]);
+
+  app.log.info(
+    { userId, removed: stale.length },
+    "reconciled stale searchIndex rows against disk",
+  );
+  return stale.length;
+}

--- a/packages/server/src/modules/notes/services/notes-watcher.ts
+++ b/packages/server/src/modules/notes/services/notes-watcher.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-user notes-directory watcher.
+ *
+ * Keeps the SearchIndex and GraphEdge tables in sync with the filesystem
+ * regardless of how files were added or removed (UI, MCP, git, manual rm,
+ * Finder, etc.). The startup reconcile (`reconcileSearchIndex`) handles the
+ * cold-start case; this watcher handles everything that happens *while* the
+ * server is running.
+ *
+ * One chokidar watcher per user-dir, started lazily on first request to that
+ * user. Watches `<notesRoot>/<userId>` recursively, debouncing fs noise.
+ *
+ * Events:
+ *   add / change  → read file content, call knowledge.indexNote +
+ *                   knowledge.updateGraphCache.
+ *   unlink        → call knowledge.removeFromIndex + knowledge.removeFromGraph.
+ *   addDir / unlinkDir → ignored; folder rows are reconstructed by the
+ *                   folders backfill on demand, and an empty folder has no
+ *                   indexable content anyway.
+ *
+ * The watcher silently ignores anything under `.history/`, `.trash/`, or any
+ * other dot-prefixed directory — those carry stale snapshots we don't want
+ * in the live index.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import chokidar, { type FSWatcher } from "chokidar";
+import type { FastifyInstance } from "fastify";
+
+interface WatcherEntry {
+  watcher: FSWatcher;
+  /** Best-effort timer so a rapid add+change pair only indexes once. */
+  pending: Map<string, NodeJS.Timeout>;
+}
+
+const watchers = new Map<string, WatcherEntry>();
+
+/** Path relative to a user's notes root, with normalized separators. */
+function relPath(userRoot: string, full: string): string | null {
+  const rel = path.relative(userRoot, full).split(path.sep).join("/");
+  if (!rel || rel.startsWith("..")) return null;
+  return rel;
+}
+
+/** Ignore anything under dot-prefixed dirs (.history/, .trash/, .git/, …). */
+function isIgnored(rel: string): boolean {
+  return rel.split("/").some((seg) => seg.startsWith("."));
+}
+
+/**
+ * Ensure a watcher is running for `userId`. Idempotent: calling it again is a
+ * no-op. Returns a Promise that resolves once chokidar's initial scan
+ * finishes so callers can rely on "everything currently on disk has been
+ * acknowledged" before continuing if they need that guarantee.
+ */
+export async function ensureNotesWatcher(
+  app: FastifyInstance,
+  notesRoot: string,
+  userId: string,
+): Promise<void> {
+  if (watchers.has(userId)) return;
+  const userRoot = path.join(notesRoot, userId);
+
+  try {
+    const s = await fs.stat(userRoot);
+    if (!s.isDirectory()) return;
+  } catch {
+    // Dir doesn't exist yet — first note save will create it; the next
+    // ensureNotesWatcher call from `ensureBackfilled` will see it and start.
+    return;
+  }
+
+  const knowledge = app.knowledge;
+
+  const watcher = chokidar.watch(userRoot, {
+    ignored: (full) => {
+      const rel = relPath(userRoot, full);
+      return rel !== null && isIgnored(rel);
+    },
+    ignoreInitial: true, // startup reconcile handles cold state
+    persistent: true,
+    awaitWriteFinish: { stabilityThreshold: 120, pollInterval: 40 },
+  });
+
+  const entry: WatcherEntry = { watcher, pending: new Map() };
+  watchers.set(userId, entry);
+
+  const reindex = async (full: string): Promise<void> => {
+    const rel = relPath(userRoot, full);
+    if (!rel || isIgnored(rel) || !rel.endsWith(".md")) return;
+    try {
+      const content = await fs.readFile(full, "utf-8");
+      await knowledge.indexNote(rel, content, userId);
+      await knowledge.updateGraph(rel, content, userId);
+    } catch (err) {
+      app.log.warn({ err, userId, path: rel }, "notes-watcher: reindex failed");
+    }
+  };
+
+  const debounce = (full: string): void => {
+    const rel = relPath(userRoot, full);
+    if (!rel) return;
+    const existing = entry.pending.get(rel);
+    if (existing) clearTimeout(existing);
+    const t = setTimeout(() => {
+      entry.pending.delete(rel);
+      void reindex(full);
+    }, 150);
+    entry.pending.set(rel, t);
+  };
+
+  const drop = async (full: string): Promise<void> => {
+    const rel = relPath(userRoot, full);
+    if (!rel || isIgnored(rel) || !rel.endsWith(".md")) return;
+    try {
+      await knowledge.removeFromIndex(rel, userId);
+      await knowledge.removeFromGraph(rel, userId);
+    } catch (err) {
+      app.log.warn({ err, userId, path: rel }, "notes-watcher: remove failed");
+    }
+  };
+
+  watcher.on("add", debounce);
+  watcher.on("change", debounce);
+  watcher.on("unlink", (full) => {
+    const rel = relPath(userRoot, full);
+    if (rel) {
+      const t = entry.pending.get(rel);
+      if (t) {
+        clearTimeout(t);
+        entry.pending.delete(rel);
+      }
+    }
+    void drop(full);
+  });
+  watcher.on("error", (err) => {
+    app.log.warn({ err, userId }, "notes-watcher: error");
+  });
+
+  // Close cleanly on app shutdown so the test harness and graceful restarts
+  // don't leak FDs.
+  app.addHook("onClose", async () => {
+    await stopNotesWatcher(userId);
+  });
+}
+
+export async function stopNotesWatcher(userId: string): Promise<void> {
+  const entry = watchers.get(userId);
+  if (!entry) return;
+  watchers.delete(userId);
+  for (const t of entry.pending.values()) clearTimeout(t);
+  entry.pending.clear();
+  try {
+    await entry.watcher.close();
+  } catch {
+    // best-effort
+  }
+}

--- a/packages/ui/src/editor/EditorToolbar.tsx
+++ b/packages/ui/src/editor/EditorToolbar.tsx
@@ -55,6 +55,10 @@ export interface EditorToolbarProps {
   className?: string;
 }
 
+/** Delay before the custom tooltip appears, in ms. Native `title` defaults
+ *  to ~1.5s which is too slow for a dense icon row. */
+const TOOLTIP_DELAY_MS = 250;
+
 function ToolbarButton({
   icon: Icon,
   title,
@@ -67,36 +71,79 @@ function ToolbarButton({
   active?: boolean;
 }) {
   const [hover, setHover] = React.useState(false);
+  const [showTip, setShowTip] = React.useState(false);
+  const tipTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const tinted = active || hover;
+
+  const beginTipTimer = (): void => {
+    if (tipTimerRef.current) clearTimeout(tipTimerRef.current);
+    tipTimerRef.current = setTimeout(() => setShowTip(true), TOOLTIP_DELAY_MS);
+  };
+  const cancelTip = (): void => {
+    if (tipTimerRef.current) {
+      clearTimeout(tipTimerRef.current);
+      tipTimerRef.current = null;
+    }
+    setShowTip(false);
+  };
+  React.useEffect(() => () => cancelTip(), []);
+
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      aria-label={title}
-      aria-pressed={active}
-      title={title}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        width: 28,
-        height: 28,
-        borderRadius: 6,
-        background: active
-          ? "var(--accent-soft)"
-          : hover
-            ? "var(--bg-hover)"
-            : "transparent",
-        color: tinted ? "var(--accent)" : "var(--fg-3)",
-        border: "none",
-        cursor: "pointer",
-        transition: "background 120ms, color 120ms",
-      }}
-    >
-      <Icon size={15} aria-hidden="true" />
-    </button>
+    <span style={{ position: "relative", display: "inline-flex" }}>
+      <button
+        type="button"
+        onClick={() => { cancelTip(); onClick(); }}
+        onMouseEnter={() => { setHover(true); beginTipTimer(); }}
+        onMouseLeave={() => { setHover(false); cancelTip(); }}
+        onFocus={beginTipTimer}
+        onBlur={cancelTip}
+        aria-label={title}
+        aria-pressed={active}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 28,
+          height: 28,
+          borderRadius: 6,
+          background: active
+            ? "var(--accent-soft)"
+            : hover
+              ? "var(--bg-hover)"
+              : "transparent",
+          color: tinted ? "var(--accent)" : "var(--fg-3)",
+          border: "none",
+          cursor: "pointer",
+          transition: "background 120ms, color 120ms",
+        }}
+      >
+        <Icon size={15} aria-hidden="true" />
+      </button>
+      {showTip && (
+        <span
+          role="tooltip"
+          style={{
+            position: "absolute",
+            top: "calc(100% + 6px)",
+            left: "50%",
+            transform: "translateX(-50%)",
+            padding: "4px 8px",
+            borderRadius: 4,
+            background: "var(--bg-2)",
+            border: "1px solid var(--line)",
+            color: "var(--fg)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            whiteSpace: "nowrap",
+            pointerEvents: "none",
+            zIndex: 50,
+            boxShadow: "var(--shadow-md)",
+          }}
+        >
+          {title}
+        </span>
+      )}
+    </span>
   );
 }
 

--- a/packages/ui/src/editor/EditorToolbar.tsx
+++ b/packages/ui/src/editor/EditorToolbar.tsx
@@ -1,3 +1,15 @@
+/**
+ * EditorToolbar — formatting action bar for the NoteEditor.
+ *
+ * Decoupled from any specific editor engine: it fires `onCommand(commandName)`
+ * and consumers wire it to CodeMirror, a contenteditable, or an iframe-based
+ * editor. Includes a view-mode toggle (edit / split / preview).
+ *
+ * Styling matches the rest of the Kryton chrome — `--bg-1` surface with a
+ * `--line` bottom border, 36px tall, mono iconography, `--accent` hover tint.
+ * Tooltips come from the native `title` attribute and adapt to the OS
+ * (`⌘B` on macOS, `Ctrl+B` everywhere else).
+ */
 import * as React from "react";
 import {
   Bold,
@@ -21,27 +33,24 @@ import {
   Eye,
   Pencil,
 } from "lucide-react";
-import { cn } from "../lib/utils";
 
 export type ViewMode = "edit" | "preview" | "split";
 
+const IS_MAC =
+  typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac");
+const MOD = IS_MAC ? "⌘" : "Ctrl";
+const SHIFT = IS_MAC ? "⇧" : "Shift";
+const SEP = IS_MAC ? "" : "+";
+
+/** Format a keyboard shortcut hint for tooltips. */
+function kbd(...parts: string[]): string {
+  return parts.join(SEP);
+}
+
 export interface EditorToolbarProps {
-  /**
-   * Called when a formatting action should be applied. Receives a command
-   * string that consumers can map to their editor instance.
-   *
-   * Commands: `"bold"`, `"italic"`, `"strikethrough"`, `"code"`, `"link"`,
-   * `"image"`, `"heading1"`, `"heading2"`, `"heading3"`, `"ul"`, `"ol"`,
-   * `"checkbox"`, `"blockquote"`, `"hr"`, `"table"`, `"undo"`, `"redo"`.
-   */
   onCommand: (command: string) => void;
-  /**
-   * Called when the user requests a file upload (e.g. pasted/dropped image).
-   */
   onUploadImage?: (file: File) => void;
-  /** Current view mode. */
   viewMode?: ViewMode;
-  /** Called when the user toggles the view mode. */
   onViewModeChange?: (mode: ViewMode) => void;
   className?: string;
 }
@@ -57,18 +66,34 @@ function ToolbarButton({
   onClick: () => void;
   active?: boolean;
 }) {
+  const [hover, setHover] = React.useState(false);
+  const tinted = active || hover;
   return (
     <button
       type="button"
       onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
       aria-label={title}
+      aria-pressed={active}
       title={title}
-      className={cn(
-        "rounded p-1.5 transition-colors",
-        active
-          ? "bg-violet-500/20 text-violet-400"
-          : "text-gray-400 hover:bg-gray-700/50 hover:text-gray-200",
-      )}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 28,
+        height: 28,
+        borderRadius: 6,
+        background: active
+          ? "var(--accent-soft)"
+          : hover
+            ? "var(--bg-hover)"
+            : "transparent",
+        color: tinted ? "var(--accent)" : "var(--fg-3)",
+        border: "none",
+        cursor: "pointer",
+        transition: "background 120ms, color 120ms",
+      }}
     >
       <Icon size={15} aria-hidden="true" />
     </button>
@@ -76,16 +101,19 @@ function ToolbarButton({
 }
 
 function ToolbarSep() {
-  return <div className="mx-0.5 h-4 w-px bg-gray-700/50" aria-hidden="true" />;
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        width: 1,
+        height: 18,
+        margin: "0 6px",
+        background: "var(--line)",
+      }}
+    />
+  );
 }
 
-/**
- * EditorToolbar — formatting action bar for the NoteEditor.
- *
- * Decoupled from any specific editor engine: it fires `onCommand(commandName)`
- * and consumers wire it to CodeMirror, a contenteditable, or an iframe-based
- * editor. Includes a view-mode toggle (edit / split / preview).
- */
 export function EditorToolbar({
   onCommand,
   onUploadImage,
@@ -106,26 +134,34 @@ export function EditorToolbar({
 
   return (
     <div
-      className={cn(
-        "flex shrink-0 flex-wrap items-center gap-0.5 border-b border-gray-700/50 bg-surface-900/80 px-2 py-1",
-        className,
-      )}
+      className={className}
       role="toolbar"
       aria-label="Editor formatting toolbar"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        flexShrink: 0,
+        gap: 4,
+        height: 36,
+        padding: "0 8px",
+        background: "var(--bg-1)",
+        borderBottom: "1px solid var(--line)",
+      }}
     >
       {/* Hidden file input for image upload */}
       <input
         ref={fileInputRef}
         type="file"
         accept="image/*"
-        className="hidden"
+        style={{ display: "none" }}
         onChange={handleFileChange}
         aria-hidden="true"
       />
 
       {/* History */}
-      <ToolbarButton icon={Undo2} title="Undo (Ctrl+Z)" onClick={() => onCommand("undo")} />
-      <ToolbarButton icon={Redo2} title="Redo (Ctrl+Shift+Z)" onClick={() => onCommand("redo")} />
+      <ToolbarButton icon={Undo2} title={`Undo (${kbd(MOD, "Z")})`} onClick={() => onCommand("undo")} />
+      <ToolbarButton icon={Redo2} title={`Redo (${kbd(MOD, SHIFT, "Z")})`} onClick={() => onCommand("redo")} />
       <ToolbarSep />
 
       {/* Headings */}
@@ -135,8 +171,8 @@ export function EditorToolbar({
       <ToolbarSep />
 
       {/* Inline formatting */}
-      <ToolbarButton icon={Bold} title="Bold (Ctrl+B)" onClick={() => onCommand("bold")} />
-      <ToolbarButton icon={Italic} title="Italic (Ctrl+I)" onClick={() => onCommand("italic")} />
+      <ToolbarButton icon={Bold} title={`Bold (${kbd(MOD, "B")})`} onClick={() => onCommand("bold")} />
+      <ToolbarButton icon={Italic} title={`Italic (${kbd(MOD, "I")})`} onClick={() => onCommand("italic")} />
       <ToolbarButton icon={Strikethrough} title="Strikethrough" onClick={() => onCommand("strikethrough")} />
       <ToolbarButton icon={Code} title="Inline code" onClick={() => onCommand("code")} />
       <ToolbarSep />
@@ -156,7 +192,7 @@ export function EditorToolbar({
       {/* Lists */}
       <ToolbarButton icon={List} title="Bullet list" onClick={() => onCommand("ul")} />
       <ToolbarButton icon={ListOrdered} title="Numbered list" onClick={() => onCommand("ol")} />
-      <ToolbarButton icon={CheckSquare} title="Checkbox" onClick={() => onCommand("checkbox")} />
+      <ToolbarButton icon={CheckSquare} title="Task list" onClick={() => onCommand("checkbox")} />
       <ToolbarSep />
 
       {/* Block formatting */}
@@ -167,7 +203,7 @@ export function EditorToolbar({
       {/* View mode toggle */}
       {onViewModeChange && (
         <>
-          <div className="flex-1" />
+          <div style={{ flex: 1 }} />
           <ToolbarButton
             icon={Pencil}
             title="Edit mode"

--- a/packages/ui/src/graph/layout/forceLayout.ts
+++ b/packages/ui/src/graph/layout/forceLayout.ts
@@ -52,8 +52,24 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
     });
   }
 
+  // Soft anchor: nudge every node toward the origin proportional to its
+  // distance. With pure repulsion, isolated/unconnected nodes drift outward
+  // forever; this gives them a weak return spring so the cluster stays
+  // compact without overpowering the link-driven layout.
+  const ANCHOR_STRENGTH = 0.005;
+  function applyAnchor() {
+    graph.forEachNode((node) => {
+      const id = node.id as string;
+      const body = layout.getBody(id);
+      if (!body || body.isPinned) return;
+      body.velocity.x -= body.pos.x * ANCHOR_STRENGTH;
+      body.velocity.y -= body.pos.y * ANCHOR_STRENGTH;
+    });
+  }
+
   const handle: LayoutHandle = {
     step() {
+      applyAnchor();
       layout.step();
       recentre();
       for (const id of pinned) {

--- a/packages/ui/src/graph/layout/forceLayout.ts
+++ b/packages/ui/src/graph/layout/forceLayout.ts
@@ -27,34 +27,20 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
 
   const pinned = new Set<string>();
 
-  // Mutable active id — `setActive(...)` updates this without recreating the
-  // layout, so existing positions survive the swap and the cluster morphs
-  // smoothly around the new pin.
-  let activeId: string | null = input.activeId ?? null;
-
-  // Pin the active note at the origin so every layout pass orbits around it.
-  // The pinned node never moves; everything else relaxes around it under
-  // spring + repulsion + the soft anchor below.
-  if (activeId) {
-    const body = layout.getBody(activeId);
-    if (body) {
-      body.pos.x = 0;
-      body.pos.y = 0;
-      body.isPinned = true;
-      pinned.add(activeId);
-    }
-  }
+  // No active-pin: the simulation runs with every node free. The active
+  // note is purely a *camera* concept — the GraphView render loop pans
+  // the viewport to keep it on screen. Pinning the active produced
+  // spider-web tugging when selection swapped the pin, because every
+  // connected spring suddenly had a new fixed endpoint to react to.
+  void input.activeId;
 
   // ngraph's gravity is pure repulsion; with no edges or sparse graphs the
   // cluster's centre of mass drifts. After every step we shift positions so
   // the *anchor* stays at (0, 0) — that's the active note when one is
   // selected (so the active stays dead-centre), or the centroid otherwise.
-  // Recentre keeps the cluster centred on world (0, 0) when there's NO active
-  // note. With an active note the camera (in GraphView) tracks the active's
-  // world position instead — shifting positions here would teleport every
-  // body each frame, defeating the morph.
+  // Keep the cluster centred on world (0, 0) so the camera has a stable
+  // anchor regardless of which node is "active" (active is camera-only now).
   function recentre() {
-    if (activeId) return;
     let sx = 0, sy = 0, count = 0;
     graph.forEachNode((node) => {
       const body = layout.getBody(node.id as string);
@@ -136,29 +122,10 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
         body.velocity.y += (Math.random() - 0.5) * alpha * 50;
       });
     },
-    setActive(id) {
-      // Release the previous pin (if any) so its body becomes a free
-      // particle again — spring + repulsion will push it away from the
-      // new focus naturally as the cluster reorganises.
-      if (activeId) {
-        const prev = layout.getBody(activeId);
-        if (prev) prev.isPinned = false;
-        pinned.delete(activeId);
-      }
-      activeId = id;
-      if (!id) return;
-      // Pin the new active *where it currently sits* — no teleport. The
-      // camera (in GraphView) follows the active's world position each
-      // frame, so as connected nodes pull closer (springs) and unrelated
-      // ones drift away (repulsion), the user sees the existing graph
-      // morph and the camera glide to the new focus, instead of a fresh
-      // layout snap.
-      const body = layout.getBody(id);
-      if (!body) return;
-      body.isPinned = true;
-      body.velocity.x = 0;
-      body.velocity.y = 0;
-      pinned.add(id);
+    setActive() {
+      // No-op for the force layout — active is purely a camera concept.
+      // The render loop pans the viewport to follow the active note's
+      // current position; the layout itself doesn't restructure.
     },
     setBounds() {
       // Force-directed global mode is bounds-agnostic; the camera handles

--- a/packages/ui/src/graph/layout/forceLayout.ts
+++ b/packages/ui/src/graph/layout/forceLayout.ts
@@ -12,10 +12,14 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
   for (const n of input.nodes) graph.addNode(n.id, { ...n });
   for (const e of input.edges) graph.addLink(e.fromNoteId, e.toNoteId);
 
+  // ngraph convention: gravity NEGATIVE = repulsion, POSITIVE = attraction.
+  // Our config uses d3-style chargeStrength (-400 = strong repulsion); divide
+  // it down to ngraph's scale (~-12 default) and keep the sign so nodes
+  // actually push apart instead of collapsing onto the centroid.
   const layout = createLayout(graph, {
     springLength: cfg.linkDistance,
     springCoefficient: 0.0008,
-    gravity: cfg.chargeStrength * -1, // ngraph: positive gravity = repulsion
+    gravity: cfg.chargeStrength / 30,
     theta: 0.8,
     dragCoefficient: 0.02,
     timeStep: 20,

--- a/packages/ui/src/graph/layout/forceLayout.ts
+++ b/packages/ui/src/graph/layout/forceLayout.ts
@@ -27,26 +27,47 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
 
   const pinned = new Set<string>();
 
+  // Pin the active note at the origin so every layout pass orbits around it.
+  // The active node never moves; everything else relaxes around it under
+  // spring + repulsion + the soft anchor below. Selecting a different note
+  // disposes the layout (in GraphView.web.tsx) and we get a fresh handle.
+  if (input.activeId) {
+    const body = layout.getBody(input.activeId);
+    if (body) {
+      body.pos.x = 0;
+      body.pos.y = 0;
+      body.isPinned = true;
+      pinned.add(input.activeId);
+    }
+  }
+
   // ngraph's gravity is pure repulsion; with no edges or sparse graphs the
-  // cluster's centre of mass drifts and falls off-screen. After every step,
-  // shift all unpinned positions so the centroid stays at (0, 0). This is
-  // gentle (relative offsets between nodes are preserved) and gives consumers
-  // a stable bbox to fit the camera against.
+  // cluster's centre of mass drifts. After every step we shift positions so
+  // the *anchor* stays at (0, 0) — that's the active note when one is
+  // selected (so the active stays dead-centre), or the centroid otherwise.
   function recentre() {
-    let sx = 0, sy = 0, count = 0;
-    graph.forEachNode((node) => {
-      const id = node.id as string;
-      const body = layout.getBody(id);
-      if (!body) return;
-      sx += body.pos.x; sy += body.pos.y; count++;
-    });
-    if (count === 0) return;
-    const dx = sx / count, dy = sy / count;
+    let dx = 0, dy = 0;
+    if (input.activeId) {
+      const anchorBody = layout.getBody(input.activeId);
+      if (!anchorBody) return;
+      dx = anchorBody.pos.x;
+      dy = anchorBody.pos.y;
+    } else {
+      let sx = 0, sy = 0, count = 0;
+      graph.forEachNode((node) => {
+        const body = layout.getBody(node.id as string);
+        if (!body) return;
+        sx += body.pos.x; sy += body.pos.y; count++;
+      });
+      if (count === 0) return;
+      dx = sx / count;
+      dy = sy / count;
+    }
     if (dx === 0 && dy === 0) return;
     graph.forEachNode((node) => {
       const id = node.id as string;
       const body = layout.getBody(id);
-      if (!body || body.isPinned) return;
+      if (!body) return;
       body.pos.x -= dx;
       body.pos.y -= dy;
     });

--- a/packages/ui/src/graph/layout/forceLayout.ts
+++ b/packages/ui/src/graph/layout/forceLayout.ts
@@ -27,17 +27,21 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
 
   const pinned = new Set<string>();
 
+  // Mutable active id — `setActive(...)` updates this without recreating the
+  // layout, so existing positions survive the swap and the cluster morphs
+  // smoothly around the new pin.
+  let activeId: string | null = input.activeId ?? null;
+
   // Pin the active note at the origin so every layout pass orbits around it.
-  // The active node never moves; everything else relaxes around it under
-  // spring + repulsion + the soft anchor below. Selecting a different note
-  // disposes the layout (in GraphView.web.tsx) and we get a fresh handle.
-  if (input.activeId) {
-    const body = layout.getBody(input.activeId);
+  // The pinned node never moves; everything else relaxes around it under
+  // spring + repulsion + the soft anchor below.
+  if (activeId) {
+    const body = layout.getBody(activeId);
     if (body) {
       body.pos.x = 0;
       body.pos.y = 0;
       body.isPinned = true;
-      pinned.add(input.activeId);
+      pinned.add(activeId);
     }
   }
 
@@ -45,29 +49,25 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
   // cluster's centre of mass drifts. After every step we shift positions so
   // the *anchor* stays at (0, 0) — that's the active note when one is
   // selected (so the active stays dead-centre), or the centroid otherwise.
+  // Recentre keeps the cluster centred on world (0, 0) when there's NO active
+  // note. With an active note the camera (in GraphView) tracks the active's
+  // world position instead — shifting positions here would teleport every
+  // body each frame, defeating the morph.
   function recentre() {
-    let dx = 0, dy = 0;
-    if (input.activeId) {
-      const anchorBody = layout.getBody(input.activeId);
-      if (!anchorBody) return;
-      dx = anchorBody.pos.x;
-      dy = anchorBody.pos.y;
-    } else {
-      let sx = 0, sy = 0, count = 0;
-      graph.forEachNode((node) => {
-        const body = layout.getBody(node.id as string);
-        if (!body) return;
-        sx += body.pos.x; sy += body.pos.y; count++;
-      });
-      if (count === 0) return;
-      dx = sx / count;
-      dy = sy / count;
-    }
+    if (activeId) return;
+    let sx = 0, sy = 0, count = 0;
+    graph.forEachNode((node) => {
+      const body = layout.getBody(node.id as string);
+      if (!body) return;
+      sx += body.pos.x; sy += body.pos.y; count++;
+    });
+    if (count === 0) return;
+    const dx = sx / count, dy = sy / count;
     if (dx === 0 && dy === 0) return;
     graph.forEachNode((node) => {
       const id = node.id as string;
       const body = layout.getBody(id);
-      if (!body) return;
+      if (!body || body.isPinned) return;
       body.pos.x -= dx;
       body.pos.y -= dy;
     });
@@ -135,6 +135,30 @@ export function createForceLayout(input: LayoutInput): LayoutHandle {
         body.velocity.x += (Math.random() - 0.5) * alpha * 50;
         body.velocity.y += (Math.random() - 0.5) * alpha * 50;
       });
+    },
+    setActive(id) {
+      // Release the previous pin (if any) so its body becomes a free
+      // particle again — spring + repulsion will push it away from the
+      // new focus naturally as the cluster reorganises.
+      if (activeId) {
+        const prev = layout.getBody(activeId);
+        if (prev) prev.isPinned = false;
+        pinned.delete(activeId);
+      }
+      activeId = id;
+      if (!id) return;
+      // Pin the new active *where it currently sits* — no teleport. The
+      // camera (in GraphView) follows the active's world position each
+      // frame, so as connected nodes pull closer (springs) and unrelated
+      // ones drift away (repulsion), the user sees the existing graph
+      // morph and the camera glide to the new focus, instead of a fresh
+      // layout snap.
+      const body = layout.getBody(id);
+      if (!body) return;
+      body.isPinned = true;
+      body.velocity.x = 0;
+      body.velocity.y = 0;
+      pinned.add(id);
     },
     setBounds() {
       // Force-directed global mode is bounds-agnostic; the camera handles

--- a/packages/ui/src/graph/layout/index.ts
+++ b/packages/ui/src/graph/layout/index.ts
@@ -1,11 +1,17 @@
 import type { LayoutHandle, LayoutInput } from "./types";
 import { createForceLayout } from "./forceLayout";
-import { createLocalLayout } from "./localLayout";
 
 export type { LayoutHandle, LayoutInput, LayoutMode, NodePosition } from "./types";
 export { createForceLayout } from "./forceLayout";
 export { createLocalLayout } from "./localLayout";
 
+/**
+ * Both `global` and `local` modes share the same force-directed layout —
+ * they only differ in display: drawScene ghosts non-set nodes/edges in
+ * local mode (see graph.jsx ~lines 53-81 for the bible's intent). Using a
+ * single layout means switching mode or selecting a note never restructures
+ * positions, so the cluster doesn't snap or vibrate.
+ */
 export function createLayout(input: LayoutInput): LayoutHandle {
-  return input.mode === "local" ? createLocalLayout(input) : createForceLayout(input);
+  return createForceLayout(input);
 }

--- a/packages/ui/src/graph/layout/localLayout.ts
+++ b/packages/ui/src/graph/layout/localLayout.ts
@@ -140,6 +140,13 @@ export function createLocalLayout(input: LayoutInput): LayoutHandle {
         n.angle += (Math.random() - 0.5) * 0.2;
       }
     },
+    setActive() {
+      // Local layout is structurally rebuilt from the active id at create
+      // time (concentric rings around the active). Switching the active
+      // requires a full rebuild — the GraphView layout effect handles that
+      // by disposing and recreating when graphData/mode change. We expose
+      // a no-op here so the LayoutHandle interface stays uniform.
+    },
     setBounds(w, h) {
       cx = w / 2;
       cy = h / 2;

--- a/packages/ui/src/graph/layout/types.ts
+++ b/packages/ui/src/graph/layout/types.ts
@@ -34,6 +34,13 @@ export interface LayoutHandle {
   unpin(id: string): void;
   /** Inject kinetic energy after a structural change. */
   reheat(alpha: number): void;
+  /**
+   * Switch the pinned/anchor node without recreating the layout. Existing
+   * positions are preserved so the cluster morphs smoothly toward the new
+   * equilibrium instead of snapping to a fresh random init. Pass null to
+   * release the current pin (no node anchored).
+   */
+  setActive(id: string | null): void;
   /** Update viewport bounds; the layout may rescale ring radii etc. */
   setBounds(width: number, height: number): void;
   /** Tear down internal state, free references. */

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -22,11 +22,14 @@ export interface GraphViewProps {
   recenterRef?: React.MutableRefObject<(() => void) | null>;
   starredPaths?: Set<string>;
   className?: string;
+  /** When true, render every node's label (fullscreen graph view). Defaults to false (rail mode shows labels only on active/hover). */
+  showAllLabels?: boolean;
 }
 
 export function GraphView({
   graphData, loading = false, activeNotePath = null, mode = "full",
   onNoteSelect, onNodeHover, recenterRef, starredPaths, className,
+  showAllLabels = false,
 }: GraphViewProps) {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
   const layoutRef = React.useRef<LayoutHandle | null>(null);
@@ -135,6 +138,8 @@ export function GraphView({
             transform: viewport,
             theme: detectTheme(),
             mode: layoutMode,
+            showAllLabels,
+            tokens: resolveTokens(canvas),
             nodes: graphData.nodes.map((n) => {
               const pos = layout.getPosition(n.id);
               return {
@@ -250,6 +255,30 @@ export function GraphView({
 function detectTheme(): "light" | "dark" {
   if (typeof document === "undefined") return "dark";
   return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+/**
+ * Resolve the graph palette from live CSS variables on the canvas's nearest
+ * styled ancestor. Canvas itself doesn't inherit custom-property reads
+ * reliably across all browsers, so we read from documentElement which always
+ * carries the global token sheet. Fallback `undefined` lets drawScene fall
+ * back to the static GRAPH_CONFIG palette when tokens are missing (tests,
+ * SSR, native).
+ */
+function resolveTokens(canvas: HTMLCanvasElement): Scene["tokens"] | undefined {
+  if (typeof document === "undefined" || !canvas) return undefined;
+  const cs = getComputedStyle(document.documentElement);
+  const get = (name: string) => cs.getPropertyValue(name).trim();
+  const bg2 = get("--bg-2");
+  if (!bg2) return undefined;
+  return {
+    bg2,
+    fg3: get("--fg-3"),
+    fg4: get("--fg-4"),
+    accent: get("--accent"),
+    accent2: get("--accent-2"),
+    accentSoft: get("--accent-soft"),
+  };
 }
 
 function computeLocalSet(

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -36,6 +36,14 @@ export function GraphView({
   const hitRef = React.useRef<HitTest | null>(null);
   const hoverRef = React.useRef<string | null>(null);
   const dragRef = React.useRef<{ id: string; startX: number; startY: number } | null>(null);
+  // d3-force style alpha decay: simulation runs while alpha > alphaMin, then
+  // stops. Selecting a note or dragging reheats it back to 1. Without this
+  // the cluster vibrates indefinitely — repulsion never wins enough to be
+  // counted "still" and the spring keeps wobbling. With decay the graph
+  // settles to a quiet equilibrium, then perturbs and re-settles on input.
+  const alphaRef = React.useRef(1);
+  const ALPHA_MIN = 0.005;
+  const ALPHA_DECAY = 0.018;
   const { viewport, bind, setViewport } = useViewport();
   const layoutMode: LayoutMode = mode === "full" ? "global" : "local";
 
@@ -94,13 +102,10 @@ export function GraphView({
       nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
       activeId, width: w, height: h,
     });
-    // Pre-settle so the first paint isn't a chaotic explosion. We deliberately
-    // do NOT freeze afterwards — the render loop keeps stepping every frame so
-    // the graph behaves like a real-time particle simulation (Obsidian-style):
-    // nodes repel, links spring, the active node stays pinned at origin, and
-    // damping (ngraph's dragCoefficient) lets the cluster settle into an
-    // organic equilibrium that perturbs and re-settles on every interaction.
+    // Pre-settle so the first paint isn't a chaotic explosion, then let the
+    // render loop continue stepping with alpha decay until equilibrium.
     for (let i = 0; i < 200; i++) layoutRef.current.step();
+    alphaRef.current = 1;
     hitRef.current = createHitTest(
       [...layoutRef.current.positions()],
       Math.sqrt(GRAPH_CONFIG.node.hitTestRadiusSq),
@@ -138,10 +143,16 @@ export function GraphView({
             canvas.width = w * dpr; canvas.height = h * dpr;
             ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
           }
-          // Continuous physics — every frame, every time. Repulsion + springs
-          // + soft anchor + active-pin do the rest.
-          layout.step();
-          hit?.rebuild([...layout.positions()]);
+          // Step only while the simulation has energy. Drag forces a step
+          // regardless so the dragged node tracks the pointer instantly.
+          if (alphaRef.current > ALPHA_MIN || dragRef.current) {
+            layout.step();
+            hit?.rebuild([...layout.positions()]);
+            alphaRef.current = Math.max(
+              ALPHA_MIN,
+              alphaRef.current * (1 - ALPHA_DECAY),
+            );
+          }
 
           const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
           const localSet = computeLocalSet(graphData, activeId, layoutMode);
@@ -217,6 +228,9 @@ export function GraphView({
     const id = hitRef.current?.test(wx, wy);
     if (id) {
       dragRef.current = { id, startX: e.clientX, startY: e.clientY };
+      // Reheat so the rest of the cluster reacts to the drag instead of
+      // the dragged node moving through frozen positions.
+      alphaRef.current = 1;
       applyDragStart(layoutRef.current!, id, wx, wy);
     }
   };

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -244,12 +244,17 @@ export function GraphView({
     // cancelled and restarted every frame.
   }, [graphData, layoutMode, activeNotePath, starredPaths, setViewport, showAllLabels]);
 
-  // Hover + click + drag from pointer events on the wrapper.
+  // Hover + click + drag from pointer events on the wrapper. We read the
+  // viewport via viewportRef (kept in sync with React state) so the click
+  // hit-test always sees the latest camera transform — even if the React
+  // closure on this handler captured a stale viewport from before the most
+  // recent camera-follow snap.
   const onPointerMove = (e: React.PointerEvent) => {
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const v = viewportRef.current;
     const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
-    const wx = (sx - viewport.x) / viewport.k;
-    const wy = (sy - viewport.y) / viewport.k;
+    const wx = (sx - v.x) / v.k;
+    const wy = (sy - v.y) / v.k;
     if (dragRef.current) {
       applyDragMove(layoutRef.current!, dragRef.current.id, wx, wy);
       return;
@@ -265,8 +270,9 @@ export function GraphView({
   };
   const onPointerDown = (e: React.PointerEvent) => {
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const wx = (e.clientX - rect.left - viewport.x) / viewport.k;
-    const wy = (e.clientY - rect.top - viewport.y) / viewport.k;
+    const v = viewportRef.current;
+    const wx = (e.clientX - rect.left - v.x) / v.k;
+    const wy = (e.clientY - rect.top - v.y) / v.k;
     const id = hitRef.current?.test(wx, wy);
     if (id) {
       dragRef.current = { id, startX: e.clientX, startY: e.clientY };

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -43,7 +43,14 @@ export function GraphView({
   const { viewport, bind, setViewport } = useViewport();
   const layoutMode: LayoutMode = mode === "full" ? "global" : "local";
 
-  /** Compute a viewport that frames the current layout positions inside (w, h). */
+  /**
+   * Compute a viewport that frames the current layout inside (w, h).
+   *
+   * When a note is active the layout pins it at world (0, 0) — we centre
+   * the canvas on that origin so the active node always sits dead-centre
+   * regardless of how the cluster shifts during settle. Without an active
+   * note we fall back to centring on the bbox.
+   */
   const fitToCanvas = React.useCallback((w: number, h: number) => {
     const layout = layoutRef.current;
     if (!layout) return { x: w / 2, y: h / 2, k: 1 };
@@ -68,10 +75,15 @@ export function GraphView({
         Math.min((w - margin) / bboxW, (h - margin) / bboxH),
       ),
     );
+    // Active node is pinned at world (0,0) by the layout, so centring the
+    // canvas on world-origin places the active node at the canvas centre.
+    if (activeNotePath) {
+      return { x: w / 2, y: h / 2, k };
+    }
     const cx = (minX + maxX) / 2;
     const cy = (minY + maxY) / 2;
     return { x: w / 2 - cx * k, y: h / 2 - cy * k, k };
-  }, []);
+  }, [activeNotePath]);
 
   // Build / rebuild layout when graphData, mode, or activeNotePath changes.
   // Settle for a few hundred ticks before fitting so the bbox is meaningful.

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -36,10 +36,6 @@ export function GraphView({
   const hitRef = React.useRef<HitTest | null>(null);
   const hoverRef = React.useRef<string | null>(null);
   const dragRef = React.useRef<{ id: string; startX: number; startY: number } | null>(null);
-  // Once the layout has been pre-settled we stop stepping the simulation —
-  // continuing would let positions drift past the initial fit. Drag bumps
-  // this back to false so the simulation runs while the user is dragging.
-  const frozenRef = React.useRef(false);
   const { viewport, bind, setViewport } = useViewport();
   const layoutMode: LayoutMode = mode === "full" ? "global" : "local";
 
@@ -98,10 +94,13 @@ export function GraphView({
       nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
       activeId, width: w, height: h,
     });
-    // Pre-settle so positions stabilise before the first paint, then freeze.
-    frozenRef.current = false;
-    for (let i = 0; i < 500; i++) layoutRef.current.step();
-    frozenRef.current = true;
+    // Pre-settle so the first paint isn't a chaotic explosion. We deliberately
+    // do NOT freeze afterwards — the render loop keeps stepping every frame so
+    // the graph behaves like a real-time particle simulation (Obsidian-style):
+    // nodes repel, links spring, the active node stays pinned at origin, and
+    // damping (ngraph's dragCoefficient) lets the cluster settle into an
+    // organic equilibrium that perturbs and re-settles on every interaction.
+    for (let i = 0; i < 200; i++) layoutRef.current.step();
     hitRef.current = createHitTest(
       [...layoutRef.current.positions()],
       Math.sqrt(GRAPH_CONFIG.node.hitTestRadiusSq),
@@ -139,10 +138,10 @@ export function GraphView({
             canvas.width = w * dpr; canvas.height = h * dpr;
             ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
           }
-          if (!frozenRef.current || dragRef.current) {
-            layout.step();
-            hit?.rebuild([...layout.positions()]);
-          }
+          // Continuous physics — every frame, every time. Repulsion + springs
+          // + soft anchor + active-pin do the rest.
+          layout.step();
+          hit?.rebuild([...layout.positions()]);
 
           const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
           const localSet = computeLocalSet(graphData, activeId, layoutMode);
@@ -218,8 +217,6 @@ export function GraphView({
     const id = hitRef.current?.test(wx, wy);
     if (id) {
       dragRef.current = { id, startX: e.clientX, startY: e.clientY };
-      // Unfreeze so the dragged node can move and the rest react.
-      frozenRef.current = false;
       applyDragStart(layoutRef.current!, id, wx, wy);
     }
   };
@@ -235,8 +232,6 @@ export function GraphView({
         if (node) onNoteSelect(node.path);
       }
       dragRef.current = null;
-      // Re-freeze after the user lets go so the simulation stops.
-      frozenRef.current = true;
     }
   };
 

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -111,31 +111,30 @@ export function GraphView({
     };
   }, [graphData, layoutMode, setViewport, fitToCanvas]);
 
-  // Selection: morph in global mode (swap the pin, preserve positions),
-  // rebuild in local mode (concentric rings are keyed on active id).
+  // Selection in global mode: do nothing to the layout. The render loop
+  // pans the camera to follow the active note's current position — the
+  // cluster stays exactly where it sits, no spring tug-of-war.
+  // Selection in local mode: the layout structure (concentric rings) is
+  // keyed on the active id, so it does need a rebuild.
   React.useEffect(() => {
+    if (layoutMode !== "local") return;
     if (!graphData) return;
     const layout = layoutRef.current;
     if (!layout) return;
     const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
-    if (layoutMode === "local") {
-      // Full rebuild — the layout structure depends on the active id.
-      layout.dispose();
-      const canvas = canvasRef.current!;
-      const w = canvas.clientWidth, h = canvas.clientHeight;
-      layoutRef.current = createLayout({
-        nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
-        activeId, width: w, height: h,
-      });
-      for (let i = 0; i < 200; i++) layoutRef.current.step();
-      hitRef.current = createHitTest(
-        [...layoutRef.current.positions()],
-        Math.sqrt(GRAPH_CONFIG.node.hitTestRadiusSq),
-      );
-      setViewport(fitToCanvas(w, h));
-    } else {
-      layout.setActive(activeId);
-    }
+    layout.dispose();
+    const canvas = canvasRef.current!;
+    const w = canvas.clientWidth, h = canvas.clientHeight;
+    layoutRef.current = createLayout({
+      nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
+      activeId, width: w, height: h,
+    });
+    for (let i = 0; i < 200; i++) layoutRef.current.step();
+    hitRef.current = createHitTest(
+      [...layoutRef.current.positions()],
+      Math.sqrt(GRAPH_CONFIG.node.hitTestRadiusSq),
+    );
+    setViewport(fitToCanvas(w, h));
     alphaRef.current = 1;
   }, [activeNotePath, graphData, layoutMode, setViewport, fitToCanvas]);
 
@@ -180,8 +179,8 @@ export function GraphView({
 
           // Camera follow: when an active note exists, glide the viewport so
           // the active node sits at the canvas centre. We lerp toward the
-          // target each frame (15% per frame ≈ ~250ms half-life) so selecting
-          // a different note pans smoothly instead of snapping.
+          // target each frame (8% per frame ≈ ~480ms half-life) for a calm
+          // glide that doesn't feel like a snap.
           if (activeId) {
             const pos = layout.getPosition(activeId);
             if (pos) {
@@ -189,10 +188,10 @@ export function GraphView({
               const targetY = h / 2 - pos.y * viewport.k;
               const dx = targetX - viewport.x;
               const dy = targetY - viewport.y;
-              if (Math.abs(dx) > 0.1 || Math.abs(dy) > 0.1) {
+              if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
                 setViewport({
-                  x: viewport.x + dx * 0.15,
-                  y: viewport.y + dy * 0.15,
+                  x: viewport.x + dx * 0.08,
+                  y: viewport.y + dy * 0.08,
                   k: viewport.k,
                 });
               }

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -36,6 +36,11 @@ export function GraphView({
   const hitRef = React.useRef<HitTest | null>(null);
   const hoverRef = React.useRef<string | null>(null);
   const dragRef = React.useRef<{ id: string; startX: number; startY: number } | null>(null);
+  // Tracks which active note we last centred the camera on. The render-loop
+  // camera-follow only fires when this drifts behind activeNotePath — so a
+  // selection re-centres once, but subsequent user pan/wheel isn't fought
+  // by the follower every frame.
+  const centredOnRef = React.useRef<string | null>(null);
   const { viewport, bind, setViewport } = useViewport();
   // viewportRef mirrors the React state; the render loop and camera-follow
   // read/write through the ref so the effect doesn't need `viewport` in its
@@ -155,22 +160,22 @@ export function GraphView({
 
           const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
 
-          // Camera follow: snap to the active note's screen position. A lerp
-          // looks like spider-web sway because every label translates in
-          // sync each frame; an instant snap on selection (and held still
-          // afterwards) reads as a clean focus change.
-          const v = viewportRef.current;
-          if (activeId) {
+          // Camera focus: snap to the active note ONCE per selection, not
+          // every frame. Continuous follow would fight user pan/wheel — they
+          // could never drag the viewport because the next frame would snap
+          // it back. centredOnRef remembers which active we last centred on;
+          // we only re-centre when it changes.
+          if (activeId && centredOnRef.current !== activeId) {
             const pos = layout.getPosition(activeId);
             if (pos) {
-              const targetX = w / 2 - pos.x * v.k;
-              const targetY = h / 2 - pos.y * v.k;
-              if (Math.abs(targetX - v.x) > 0.5 || Math.abs(targetY - v.y) > 0.5) {
-                const next = { x: targetX, y: targetY, k: v.k };
-                viewportRef.current = next;
-                setViewport(next);
-              }
+              const v = viewportRef.current;
+              const next = { x: w / 2 - pos.x * v.k, y: h / 2 - pos.y * v.k, k: v.k };
+              viewportRef.current = next;
+              setViewport(next);
+              centredOnRef.current = activeId;
             }
+          } else if (!activeId) {
+            centredOnRef.current = null;
           }
           const tiers = computeLocalTiers(graphData, activeId, layoutMode);
           const tierFor = (id: string): "primary" | "secondary" | "hidden" => {

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -172,39 +172,56 @@ export function GraphView({
               }
             }
           }
-          const localSet = computeLocalSet(graphData, activeId, layoutMode);
+          const tiers = computeLocalTiers(graphData, activeId, layoutMode);
+          const tierFor = (id: string): "primary" | "secondary" | "hidden" => {
+            if (!tiers) return "primary"; // global mode: everything is primary
+            if (tiers.primary.has(id)) return "primary";
+            if (tiers.secondary.has(id)) return "secondary";
+            return "hidden";
+          };
           const scene: Scene = {
             transform: viewportRef.current,
             theme: detectTheme(),
             mode: layoutMode,
             showAllLabels,
             tokens: resolveTokens(canvas),
-            nodes: graphData.nodes.map((n) => {
-              const pos = layout.getPosition(n.id);
-              return {
-                node: n,
-                position: pos ?? { id: n.id, x: 0, y: 0 },
-                isActive: n.id === activeId,
-                isHovered: n.id === hoverRef.current,
-                isStarred: !!(starredPaths && starredPaths.has(n.path)),
-                isShared: !!n.shared,
-                isVisible: !!pos,
-                isInLocalSet: localSet ? localSet.has(n.id) : true,
-              };
-            }),
+            // Skip hidden nodes entirely (3rd-tier+ in local mode).
+            nodes: graphData.nodes
+              .map((n) => ({ n, tier: tierFor(n.id) }))
+              .filter((x) => x.tier !== "hidden")
+              .map(({ n, tier }) => {
+                const pos = layout.getPosition(n.id);
+                return {
+                  node: n,
+                  position: pos ?? { id: n.id, x: 0, y: 0 },
+                  isActive: n.id === activeId,
+                  isHovered: n.id === hoverRef.current,
+                  isStarred: !!(starredPaths && starredPaths.has(n.path)),
+                  isShared: !!n.shared,
+                  isVisible: !!pos,
+                  tier,
+                };
+              }),
+            // An edge is drawn if both endpoints are visible. Its tier is
+            // the higher (more ghosted) of the two endpoints' tiers.
             edges: graphData.edges
               .map((e) => {
+                const fromTier = tierFor(e.fromNoteId);
+                const toTier = tierFor(e.toNoteId);
+                if (fromTier === "hidden" || toTier === "hidden") return null;
                 const fp = layout.getPosition(e.fromNoteId);
                 const tp = layout.getPosition(e.toNoteId);
                 if (!fp || !tp) return null;
+                const tier: "primary" | "secondary" =
+                  fromTier === "primary" && toTier === "primary"
+                    ? "primary"
+                    : "secondary";
                 return {
                   fromPosition: fp,
                   toPosition: tp,
                   isActive: e.fromNoteId === activeId || e.toNoteId === activeId,
                   isHovered: e.fromNoteId === hoverRef.current || e.toNoteId === hoverRef.current,
-                  isInLocalSet: localSet
-                    ? localSet.has(e.fromNoteId) && localSet.has(e.toNoteId)
-                    : true,
+                  tier,
                 };
               })
               .filter((e): e is NonNullable<typeof e> => e !== null),
@@ -321,21 +338,32 @@ function resolveTokens(canvas: HTMLCanvasElement): Scene["tokens"] | undefined {
   };
 }
 
-// Per prototype/app/graph.jsx ~line 14-16:
-//   const visibleNodes = mode === 'local' && activeId
-//     ? nodes.filter(n => n.id === activeId
-//         || edges.some(([a,b]) => (a === activeId && b === n.id) || (b === activeId && a === n.id)))
-//     : nodes;
-// Local mode shows ONLY the active note + direct (1-hop) neighbours. Local
-// without an active note matches global. Global always shows everything.
-function computeLocalSet(
+/**
+ * Compute the two visibility tiers for local mode:
+ *   primary  = active + 1-hop  (drawn full colour)
+ *   secondary = 2-hop neighbours (drawn as gray ghost dots)
+ * Anything farther is hidden entirely.
+ *
+ * Returns null in global mode (every node is primary; no ghosting/hiding).
+ */
+function computeLocalTiers(
   data: GraphData, activeId: string | null, mode: LayoutMode,
-): Set<string> | null {
+): { primary: Set<string>; secondary: Set<string> } | null {
   if (mode !== "local" || !activeId) return null;
-  const set = new Set<string>([activeId]);
+  const adj = new Map<string, Set<string>>();
+  for (const n of data.nodes) adj.set(n.id, new Set());
   for (const e of data.edges) {
-    if (e.fromNoteId === activeId) set.add(e.toNoteId);
-    else if (e.toNoteId === activeId) set.add(e.fromNoteId);
+    adj.get(e.fromNoteId)?.add(e.toNoteId);
+    adj.get(e.toNoteId)?.add(e.fromNoteId);
   }
-  return set;
+  const primary = new Set<string>([activeId]);
+  for (const id of adj.get(activeId) ?? []) primary.add(id);
+  const secondary = new Set<string>();
+  for (const id of primary) {
+    if (id === activeId) continue;
+    for (const id2 of adj.get(id) ?? []) {
+      if (!primary.has(id2)) secondary.add(id2);
+    }
+  }
+  return { primary, secondary };
 }

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -45,6 +45,13 @@ export function GraphView({
   const ALPHA_MIN = 0.005;
   const ALPHA_DECAY = 0.018;
   const { viewport, bind, setViewport } = useViewport();
+  // viewportRef mirrors the React state; the render loop and camera-follow
+  // read/write through the ref so the effect doesn't need `viewport` in its
+  // deps. Without this, every camera-lerp tick triggered a setViewport
+  // → state change → effect re-run → rAF cancel + restart, which is the
+  // "spider web vibration" the user reported.
+  const viewportRef = React.useRef(viewport);
+  React.useEffect(() => { viewportRef.current = viewport; }, [viewport]);
   const layoutMode: LayoutMode = mode === "full" ? "global" : "local";
 
   /**
@@ -111,32 +118,10 @@ export function GraphView({
     };
   }, [graphData, layoutMode, setViewport, fitToCanvas]);
 
-  // Selection in global mode: do nothing to the layout. The render loop
-  // pans the camera to follow the active note's current position — the
-  // cluster stays exactly where it sits, no spring tug-of-war.
-  // Selection in local mode: the layout structure (concentric rings) is
-  // keyed on the active id, so it does need a rebuild.
-  React.useEffect(() => {
-    if (layoutMode !== "local") return;
-    if (!graphData) return;
-    const layout = layoutRef.current;
-    if (!layout) return;
-    const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
-    layout.dispose();
-    const canvas = canvasRef.current!;
-    const w = canvas.clientWidth, h = canvas.clientHeight;
-    layoutRef.current = createLayout({
-      nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
-      activeId, width: w, height: h,
-    });
-    for (let i = 0; i < 200; i++) layoutRef.current.step();
-    hitRef.current = createHitTest(
-      [...layoutRef.current.positions()],
-      Math.sqrt(GRAPH_CONFIG.node.hitTestRadiusSq),
-    );
-    setViewport(fitToCanvas(w, h));
-    alphaRef.current = 1;
-  }, [activeNotePath, graphData, layoutMode, setViewport, fitToCanvas]);
+  // Selection never touches the layout. Both modes use the same force
+  // layout; local just ghosts the non-active set in the renderer (see
+  // drawScene + computeLocalSet). The render-loop's camera-follow pans
+  // the viewport to the new active.
 
   // Recenter handle — fits the bounding box of current positions to the canvas.
   React.useEffect(() => {
@@ -180,26 +165,33 @@ export function GraphView({
           // Camera follow: when an active note exists, glide the viewport so
           // the active node sits at the canvas centre. We lerp toward the
           // target each frame (8% per frame ≈ ~480ms half-life) for a calm
-          // glide that doesn't feel like a snap.
+          // glide that doesn't feel like a snap. Mutates the ref directly
+          // so the next frame sees the updated viewport without waiting on
+          // React state — and only calls setViewport when the camera has
+          // actually moved by a pixel, which keeps re-renders rare instead
+          // of one-per-frame.
+          const v = viewportRef.current;
           if (activeId) {
             const pos = layout.getPosition(activeId);
             if (pos) {
-              const targetX = w / 2 - pos.x * viewport.k;
-              const targetY = h / 2 - pos.y * viewport.k;
-              const dx = targetX - viewport.x;
-              const dy = targetY - viewport.y;
+              const targetX = w / 2 - pos.x * v.k;
+              const targetY = h / 2 - pos.y * v.k;
+              const dx = targetX - v.x;
+              const dy = targetY - v.y;
               if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
-                setViewport({
-                  x: viewport.x + dx * 0.08,
-                  y: viewport.y + dy * 0.08,
-                  k: viewport.k,
-                });
+                const next = {
+                  x: v.x + dx * 0.08,
+                  y: v.y + dy * 0.08,
+                  k: v.k,
+                };
+                viewportRef.current = next;
+                setViewport(next);
               }
             }
           }
           const localSet = computeLocalSet(graphData, activeId, layoutMode);
           const scene: Scene = {
-            transform: viewport,
+            transform: viewportRef.current,
             theme: detectTheme(),
             mode: layoutMode,
             showAllLabels,
@@ -242,7 +234,10 @@ export function GraphView({
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-  }, [graphData, viewport, activeNotePath, layoutMode, starredPaths]);
+    // viewport intentionally NOT in deps — read via viewportRef so the rAF
+    // loop stays alive across camera-follow updates instead of being
+    // cancelled and restarted every frame.
+  }, [graphData, layoutMode, activeNotePath, starredPaths, setViewport, showAllLabels]);
 
   // Hover + click + drag from pointer events on the wrapper.
   const onPointerMove = (e: React.PointerEvent) => {

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -36,14 +36,6 @@ export function GraphView({
   const hitRef = React.useRef<HitTest | null>(null);
   const hoverRef = React.useRef<string | null>(null);
   const dragRef = React.useRef<{ id: string; startX: number; startY: number } | null>(null);
-  // d3-force style alpha decay: simulation runs while alpha > alphaMin, then
-  // stops. Selecting a note or dragging reheats it back to 1. Without this
-  // the cluster vibrates indefinitely — repulsion never wins enough to be
-  // counted "still" and the spring keeps wobbling. With decay the graph
-  // settles to a quiet equilibrium, then perturbs and re-settles on input.
-  const alphaRef = React.useRef(1);
-  const ALPHA_MIN = 0.005;
-  const ALPHA_DECAY = 0.018;
   const { viewport, bind, setViewport } = useViewport();
   // viewportRef mirrors the React state; the render loop and camera-follow
   // read/write through the ref so the effect doesn't need `viewport` in its
@@ -105,8 +97,12 @@ export function GraphView({
       nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
       activeId, width: w, height: h,
     });
-    for (let i = 0; i < 200; i++) layoutRef.current.step();
-    alphaRef.current = 1;
+    // Pre-settle thoroughly so the graph is in equilibrium before first
+    // paint. We then *stop stepping* in the render loop — running the
+    // simulation continuously made the cluster look like a spider web in
+    // the wind because every spring kept nudging neighbours by sub-pixel
+    // amounts each frame. Dragging temporarily resumes stepping.
+    for (let i = 0; i < 800; i++) layoutRef.current.step();
     hitRef.current = createHitTest(
       [...layoutRef.current.positions()],
       Math.sqrt(GRAPH_CONFIG.node.hitTestRadiusSq),
@@ -149,41 +145,28 @@ export function GraphView({
             canvas.width = w * dpr; canvas.height = h * dpr;
             ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
           }
-          // Step only while the simulation has energy. Drag forces a step
-          // regardless so the dragged node tracks the pointer instantly.
-          if (alphaRef.current > ALPHA_MIN || dragRef.current) {
+          // Only step while the user is dragging — the layout was already
+          // pre-settled at mount and stays frozen otherwise, so the graph
+          // doesn't wobble between renders.
+          if (dragRef.current) {
             layout.step();
             hit?.rebuild([...layout.positions()]);
-            alphaRef.current = Math.max(
-              ALPHA_MIN,
-              alphaRef.current * (1 - ALPHA_DECAY),
-            );
           }
 
           const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
 
-          // Camera follow: when an active note exists, glide the viewport so
-          // the active node sits at the canvas centre. We lerp toward the
-          // target each frame (8% per frame ≈ ~480ms half-life) for a calm
-          // glide that doesn't feel like a snap. Mutates the ref directly
-          // so the next frame sees the updated viewport without waiting on
-          // React state — and only calls setViewport when the camera has
-          // actually moved by a pixel, which keeps re-renders rare instead
-          // of one-per-frame.
+          // Camera follow: snap to the active note's screen position. A lerp
+          // looks like spider-web sway because every label translates in
+          // sync each frame; an instant snap on selection (and held still
+          // afterwards) reads as a clean focus change.
           const v = viewportRef.current;
           if (activeId) {
             const pos = layout.getPosition(activeId);
             if (pos) {
               const targetX = w / 2 - pos.x * v.k;
               const targetY = h / 2 - pos.y * v.k;
-              const dx = targetX - v.x;
-              const dy = targetY - v.y;
-              if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) {
-                const next = {
-                  x: v.x + dx * 0.08,
-                  y: v.y + dy * 0.08,
-                  k: v.k,
-                };
+              if (Math.abs(targetX - v.x) > 0.5 || Math.abs(targetY - v.y) > 0.5) {
+                const next = { x: targetX, y: targetY, k: v.k };
                 viewportRef.current = next;
                 setViewport(next);
               }
@@ -265,9 +248,6 @@ export function GraphView({
     const id = hitRef.current?.test(wx, wy);
     if (id) {
       dragRef.current = { id, startX: e.clientX, startY: e.clientY };
-      // Reheat so the rest of the cluster reacts to the drag instead of
-      // the dragged node moving through frozen positions.
-      alphaRef.current = 1;
       applyDragStart(layoutRef.current!, id, wx, wy);
     }
   };

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -273,6 +273,7 @@ function resolveTokens(canvas: HTMLCanvasElement): Scene["tokens"] | undefined {
   if (!bg2) return undefined;
   return {
     bg2,
+    fg1: get("--fg-1"),
     fg3: get("--fg-3"),
     fg4: get("--fg-4"),
     accent: get("--accent"),

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -276,26 +276,28 @@ function resolveTokens(canvas: HTMLCanvasElement): Scene["tokens"] | undefined {
     fg1: get("--fg-1"),
     fg3: get("--fg-3"),
     fg4: get("--fg-4"),
+    line: get("--line"),
     accent: get("--accent"),
     accent2: get("--accent-2"),
     accentSoft: get("--accent-soft"),
   };
 }
 
+// Per prototype/app/graph.jsx ~line 14-16:
+//   const visibleNodes = mode === 'local' && activeId
+//     ? nodes.filter(n => n.id === activeId
+//         || edges.some(([a,b]) => (a === activeId && b === n.id) || (b === activeId && a === n.id)))
+//     : nodes;
+// Local mode shows ONLY the active note + direct (1-hop) neighbours. Local
+// without an active note matches global. Global always shows everything.
 function computeLocalSet(
   data: GraphData, activeId: string | null, mode: LayoutMode,
 ): Set<string> | null {
   if (mode !== "local" || !activeId) return null;
   const set = new Set<string>([activeId]);
-  const adj = new Map<string, Set<string>>();
-  for (const n of data.nodes) adj.set(n.id, new Set());
   for (const e of data.edges) {
-    adj.get(e.fromNoteId)?.add(e.toNoteId);
-    adj.get(e.toNoteId)?.add(e.fromNoteId);
-  }
-  for (const id of adj.get(activeId) ?? []) {
-    set.add(id);
-    for (const id2 of adj.get(id) ?? []) set.add(id2);
+    if (e.fromNoteId === activeId) set.add(e.toNoteId);
+    else if (e.toNoteId === activeId) set.add(e.fromNoteId);
   }
   return set;
 }

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -48,12 +48,11 @@ export function GraphView({
   const layoutMode: LayoutMode = mode === "full" ? "global" : "local";
 
   /**
-   * Compute a viewport that frames the current layout inside (w, h).
-   *
-   * When a note is active the layout pins it at world (0, 0) — we centre
-   * the canvas on that origin so the active node always sits dead-centre
-   * regardless of how the cluster shifts during settle. Without an active
-   * note we fall back to centring on the bbox.
+   * Compute a viewport that frames the current layout's bounding box inside
+   * (w, h). Used at mount and when the user hits the recenter button. With
+   * an active note the render loop continuously pans the camera to follow
+   * the active's world position, so initial fit just sets the zoom — the
+   * follow logic handles centring afterwards.
    */
   const fitToCanvas = React.useCallback((w: number, h: number) => {
     const layout = layoutRef.current;
@@ -68,9 +67,6 @@ export function GraphView({
     const bboxW = Math.max(1, maxX - minX);
     const bboxH = Math.max(1, maxY - minY);
     const margin = 60;
-    // Auto-fit caps zoom-in at 1.5× so a sparse cluster doesn't blow up
-    // node radii to the size of the rail. User can still pinch / wheel up
-    // to scaleMax manually.
     const AUTO_FIT_MAX_K = 1.5;
     const k = Math.min(
       AUTO_FIT_MAX_K,
@@ -79,31 +75,29 @@ export function GraphView({
         Math.min((w - margin) / bboxW, (h - margin) / bboxH),
       ),
     );
-    // Active node is pinned at world (0,0) by the layout, so centring the
-    // canvas on world-origin places the active node at the canvas centre.
-    if (activeNotePath) {
-      return { x: w / 2, y: h / 2, k };
-    }
     const cx = (minX + maxX) / 2;
     const cy = (minY + maxY) / 2;
     return { x: w / 2 - cx * k, y: h / 2 - cy * k, k };
-  }, [activeNotePath]);
+  }, []);
 
-  // Build / rebuild layout when graphData, mode, or activeNotePath changes.
-  // Settle for a few hundred ticks before fitting so the bbox is meaningful.
+  // Latest activeNotePath, read by long-lived effects that only want to
+  // react to graphData / mode changes (not selection). Selection is handled
+  // by a separate effect that calls layout.setActive.
+  const activePathRef = React.useRef(activeNotePath);
+  activePathRef.current = activeNotePath;
+
+  // Build the layout once per graphData / mode. Selection is handled below.
   React.useEffect(() => {
     if (!graphData) return;
     layoutRef.current?.dispose();
     const canvas = canvasRef.current!;
     const w = canvas.clientWidth;
     const h = canvas.clientHeight;
-    const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
+    const activeId = graphData.nodes.find((n) => n.path === activePathRef.current)?.id ?? null;
     layoutRef.current = createLayout({
       nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
       activeId, width: w, height: h,
     });
-    // Pre-settle so the first paint isn't a chaotic explosion, then let the
-    // render loop continue stepping with alpha decay until equilibrium.
     for (let i = 0; i < 200; i++) layoutRef.current.step();
     alphaRef.current = 1;
     hitRef.current = createHitTest(
@@ -115,7 +109,35 @@ export function GraphView({
       layoutRef.current?.dispose();
       layoutRef.current = null;
     };
-  }, [graphData, layoutMode, activeNotePath, setViewport, fitToCanvas]);
+  }, [graphData, layoutMode, setViewport, fitToCanvas]);
+
+  // Selection: morph in global mode (swap the pin, preserve positions),
+  // rebuild in local mode (concentric rings are keyed on active id).
+  React.useEffect(() => {
+    if (!graphData) return;
+    const layout = layoutRef.current;
+    if (!layout) return;
+    const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
+    if (layoutMode === "local") {
+      // Full rebuild — the layout structure depends on the active id.
+      layout.dispose();
+      const canvas = canvasRef.current!;
+      const w = canvas.clientWidth, h = canvas.clientHeight;
+      layoutRef.current = createLayout({
+        nodes: graphData.nodes, edges: graphData.edges, mode: layoutMode,
+        activeId, width: w, height: h,
+      });
+      for (let i = 0; i < 200; i++) layoutRef.current.step();
+      hitRef.current = createHitTest(
+        [...layoutRef.current.positions()],
+        Math.sqrt(GRAPH_CONFIG.node.hitTestRadiusSq),
+      );
+      setViewport(fitToCanvas(w, h));
+    } else {
+      layout.setActive(activeId);
+    }
+    alphaRef.current = 1;
+  }, [activeNotePath, graphData, layoutMode, setViewport, fitToCanvas]);
 
   // Recenter handle — fits the bounding box of current positions to the canvas.
   React.useEffect(() => {
@@ -155,6 +177,27 @@ export function GraphView({
           }
 
           const activeId = graphData.nodes.find((n) => n.path === activeNotePath)?.id ?? null;
+
+          // Camera follow: when an active note exists, glide the viewport so
+          // the active node sits at the canvas centre. We lerp toward the
+          // target each frame (15% per frame ≈ ~250ms half-life) so selecting
+          // a different note pans smoothly instead of snapping.
+          if (activeId) {
+            const pos = layout.getPosition(activeId);
+            if (pos) {
+              const targetX = w / 2 - pos.x * viewport.k;
+              const targetY = h / 2 - pos.y * viewport.k;
+              const dx = targetX - viewport.x;
+              const dy = targetY - viewport.y;
+              if (Math.abs(dx) > 0.1 || Math.abs(dy) > 0.1) {
+                setViewport({
+                  x: viewport.x + dx * 0.15,
+                  y: viewport.y + dy * 0.15,
+                  k: viewport.k,
+                });
+              }
+            }
+          }
           const localSet = computeLocalSet(graphData, activeId, layoutMode);
           const scene: Scene = {
             transform: viewport,

--- a/packages/ui/src/graph/view/Painter.ts
+++ b/packages/ui/src/graph/view/Painter.ts
@@ -57,4 +57,15 @@ export interface Scene {
   theme: "light" | "dark";
   /** Mode-aware: local mode ghosts non-set elements. */
   mode: "global" | "local";
+  /** When true, draw every node's label. Otherwise labels render on hover/active only. */
+  showAllLabels?: boolean;
+  /** Optional design-token overrides resolved from CSS variables at draw time. */
+  tokens?: {
+    bg2: string;
+    fg3: string;
+    fg4: string;
+    accent: string;
+    accent2: string;
+    accentSoft: string;
+  };
 }

--- a/packages/ui/src/graph/view/Painter.ts
+++ b/packages/ui/src/graph/view/Painter.ts
@@ -29,6 +29,15 @@ export interface Painter {
   measureText(text: string, fontSize: number, fontFamily: string): number;
 }
 
+/**
+ * Local-mode tier:
+ *   "primary"   = active note + its 1-hop neighbours (full colour)
+ *   "secondary" = 2-hop neighbours (gray ghost dots)
+ *   "hidden"    = farther than 2 hops — not drawn
+ * In global mode every node is "primary" (no ghosting, no hiding).
+ */
+export type LocalTier = "primary" | "secondary" | "hidden";
+
 export interface SceneNode {
   node: GraphNode;
   position: NodePosition;
@@ -37,7 +46,7 @@ export interface SceneNode {
   isStarred: boolean;
   isShared: boolean;
   isVisible: boolean;
-  isInLocalSet: boolean;
+  tier: LocalTier;
 }
 
 export interface SceneEdge {
@@ -45,7 +54,7 @@ export interface SceneEdge {
   toPosition: NodePosition;
   isActive: boolean;
   isHovered: boolean;
-  isInLocalSet: boolean;
+  tier: LocalTier;
 }
 
 export interface Scene {

--- a/packages/ui/src/graph/view/Painter.ts
+++ b/packages/ui/src/graph/view/Painter.ts
@@ -65,6 +65,7 @@ export interface Scene {
     fg1: string;
     fg3: string;
     fg4: string;
+    line: string;
     accent: string;
     accent2: string;
     accentSoft: string;

--- a/packages/ui/src/graph/view/Painter.ts
+++ b/packages/ui/src/graph/view/Painter.ts
@@ -62,6 +62,7 @@ export interface Scene {
   /** Optional design-token overrides resolved from CSS variables at draw time. */
   tokens?: {
     bg2: string;
+    fg1: string;
     fg3: string;
     fg4: string;
     accent: string;

--- a/packages/ui/src/graph/view/__tests__/drawScene.test.ts
+++ b/packages/ui/src/graph/view/__tests__/drawScene.test.ts
@@ -9,20 +9,20 @@ const baseScene = (): Scene => ({
       node: { id: "a", title: "A", path: "a.md" },
       position: { id: "a", x: 100, y: 100 },
       isActive: true, isHovered: false, isStarred: false, isShared: false,
-      isVisible: true, isInLocalSet: true,
+      isVisible: true, tier: "primary",
     },
     {
       node: { id: "b", title: "B", path: "b.md" },
       position: { id: "b", x: 200, y: 200 },
       isActive: false, isHovered: false, isStarred: true, isShared: false,
-      isVisible: true, isInLocalSet: true,
+      isVisible: true, tier: "primary",
     },
   ],
   edges: [
     {
       fromPosition: { id: "a", x: 100, y: 100 },
       toPosition: { id: "b", x: 200, y: 200 },
-      isActive: false, isHovered: false, isInLocalSet: true,
+      isActive: false, isHovered: false, tier: "primary",
     },
   ],
   transform: { x: 0, y: 0, k: 1 },
@@ -65,7 +65,7 @@ describe("drawScene", () => {
     const scene = baseScene();
     scene.mode = "local";
     const node1 = scene.nodes[1];
-    if (node1) node1.isInLocalSet = false;
+    if (node1) node1.tier = "secondary";
     drawScene(painter, scene, 400, 400);
     const ghostedCircle = calls.find(
       (c) => c.kind === "circle" && (c.style.alpha ?? 1) < 0.5,

--- a/packages/ui/src/graph/view/drawScene.ts
+++ b/packages/ui/src/graph/view/drawScene.ts
@@ -3,7 +3,27 @@ import { GRAPH_CONFIG } from "../graphConfig";
 import type { Painter, Scene, SceneEdge, SceneNode } from "./Painter";
 
 export function drawScene(painter: Painter, scene: Scene, width: number, height: number): void {
-  const palette = GRAPH_CONFIG.colors[scene.theme];
+  // Build the palette from design tokens when available so the canvas tracks
+  // the live theme; fall back to the static GRAPH_CONFIG palette on platforms
+  // that can't resolve CSS vars (e.g. native Skia).
+  const palette: Palette = scene.tokens
+    ? {
+      link: scene.tokens.fg4,
+      node: scene.tokens.bg2,
+      nodeHovered: scene.tokens.bg2,
+      nodeActive: scene.tokens.accent,
+      nodeShared: scene.tokens.accent2,
+      strokeActive: scene.tokens.accent,
+      strokeShared: scene.tokens.accent2,
+      strokeHovered: scene.tokens.accent,
+      label: scene.tokens.fg3,
+      star: GRAPH_CONFIG.colors[scene.theme].star,
+      starStroke: GRAPH_CONFIG.colors[scene.theme].starStroke,
+      strokeDefault: scene.tokens.fg3,
+      activeHalo: scene.tokens.accentSoft,
+    }
+    : { ...GRAPH_CONFIG.colors[scene.theme], strokeDefault: GRAPH_CONFIG.colors[scene.theme].label, activeHalo: GRAPH_CONFIG.colors[scene.theme].nodeActive };
+
   painter.beginFrame(width, height);
   painter.save();
   painter.translate(scene.transform.x, scene.transform.y);
@@ -11,13 +31,27 @@ export function drawScene(painter: Painter, scene: Scene, width: number, height:
 
   // Edges first so nodes paint over them.
   for (const e of scene.edges) drawEdge(painter, e, palette, scene.mode);
-  for (const n of scene.nodes) drawNode(painter, n, palette, scene.mode);
+  for (const n of scene.nodes) drawNode(painter, n, palette, scene.mode, !!scene.showAllLabels);
 
   painter.restore();
   painter.endFrame();
 }
 
-type Palette = typeof GRAPH_CONFIG.colors.light | typeof GRAPH_CONFIG.colors.dark;
+interface Palette {
+  link: string;
+  node: string;
+  nodeHovered: string;
+  nodeActive: string;
+  nodeShared: string;
+  strokeActive: string;
+  strokeShared: string;
+  strokeHovered: string;
+  label: string;
+  star: string;
+  starStroke: string;
+  strokeDefault: string;
+  activeHalo: string;
+}
 
 function drawEdge(p: Painter, e: SceneEdge, palette: Palette, mode: Scene["mode"]) {
   const ghosted = mode === "local" && !e.isInLocalSet;
@@ -29,7 +63,7 @@ function drawEdge(p: Painter, e: SceneEdge, palette: Palette, mode: Scene["mode"
   });
 }
 
-function drawNode(p: Painter, n: SceneNode, palette: Palette, mode: Scene["mode"]) {
+function drawNode(p: Painter, n: SceneNode, palette: Palette, mode: Scene["mode"], showAllLabels: boolean) {
   const ghosted = mode === "local" && !n.isInLocalSet;
   const r = n.isActive
     ? GRAPH_CONFIG.node.activeRadius
@@ -41,14 +75,26 @@ function drawNode(p: Painter, n: SceneNode, palette: Palette, mode: Scene["mode"
     : n.isShared
       ? palette.nodeShared
       : palette.node;
+  // Per prototype/app/graph.jsx: default nodes use --bg-2 fill with a --fg-3
+  // stroke; hovered nodes swap to an --accent stroke. Active nodes get a
+  // halo (drawn first so the solid node sits on top).
   const stroke = n.isActive
     ? palette.strokeActive
     : n.isShared
       ? palette.strokeShared
       : n.isHovered
         ? palette.strokeHovered
-        : fill;
+        : palette.strokeDefault;
   const baseStyle = { fill, stroke, strokeWidth: n.isActive ? 2 : 1.2, alpha: ghosted ? 0.25 : 1 };
+
+  if ((n.isActive || n.isHovered) && !ghosted && !n.isStarred) {
+    p.drawCircle(n.position.x, n.position.y, r + 6, {
+      fill: palette.activeHalo,
+      stroke: palette.activeHalo,
+      strokeWidth: 0,
+      alpha: 0.18,
+    });
+  }
 
   if (n.isStarred && !n.isActive && !ghosted) {
     const outerR = n.isHovered ? GRAPH_CONFIG.node.starHoveredRadius : GRAPH_CONFIG.node.starDefaultRadius;
@@ -60,7 +106,7 @@ function drawNode(p: Painter, n: SceneNode, palette: Palette, mode: Scene["mode"
     p.drawCircle(n.position.x, n.position.y, r, baseStyle);
   }
 
-  if ((n.isActive || n.isHovered) && !ghosted) {
+  if ((n.isActive || n.isHovered || showAllLabels) && !ghosted) {
     p.drawText(
       n.position.x,
       n.position.y + r + GRAPH_CONFIG.node.labelOffset + GRAPH_CONFIG.font.defaultSize,

--- a/packages/ui/src/graph/view/drawScene.ts
+++ b/packages/ui/src/graph/view/drawScene.ts
@@ -30,8 +30,15 @@ export function drawScene(painter: Painter, scene: Scene, width: number, height:
       // Bible uses solid accent at 0.18 opacity — pass full-alpha accent
       // through and let drawCircle apply alpha 0.18 itself.
       activeHalo: scene.tokens.accent,
+      ghostLine: scene.tokens.line,
     }
-    : { ...GRAPH_CONFIG.colors[scene.theme], strokeDefault: GRAPH_CONFIG.colors[scene.theme].label, activeHalo: GRAPH_CONFIG.colors[scene.theme].nodeActive, labelActive: GRAPH_CONFIG.colors[scene.theme].nodeActive };
+    : {
+      ...GRAPH_CONFIG.colors[scene.theme],
+      strokeDefault: GRAPH_CONFIG.colors[scene.theme].label,
+      activeHalo: GRAPH_CONFIG.colors[scene.theme].nodeActive,
+      labelActive: GRAPH_CONFIG.colors[scene.theme].nodeActive,
+      ghostLine: GRAPH_CONFIG.colors[scene.theme].link,
+    };
 
   painter.beginFrame(width, height);
   painter.save();
@@ -48,6 +55,7 @@ export function drawScene(painter: Painter, scene: Scene, width: number, height:
 
 interface Palette {
   link: string;
+  ghostLine: string;
   node: string;
   nodeHovered: string;
   nodeActive: string;
@@ -63,13 +71,26 @@ interface Palette {
   activeHalo: string;
 }
 
+// Per prototype/app/graph.jsx ~line 53-75:
+//   ghost edge (local mode, one end outside set):
+//     stroke=var(--line) strokeWidth=1 opacity=0.3
+//   visible edge:
+//     stroke= active/hover ? var(--accent) : var(--fg-4)
+//     strokeWidth= active/hover ? 1.5 : 1
+//     opacity= active/hover ? 0.9 : 0.5
 function drawEdge(p: Painter, e: SceneEdge, palette: Palette, mode: Scene["mode"]) {
   const ghosted = mode === "local" && !e.isInLocalSet;
-  const stroke = e.isActive || e.isHovered ? palette.strokeHovered : palette.link;
-  const alpha = ghosted ? 0.2 : e.isActive || e.isHovered ? 0.9 : 0.5;
-  const strokeWidth = e.isActive || e.isHovered ? 1.5 : 1;
+  if (ghosted) {
+    p.drawLine(e.fromPosition.x, e.fromPosition.y, e.toPosition.x, e.toPosition.y, {
+      stroke: palette.ghostLine, strokeWidth: 1, alpha: 0.3,
+    });
+    return;
+  }
+  const highlighted = e.isActive || e.isHovered;
   p.drawLine(e.fromPosition.x, e.fromPosition.y, e.toPosition.x, e.toPosition.y, {
-    stroke, strokeWidth, alpha,
+    stroke: highlighted ? palette.strokeHovered : palette.link,
+    strokeWidth: highlighted ? 1.5 : 1,
+    alpha: highlighted ? 0.9 : 0.5,
   });
 }
 
@@ -80,6 +101,21 @@ function drawNode(p: Painter, n: SceneNode, palette: Palette, mode: Scene["mode"
     : n.isHovered
       ? GRAPH_CONFIG.node.hoveredRadius
       : GRAPH_CONFIG.node.defaultRadius;
+
+  // Per prototype/app/graph.jsx ~line 78-81:
+  //   {mode === 'local' && nodes.filter(n => !visibleIds.has(n.id)).map(n => (
+  //     <circle ... r={n.r * 0.6} fill="var(--fg-4)" opacity="0.25"/>
+  //   ))}
+  // Ghost nodes are small dim dots with no label, no halo — exit early.
+  if (ghosted) {
+    p.drawCircle(n.position.x, n.position.y, r * 0.6, {
+      fill: palette.link, // --fg-4 token
+      stroke: palette.link,
+      strokeWidth: 0,
+      alpha: 0.25,
+    });
+    return;
+  }
   const fill = n.isActive
     ? palette.nodeActive
     : n.isShared

--- a/packages/ui/src/graph/view/drawScene.ts
+++ b/packages/ui/src/graph/view/drawScene.ts
@@ -72,14 +72,14 @@ interface Palette {
 }
 
 // Per prototype/app/graph.jsx ~line 53-75:
-//   ghost edge (local mode, one end outside set):
+//   ghost edge (local-mode secondary tier):
 //     stroke=var(--line) strokeWidth=1 opacity=0.3
-//   visible edge:
+//   visible edge (primary tier):
 //     stroke= active/hover ? var(--accent) : var(--fg-4)
 //     strokeWidth= active/hover ? 1.5 : 1
 //     opacity= active/hover ? 0.9 : 0.5
 function drawEdge(p: Painter, e: SceneEdge, palette: Palette, mode: Scene["mode"]) {
-  const ghosted = mode === "local" && !e.isInLocalSet;
+  const ghosted = mode === "local" && e.tier === "secondary";
   if (ghosted) {
     p.drawLine(e.fromPosition.x, e.fromPosition.y, e.toPosition.x, e.toPosition.y, {
       stroke: palette.ghostLine, strokeWidth: 1, alpha: 0.3,
@@ -95,7 +95,7 @@ function drawEdge(p: Painter, e: SceneEdge, palette: Palette, mode: Scene["mode"
 }
 
 function drawNode(p: Painter, n: SceneNode, palette: Palette, mode: Scene["mode"], showAllLabels: boolean) {
-  const ghosted = mode === "local" && !n.isInLocalSet;
+  const ghosted = mode === "local" && n.tier === "secondary";
   const r = n.isActive
     ? GRAPH_CONFIG.node.activeRadius
     : n.isHovered

--- a/packages/ui/src/graph/view/drawScene.ts
+++ b/packages/ui/src/graph/view/drawScene.ts
@@ -6,6 +6,12 @@ export function drawScene(painter: Painter, scene: Scene, width: number, height:
   // Build the palette from design tokens when available so the canvas tracks
   // the live theme; fall back to the static GRAPH_CONFIG palette on platforms
   // that can't resolve CSS vars (e.g. native Skia).
+  // Palette resolution mirrors prototype/app/graph.jsx exactly:
+  //   edge default: --fg-4, active/hover: --accent
+  //   node fill default: --bg-2, active: --accent
+  //   node stroke default: --fg-3, active/hover: --accent
+  //   halo: solid --accent at opacity 0.18, no stroke
+  //   label default: --fg-1, active: --accent
   const palette: Palette = scene.tokens
     ? {
       link: scene.tokens.fg4,
@@ -16,13 +22,16 @@ export function drawScene(painter: Painter, scene: Scene, width: number, height:
       strokeActive: scene.tokens.accent,
       strokeShared: scene.tokens.accent2,
       strokeHovered: scene.tokens.accent,
-      label: scene.tokens.fg3,
+      label: scene.tokens.fg1,
+      labelActive: scene.tokens.accent,
       star: GRAPH_CONFIG.colors[scene.theme].star,
       starStroke: GRAPH_CONFIG.colors[scene.theme].starStroke,
       strokeDefault: scene.tokens.fg3,
-      activeHalo: scene.tokens.accentSoft,
+      // Bible uses solid accent at 0.18 opacity — pass full-alpha accent
+      // through and let drawCircle apply alpha 0.18 itself.
+      activeHalo: scene.tokens.accent,
     }
-    : { ...GRAPH_CONFIG.colors[scene.theme], strokeDefault: GRAPH_CONFIG.colors[scene.theme].label, activeHalo: GRAPH_CONFIG.colors[scene.theme].nodeActive };
+    : { ...GRAPH_CONFIG.colors[scene.theme], strokeDefault: GRAPH_CONFIG.colors[scene.theme].label, activeHalo: GRAPH_CONFIG.colors[scene.theme].nodeActive, labelActive: GRAPH_CONFIG.colors[scene.theme].nodeActive };
 
   painter.beginFrame(width, height);
   painter.save();
@@ -47,6 +56,7 @@ interface Palette {
   strokeShared: string;
   strokeHovered: string;
   label: string;
+  labelActive: string;
   star: string;
   starStroke: string;
   strokeDefault: string;
@@ -106,14 +116,19 @@ function drawNode(p: Painter, n: SceneNode, palette: Palette, mode: Scene["mode"
     p.drawCircle(n.position.x, n.position.y, r, baseStyle);
   }
 
+  // Per prototype/app/graph.jsx EditorMeta line ~99-106: labels render at
+  //   y + n.r + 14
+  //   fontSize = fullscreen ? 13 : 11
+  //   fill = active ? --accent : --fg-1
   if ((n.isActive || n.isHovered || showAllLabels) && !ghosted) {
+    const fontSize = showAllLabels ? 13 : 11;
     p.drawText(
       n.position.x,
-      n.position.y + r + GRAPH_CONFIG.node.labelOffset + GRAPH_CONFIG.font.defaultSize,
+      n.position.y + r + 14,
       truncate(n.node.title),
-      n.isActive ? GRAPH_CONFIG.font.activeSize : GRAPH_CONFIG.font.defaultSize,
+      fontSize,
       GRAPH_CONFIG.font.family,
-      palette.label,
+      n.isActive ? palette.labelActive : palette.label,
       "center",
     );
   }


### PR DESCRIPTION
## Summary
- AppStatusBar now fetches `/api/backlinks/<path>` via react-query and surfaces the count in the EditorMeta rail.
- Closes the last visible diff between live and prototype's status bar (`<n> outgoing · <n> backlinks · <n> tags · ...`).

## Test plan
- [x] Open a note with inbound wikilinks; status bar shows real count
- [x] tsc --noEmit clean