### PR TITLE
fix: address pre-existing audit findings (5 issues)

### DIFF
--- a/packages/client/src/data/HttpDataProvider.tsx
+++ b/packages/client/src/data/HttpDataProvider.tsx
@@ -1,6 +1,11 @@
 /**
  * HttpDataProvider — wraps HttpAdapter in <KrytonDataProvider> and triggers
- * an initial full refresh on mount.
+ * an initial full refresh once an authenticated session exists.
+ *
+ * Refreshes are gated on `/api/auth/get-session` returning a user, so the
+ * pre-auth landing page doesn't fire a flood of 401s for every entity type.
+ * A `kryton:auth-changed` window event re-runs the refresh after sign-in /
+ * sign-out.
  *
  * Usage:
  *   const adapter = new HttpAdapter({ baseUrl: "" });
@@ -16,24 +21,50 @@ interface HttpDataProviderProps {
   children: ReactNode;
 }
 
+const ENTITY_TYPES = [
+  "notes",
+  "tags",
+  "settings",
+  "noteShares",
+  "trashItems",
+  "currentUser",
+] as const;
+
+async function hasSession(): Promise<boolean> {
+  try {
+    const res = await fetch("/api/auth/get-session", { credentials: "include" });
+    if (!res.ok) return false;
+    const data = (await res.json().catch(() => null)) as { user?: unknown } | null;
+    return Boolean(data && data.user);
+  } catch {
+    return false;
+  }
+}
+
 export function HttpDataProvider({ adapter, children }: HttpDataProviderProps) {
   useEffect(() => {
-    // Prime all caches on mount. Errors are non-fatal — UI will just show empty state.
-    const entityTypes = [
-      "notes",
-      "tags",
-      "settings",
-      "noteShares",
-      "trashItems",
-      "currentUser",
-    ] as const;
+    let cancelled = false;
 
-    for (const entityType of entityTypes) {
-      adapter.refresh(entityType).catch((err: unknown) => {
-        console.warn(`[HttpDataProvider] initial refresh(${entityType}) failed:`, err);
-      });
+    async function refreshAll(): Promise<void> {
+      if (cancelled) return;
+      if (!(await hasSession())) return;
+      for (const entityType of ENTITY_TYPES) {
+        if (cancelled) return;
+        adapter.refresh(entityType).catch((err: unknown) => {
+          // Genuine post-auth refresh errors are still worth surfacing. The
+          // common pre-auth 401 flood is now prevented by the session gate.
+          console.warn(`[HttpDataProvider] refresh(${entityType}) failed:`, err);
+        });
+      }
     }
-   
+
+    void refreshAll();
+    const onAuthChanged = (): void => { void refreshAll(); };
+    window.addEventListener("kryton:auth-changed", onAuthChanged);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("kryton:auth-changed", onAuthChanged);
+    };
   }, [adapter]);
 
   return <KrytonDataProvider adapter={adapter}>{children}</KrytonDataProvider>;

--- a/packages/server/src/modules/notes/index.ts
+++ b/packages/server/src/modules/notes/index.ts
@@ -1,8 +1,9 @@
 import * as path from "node:path";
 import type { FastifyPluginAsync } from "fastify";
 import { backfillFolders } from "./services/backfill/folders-backfill.js";
+import { backfillSearchIndex } from "./services/backfill/search-index-backfill.js";
 import { backfillTags } from "./services/backfill/tags-backfill.js";
-import { ensureNotesWatcher } from "./services/notes-watcher.js";
+import { ensureNotesWatcher, stopAllNotesWatchers } from "./services/notes-watcher.js";
 import { NoteService } from "./services/note.service.js";
 import { getUserNotesDir } from "./services/user-notes-dir.service.js";
 import {
@@ -96,6 +97,12 @@ export const notesModule: FastifyPluginAsync = async (app) => {
     backfilledUsers.add(userId);
     try {
       await backfillFolders(app, notesDir, userId);
+      // Reconcile SearchIndex + GraphEdge against disk. This replaces the
+      // initial-scan side of the MiniSearch reconcile module that was
+      // deleted in the Postgres migration (Phase 6 / PR #109). Without this,
+      // any .md file present on disk before chokidar starts watching never
+      // gets indexed because the watcher runs with `ignoreInitial: true`.
+      await backfillSearchIndex(app, notesDir, userId);
       await backfillTags(app, userId);
       // Start a live chokidar watcher so out-of-band changes (filesystem rm,
       // Finder, git checkout) keep the index in sync without the user having
@@ -134,6 +141,14 @@ export const notesModule: FastifyPluginAsync = async (app) => {
     } catch (err) {
       app.log.warn({ err }, "warm-start watchers failed");
     }
+  });
+
+  // Register the shutdown hook once at module init. ensureNotesWatcher used
+  // to call addHook per-user inside its body, which fails with
+  // FST_ERR_INSTANCE_ALREADY_LISTENING the moment a request triggers the
+  // lazy-init path after `app.ready()` has resolved.
+  app.addHook("onClose", async () => {
+    await stopAllNotesWatchers();
   });
 
   // Mount shared-notes BEFORE /api/notes so the prefix is matched first.

--- a/packages/server/src/modules/notes/services/backfill/search-index-backfill.ts
+++ b/packages/server/src/modules/notes/services/backfill/search-index-backfill.ts
@@ -1,0 +1,94 @@
+/**
+ * Walk a user's notes dir on first authenticated request and ensure every
+ * `.md` file is reflected in `SearchIndex` + `GraphEdge`. Idempotent.
+ *
+ * This replaces the file-by-file initial scan that the deleted MiniSearch
+ * reconcile module used to do (see PR #109's Phase 6, which removed the
+ * MiniSearch index manager but left the boot-time index population gap
+ * behind). The chokidar watcher in `notes-watcher.ts` runs with
+ * `ignoreInitial: true`, so without this backfill the SearchIndex (and the
+ * tsvector column) stays empty until each note is touched again.
+ *
+ * For performance, we read `SearchIndex.modifiedAt` for the user up front
+ * and only re-index files whose disk mtime exceeds the indexed mtime (or
+ * have no index row yet).
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
+import { searchIndex } from "../../../../db/schema/notes.js";
+
+/** Recursively list every .md file under `userRoot`, skipping dot-dirs. */
+async function listMarkdownFiles(userRoot: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(dir: string, rel: string): Promise<void> {
+    let entries: { name: string; isDirectory: () => boolean; isFile: () => boolean }[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name.startsWith(".")) continue;
+      const full = path.join(dir, e.name);
+      const sub = rel ? `${rel}/${e.name}` : e.name;
+      if (e.isDirectory()) {
+        await walk(full, sub);
+      } else if (e.isFile() && e.name.endsWith(".md")) {
+        out.push(sub);
+      }
+    }
+  }
+  await walk(userRoot, "");
+  return out;
+}
+
+export async function backfillSearchIndex(
+  app: FastifyInstance,
+  notesRoot: string,
+  userId: string,
+): Promise<number> {
+  const userRoot = path.join(notesRoot, userId);
+  let stats;
+  try {
+    stats = await fs.stat(userRoot);
+  } catch {
+    return 0;
+  }
+  if (!stats.isDirectory()) return 0;
+
+  const knowledge = app.knowledge;
+  if (!knowledge) return 0;
+
+  // Existing index: notePath → modifiedAt. We re-index files whose disk
+  // mtime is newer than the indexed mtime, plus any file not in the index.
+  const rows = await app.db
+    .select({ notePath: searchIndex.notePath, modifiedAt: searchIndex.modifiedAt })
+    .from(searchIndex)
+    .where(eq(searchIndex.userId, userId));
+  const indexed = new Map(rows.map((r) => [r.notePath, r.modifiedAt.getTime()]));
+
+  const paths = await listMarkdownFiles(userRoot);
+  let touched = 0;
+  for (const rel of paths) {
+    const full = path.join(userRoot, rel);
+    let stat;
+    try {
+      stat = await fs.stat(full);
+    } catch {
+      continue;
+    }
+    const existing = indexed.get(rel);
+    if (existing !== undefined && existing >= stat.mtimeMs) continue;
+    try {
+      const content = await fs.readFile(full, "utf-8");
+      await knowledge.indexNote(rel, content, userId);
+      await knowledge.updateGraph(rel, content, userId);
+      touched++;
+    } catch (err) {
+      app.log.warn({ err, userId, path: rel }, "search-index-backfill: skip");
+    }
+  }
+  return touched;
+}

--- a/packages/server/src/modules/notes/services/note.service.ts
+++ b/packages/server/src/modules/notes/services/note.service.ts
@@ -6,6 +6,16 @@ import { moveToTrash } from "./trash.service.js";
 import { saveHistorySnapshot } from "./history.service.js";
 import { trashItem } from "../../../db/schema/notes.js";
 import { noteShare } from "../../../db/schema/sharing.js";
+import { NotFoundError } from "../../../lib/errors.js";
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ENOENT"
+  );
+}
 
 /**
  * Cross-module decorator surfaces that the notes module relies on:
@@ -88,8 +98,27 @@ export class NoteService {
     const fullPath = path.join(notesDir, notePath);
     ensureWithinBase(fullPath, notesDir);
 
-    const content = await fs.readFile(fullPath, "utf-8");
-    const stat = await fs.stat(fullPath);
+    let content: string;
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      content = await fs.readFile(fullPath, "utf-8");
+      stat = await fs.stat(fullPath);
+    } catch (err) {
+      // ENOENT (file gone) and ENOTDIR (parent component isn't a directory
+      // because the caller tacked extra segments onto a leaf path) both mean
+      // "no note here." Map to 404 instead of letting the global error
+      // handler surface them as 500.
+      if (
+        isEnoent(err) ||
+        (typeof err === "object" &&
+          err !== null &&
+          "code" in err &&
+          (err as { code?: unknown }).code === "ENOTDIR")
+      ) {
+        throw new NotFoundError(`Note not found: ${notePath}`);
+      }
+      throw err;
+    }
     const title = this.extractTitle(content, notePath);
 
     return { path: notePath, content, title, modifiedAt: stat.mtime };

--- a/packages/server/src/modules/notes/services/notes-watcher.ts
+++ b/packages/server/src/modules/notes/services/notes-watcher.ts
@@ -135,12 +135,6 @@ export async function ensureNotesWatcher(
   watcher.on("error", (err) => {
     app.log.warn({ err, userId }, "notes-watcher: error");
   });
-
-  // Close cleanly on app shutdown so the test harness and graceful restarts
-  // don't leak FDs.
-  app.addHook("onClose", async () => {
-    await stopNotesWatcher(userId);
-  });
 }
 
 export async function stopNotesWatcher(userId: string): Promise<void> {
@@ -154,4 +148,10 @@ export async function stopNotesWatcher(userId: string): Promise<void> {
   } catch {
     // best-effort
   }
+}
+
+/** Stop every active watcher. Called once at app shutdown. */
+export async function stopAllNotesWatchers(): Promise<void> {
+  const ids = Array.from(watchers.keys());
+  await Promise.all(ids.map((id) => stopNotesWatcher(id)));
 }

--- a/packages/server/src/plugins/auth.ts
+++ b/packages/server/src/plugins/auth.ts
@@ -5,6 +5,8 @@ import { fromNodeHeaders } from "better-auth/node";
 import { createAuth, type Auth } from "../modules/identity/auth-config.js";
 import { AuthError, ForbiddenError } from "../lib/errors.js";
 import { user } from "../db/schema/auth.js";
+import { settings } from "../db/schema/settings.js";
+import { GLOBAL_USER_ID } from "../lib/pathUtils.js";
 
 export interface AuthUser {
   id: string;
@@ -193,6 +195,31 @@ export const authPlugin = fp(async (app) => {
   };
 
   app.decorate("auth", api);
+
+  // Public auth config — read by the login page to decide which sign-in
+  // affordances to show. Registered BEFORE the better-auth catch-all so the
+  // specific path takes precedence over `/api/auth/*`. No auth required.
+  app.route({
+    method: "GET",
+    url: "/api/auth/config",
+    schema: { hide: true },
+    handler: async () => {
+      const rows = await app.db.query.settings.findMany({
+        where: eq(settings.key, "registration_mode"),
+      });
+      const row = rows.find((r) => r.userId === GLOBAL_USER_ID) ?? rows[0];
+      const registrationMode = (row?.value as string | undefined) ?? "open";
+      return {
+        registrationMode,
+        // OAuth + SMTP are not wired in this build. Surfaced here so the
+        // login page can hide the relevant buttons cleanly instead of probing
+        // and getting a 404.
+        googleEnabled: false,
+        githubEnabled: false,
+        smtpEnabled: false,
+      };
+    },
+  });
 
   // Mount Better Auth catch-all. We use Fastify's raw request/response to avoid
   // body parsing conflicts.


### PR DESCRIPTION
Five issues surfaced during the post-migration verification walk. None were caused by the Postgres migration or sync-removal PRs, but all impact real behavior on a fresh install.

## Fixes

### 1. `NoteService.readNote` — ENOENT/ENOTDIR → 404 (not 500)
Map filesystem errors to `NotFoundError` so the global error handler returns 404 with the standard envelope instead of 500. Affects `GET /api/notes/<missing-or-deleted-path>`.

### 2. `HttpDataProvider` — gate initial refresh on session
The login screen used to fire 6 entity refreshes immediately, all of which 401'd because no auth cookie existed yet. Now waits for `/api/auth/get-session` to return a user, and re-runs the batch on a `kryton:auth-changed` window event.

### 3. Public `GET /api/auth/config` endpoint
The login page probes `/api/auth/config` for `registrationMode + googleEnabled + githubEnabled + smtpEnabled`. The endpoint didn't exist, so the probe 404'd and the page fell back to defaults. New route in the auth plugin, registered before the better-auth catch-all so the specific path takes precedence.

### 4. `notes-watcher` — addHook race causing FST_ERR_INSTANCE_ALREADY_LISTENING
The per-user `ensureNotesWatcher` was calling `app.addHook('onClose', ...)` inside its body. The first request to a fresh user post-`app.ready()` failed because Fastify forbids adding hooks once listening. **This was the root cause of the empty SearchIndex bug** (#5) — the backfill chain bailed before reaching the indexer.

Hook now registered once at module-init time, with a new `stopAllNotesWatchers()` helper that iterates the in-memory watcher map.

### 5. Empty SearchIndex + empty graph view on fresh user
Phase 6 of the Postgres migration deleted the MiniSearch reconcile module but left the chokidar watcher with `ignoreInitial: true`. Any `.md` file on disk before chokidar starts watching never got indexed.

New `services/backfill/search-index-backfill.ts` walks the user dir on first authenticated request, reads existing `SearchIndex.modifiedAt`, and reindexes any file whose disk mtime is newer (or that has no row). Idempotent — repeat boots skip unchanged files.

Lexical search and the graph view now return real results immediately after sign-up.

## Not fixed (not a bug)

`GET /api/folders/` returns 404 because only `POST` and `DELETE` are defined for that path. The UI never calls `GET` on it. The OpenAPI snapshot correctly lists the path with only the methods that exist.

## Verification

- Fresh DB + fresh user signup → SearchIndex populated with 6 rows (was 0 before fix)
- `GET /api/search/?q=kryton` → returns Welcome.md + Daily/2026-03-23.md hits
- `GET /api/graph/` → returns real nodes + edges
- `GET /api/notes/<missing>` → 404 with proper envelope (was 500)
- `GET /api/auth/config` → 200 with public config
- Browser console: no pre-auth 401 noise

## Test plan

- [x] Server tests: 80 passed, 2 skipped (matches baseline)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no eslint-disable)
- [x] `npm run build --workspace=packages/ui` (regenerates `dist/` so client types resolve)
- [ ] Manual UI smoke: sign-up → verify search returns "kryton" matches; verify graph view shows nodes; verify reading a deleted note shows 404 toast instead of crash