### PR TITLE
style(client/admin): theme AdminPage to match Account Settings

### DIFF
--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -1,21 +1,45 @@
-import { useState, useEffect, useCallback, CSSProperties } from 'react';
+import { useState, useEffect, useCallback, CSSProperties, FormEvent } from 'react';
+import {
+  X, Users, Ticket, Settings, Trash2, ShieldCheck, ShieldOff,
+  UserX, UserCheck, Plus, Copy, Check, Key, Package,
+} from 'lucide-react';
+import { useAuth } from '../hooks/useAuth';
+import { request } from '../lib/api';
+import { PluginsTab } from './PluginsTab';
+import { Section, Field, Toolbar } from '../components/Settings/settings-kit';
+import {
+  helpText,
+  inputStyle as kitInputStyle,
+  primaryBtn,
+  ghostBtn,
+  dangerBtn,
+} from '../components/Settings/settings-kit-styles';
 
 const dialogStyle: CSSProperties = { background: 'var(--bg-1)' };
 const borderLine: CSSProperties = { borderColor: 'var(--line)' };
-const headingStyle: CSSProperties = { color: 'var(--fg)' };
 const mutedStyle: CSSProperties = { color: 'var(--fg-3)' };
-const cardStyle: CSSProperties = { background: 'var(--bg-2)', borderColor: 'var(--line)' };
-const inputSmallStyle: CSSProperties = {
-  background: 'var(--bg-2)',
-  borderColor: 'var(--line)',
-  color: 'var(--fg)',
+
+const errorBoxStyle: CSSProperties = {
+  ...helpText,
+  marginBottom: 12,
+  padding: '8px 10px',
+  borderRadius: 5,
+  background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)',
+  border: '1px solid color-mix(in oklch, var(--accent-danger) 30%, transparent)',
+  color: 'var(--accent-danger)',
+  fontFamily: 'var(--font-mono)',
 };
-const ghostBtnStyle: CSSProperties = { color: 'var(--fg-3)' };
-const accentBtnStyle: CSSProperties = { background: 'var(--accent)', color: '#fff' };
-import { useAuth } from '../hooks/useAuth';
-import { request } from '../lib/api';
-import { X, Users, Ticket, Settings, Trash2, ShieldCheck, ShieldOff, UserX, UserCheck, Plus, Copy, Check, Key, Package } from 'lucide-react';
-import { PluginsTab } from './PluginsTab';
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  background: 'var(--bg-1)',
+  border: '1px solid var(--line)',
+  borderRadius: 6,
+  padding: '10px 12px',
+  marginBottom: 8,
+};
 
 interface AdminUser {
   id: string;
@@ -37,6 +61,13 @@ interface InviteCode {
 
 type Tab = 'users' | 'invites' | 'settings' | 'plugins';
 
+const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
+  { key: 'users', label: 'Users', icon: Users },
+  { key: 'invites', label: 'Invite Codes', icon: Ticket },
+  { key: 'settings', label: 'Settings', icon: Settings },
+  { key: 'plugins', label: 'Plugins', icon: Package },
+];
+
 export default function AdminPage({ onClose }: { onClose: () => void }) {
   const { user } = useAuth();
   const [tab, setTab] = useState<Tab>('users');
@@ -51,41 +82,62 @@ export default function AdminPage({ onClose }: { onClose: () => void }) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="admin-panel-title"
-        className="rounded-xl shadow-2xl w-[90vw] max-w-4xl max-h-[85vh] overflow-hidden flex flex-col"
-        style={dialogStyle}
+        className="rounded-xl shadow-2xl w-[90vw] max-w-2xl overflow-hidden flex flex-col"
+        style={{ ...dialogStyle, height: 'min(640px, 85vh)' }}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b" style={borderLine}>
-          <h2 id="admin-panel-title" className="text-lg font-semibold" style={headingStyle}>Admin Panel</h2>
+          <div className="flex items-center gap-2">
+            <ShieldCheck size={18} style={{ color: 'var(--accent)' }} />
+            <h2 id="admin-panel-title" className="text-lg font-semibold" style={{ color: 'var(--fg)' }}>
+              Admin Panel
+            </h2>
+          </div>
           <button
             onClick={onClose}
             className="p-1.5 rounded-lg transition-colors"
-            style={ghostBtnStyle}
-            onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--fg)'; }}
-            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--fg-3)'; }}
+            style={{ color: 'var(--fg-3)' }}
+            onMouseEnter={e => {
+              e.currentTarget.style.background = 'var(--bg-hover)';
+              e.currentTarget.style.color = 'var(--fg)';
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.background = 'transparent';
+              e.currentTarget.style.color = 'var(--fg-3)';
+            }}
           >
             <X size={18} />
           </button>
         </div>
 
-        {/* Tabs */}
-        <div className="flex border-b px-6" style={borderLine}>
-          {([
-            { key: 'users' as Tab, label: 'Users', icon: Users },
-            { key: 'invites' as Tab, label: 'Invite Codes', icon: Ticket },
-            { key: 'settings' as Tab, label: 'Settings', icon: Settings },
-            { key: 'plugins' as Tab, label: 'Plugins', icon: Package },
-          ]).map(t => (
+        {/* Tabs — mode-pill pattern (matches AccountSettingsPage) */}
+        <div className="flex items-center px-4 py-2 border-b" style={{ ...borderLine, gap: 2 }}>
+          {TABS.map(t => (
             <button
               key={t.key}
               onClick={() => setTab(t.key)}
-              className="flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors"
-              style={tab === t.key
-                ? { borderColor: 'var(--accent)', color: 'var(--accent)' }
-                : { borderColor: 'transparent', color: 'var(--fg-3)' }}
+              className="flex items-center gap-1.5 text-sm font-medium transition-colors"
+              style={{
+                padding: '6px 10px',
+                borderRadius: 6,
+                background: tab === t.key ? 'var(--accent-soft)' : 'transparent',
+                color: tab === t.key ? 'var(--accent)' : 'var(--fg-3)',
+              }}
+              onMouseEnter={(e) => {
+                if (tab !== t.key) {
+                  e.currentTarget.style.background = 'var(--bg-hover)';
+                  e.currentTarget.style.color = 'var(--fg)';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (tab !== t.key) {
+                  e.currentTarget.style.background = 'transparent';
+                  e.currentTarget.style.color = 'var(--fg-3)';
+                }
+              }}
             >
-              <t.icon size={16} />
+              <t.icon size={14} />
               {t.label}
             </button>
           ))}
@@ -132,7 +184,7 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
     })();
   }, [fetchUsers]);
 
-  const toggleDisabled = async (u: AdminUser) => {
+  const toggleDisabled = useCallback(async (u: AdminUser) => {
     try {
       const updated = await request<AdminUser>(`/admin/users/${u.id}`, {
         method: 'PUT',
@@ -142,9 +194,9 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update user');
     }
-  };
+  }, []);
 
-  const toggleRole = async (u: AdminUser) => {
+  const toggleRole = useCallback(async (u: AdminUser) => {
     const newRole = u.role === 'admin' ? 'user' : 'admin';
     try {
       const updated = await request<AdminUser>(`/admin/users/${u.id}`, {
@@ -155,9 +207,9 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update user');
     }
-  };
+  }, []);
 
-  const deleteUser = async (id: string) => {
+  const deleteUser = useCallback(async (id: string) => {
     try {
       await request<{ ok: boolean }>(`/admin/users/${id}`, { method: 'DELETE' });
       setUsers(prev => prev.filter(x => x.id !== id));
@@ -165,161 +217,155 @@ function UsersSection({ currentUserId }: { currentUserId: string }) {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete user');
     }
-  };
+  }, []);
 
-  if (loading) {
-    return <div className="text-sm" style={mutedStyle}>Loading users...</div>;
-  }
+  const submitResetPw = useCallback(async (id: string, e: FormEvent) => {
+    e.preventDefault();
+    try {
+      await request('/admin/users/' + id + '/reset-password', {
+        method: 'POST',
+        body: JSON.stringify({ newPassword: resetPwValue }),
+      });
+      setResetPwUser(null);
+      setResetPwValue('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reset failed');
+    }
+  }, [resetPwValue]);
 
   return (
-    <div>
-      {error && (
-        <div
-          className="mb-4 px-3 py-2 border rounded-lg text-sm"
-          style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
-        >
-          {error}
-        </div>
-      )}
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left border-b" style={{ ...mutedStyle, ...borderLine }}>
-              <th className="pb-3 font-medium">Name</th>
-              <th className="pb-3 font-medium">Email</th>
-              <th className="pb-3 font-medium">Role</th>
-              <th className="pb-3 font-medium">Status</th>
-              <th className="pb-3 font-medium">Joined</th>
-              <th className="pb-3 font-medium text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
+    <div style={{ color: 'var(--fg-1)' }}>
+      {error && <div style={errorBoxStyle}>{error}</div>}
+
+      <Section title="users">
+        <div style={helpText}>Manage application users — toggle roles, disable accounts, or reset passwords.</div>
+        {loading ? (
+          <div style={helpText}>Loading users...</div>
+        ) : users.length === 0 ? (
+          <div style={helpText}>No users found.</div>
+        ) : (
+          <div style={{ marginBottom: 8 }}>
             {users.map(u => {
               const isSelf = u.id === currentUserId;
               return (
-                <tr key={u.id} className="border-b" style={borderLine}>
-                  <td className="py-3" style={headingStyle}>{u.name || '-'}</td>
-                  <td className="py-3" style={{ color: 'var(--fg)' }}>{u.email}</td>
-                  <td className="py-3">
-                    <span
-                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                      style={u.role === 'admin'
-                        ? { background: 'var(--accent-soft)', color: 'var(--accent)' }
-                        : { background: 'var(--bg-2)', color: 'var(--fg)' }}
-                    >
-                      {u.role === 'admin' ? <ShieldCheck size={12} /> : null}
-                      {u.role}
-                    </span>
-                  </td>
-                  <td className="py-3">
-                    <span
-                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                      style={u.disabled
-                        ? { background: 'color-mix(in oklch, var(--accent-danger) 20%, transparent)', color: 'var(--accent-danger)' }
-                        : { background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' }}
-                    >
-                      {u.disabled ? 'Disabled' : 'Active'}
-                    </span>
-                  </td>
-                  <td className="py-3" style={mutedStyle}>
-                    {new Date(u.createdAt).toLocaleDateString()}
-                  </td>
-                  <td className="py-3 text-right">
+                <div key={u.id} style={rowStyle}>
+                  <div style={{ minWidth: 0, flex: 1 }}>
+                    <div style={{
+                      fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)',
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>
+                      {u.name || u.email}
+                      <span style={{ marginLeft: 8, color: 'var(--fg-3)', fontSize: 11 }}>
+                        {u.name ? u.email : ''}
+                      </span>
+                    </div>
+                    <div style={{
+                      fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-3)',
+                      marginTop: 2, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap',
+                    }}>
+                      <span
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                        style={u.role === 'admin'
+                          ? { background: 'var(--accent-soft)', color: 'var(--accent)' }
+                          : { background: 'var(--bg-2)', color: 'var(--fg)' }}
+                      >
+                        {u.role === 'admin' ? <ShieldCheck size={10} /> : null}
+                        {u.role}
+                      </span>
+                      <span
+                        className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                        style={u.disabled
+                          ? { background: 'color-mix(in oklch, var(--accent-danger) 20%, transparent)', color: 'var(--accent-danger)' }
+                          : { background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' }}
+                      >
+                        {u.disabled ? 'Disabled' : 'Active'}
+                      </span>
+                      <span>Joined {new Date(u.createdAt).toLocaleDateString()}</span>
+                    </div>
+                  </div>
+
+                  <div style={{ display: 'flex', gap: 6, marginLeft: 8, alignItems: 'center' }}>
                     {isSelf ? (
-                      <span className="text-xs" style={mutedStyle}>(you)</span>
+                      <span style={{ ...mutedStyle, fontSize: 11, fontFamily: 'var(--font-mono)' }}>(you)</span>
+                    ) : confirmDelete === u.id ? (
+                      <>
+                        <button onClick={() => deleteUser(u.id)} style={dangerBtn}>Confirm</button>
+                        <button onClick={() => setConfirmDelete(null)} style={ghostBtn}>Cancel</button>
+                      </>
+                    ) : resetPwUser === u.id ? (
+                      <form onSubmit={e => submitResetPw(u.id, e)} style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                        <input
+                          type="password"
+                          value={resetPwValue}
+                          onChange={e => setResetPwValue(e.target.value)}
+                          placeholder="New password"
+                          minLength={8}
+                          required
+                          style={{ ...kitInputStyle, width: 140, padding: '4px 8px', fontSize: 11 }}
+                          autoFocus
+                        />
+                        <button type="submit" style={primaryBtn}>Set</button>
+                        <button type="button" onClick={() => setResetPwUser(null)} style={ghostBtn}>Cancel</button>
+                      </form>
                     ) : (
-                      <div className="flex items-center justify-end gap-1">
-                        <button
+                      <>
+                        <IconBtn
                           onClick={() => toggleDisabled(u)}
-                          className="p-1.5 rounded-lg transition-colors"
-                          style={{ color: u.disabled ? 'var(--accent-good)' : 'var(--accent-warn)' }}
-                          onMouseEnter={e => { e.currentTarget.style.background = u.disabled
-                            ? 'color-mix(in oklch, var(--accent-good) 10%, transparent)'
-                            : 'color-mix(in oklch, var(--accent-warn) 10%, transparent)'; }}
-                          onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
                           title={u.disabled ? 'Enable user' : 'Disable user'}
-                        >
-                          {u.disabled ? <UserCheck size={15} /> : <UserX size={15} />}
-                        </button>
-                        <button
+                          color={u.disabled ? 'var(--accent-good)' : 'var(--accent-warn)'}
+                          icon={u.disabled ? <UserCheck size={14} /> : <UserX size={14} />}
+                        />
+                        <IconBtn
                           onClick={() => toggleRole(u)}
-                          className="p-1.5 rounded-lg transition-colors"
-                          style={{ color: 'var(--accent)' }}
                           title={u.role === 'admin' ? 'Demote to user' : 'Promote to admin'}
-                        >
-                          {u.role === 'admin' ? <ShieldOff size={15} /> : <ShieldCheck size={15} />}
-                        </button>
-                        {confirmDelete === u.id ? (
-                          <div className="flex items-center gap-1">
-                            <button
-                              onClick={() => deleteUser(u.id)}
-                              className="px-2 py-1 rounded text-xs transition-colors"
-                              style={{ background: 'var(--accent-danger)', color: 'var(--fg)' }}
-                            >
-                              Confirm
-                            </button>
-                            <button
-                              onClick={() => setConfirmDelete(null)}
-                              className="px-2 py-1 rounded text-xs transition-colors"
-                              style={mutedStyle}
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        ) : (
-                          <div className="flex items-center gap-1">
-                            {resetPwUser === u.id ? (
-                              <form onSubmit={async (e) => {
-                                e.preventDefault();
-                                try {
-                                  await request('/admin/users/' + u.id + '/reset-password', { method: 'POST', body: JSON.stringify({ newPassword: resetPwValue }) });
-                                  setResetPwUser(null); setResetPwValue('');
-                                } catch (err) { setError(err instanceof Error ? err.message : 'Reset failed'); }
-                              }} className="flex items-center gap-1">
-                                <input type="password" value={resetPwValue} onChange={e => setResetPwValue(e.target.value)}
-                                  placeholder="New password" minLength={8} required
-                                  className="w-24 border rounded px-1.5 py-0.5 text-xs"
-                                  style={inputSmallStyle} />
-                                <button type="submit" className="text-xs" style={{ color: 'var(--accent-good)' }}>Set</button>
-                                <button type="button" onClick={() => setResetPwUser(null)} className="text-xs" style={mutedStyle}>✕</button>
-                              </form>
-                            ) : (
-                              <button
-                                onClick={() => { setResetPwUser(u.id); setResetPwValue(''); }}
-                                className="p-1.5 rounded-lg transition-colors"
-                                style={{ color: 'var(--accent-warn)' }}
-                                onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-warn) 10%, transparent)'; }}
-                                onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
-                                title="Reset password"
-                              >
-                                <Key size={15} />
-                              </button>
-                            )}
-                            <button
-                              onClick={() => setConfirmDelete(u.id)}
-                              className="p-1.5 rounded-lg transition-colors"
-                              style={{ color: 'var(--accent-danger)' }}
-                              onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-danger) 10%, transparent)'; }}
-                              onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
-                              title="Delete user"
-                            >
-                              <Trash2 size={15} />
-                            </button>
-                          </div>
-                        )}
-                      </div>
+                          color="var(--accent)"
+                          icon={u.role === 'admin' ? <ShieldOff size={14} /> : <ShieldCheck size={14} />}
+                        />
+                        <IconBtn
+                          onClick={() => { setResetPwUser(u.id); setResetPwValue(''); }}
+                          title="Reset password"
+                          color="var(--accent-warn)"
+                          icon={<Key size={14} />}
+                        />
+                        <IconBtn
+                          onClick={() => setConfirmDelete(u.id)}
+                          title="Delete user"
+                          color="var(--accent-danger)"
+                          icon={<Trash2 size={14} />}
+                        />
+                      </>
                     )}
-                  </td>
-                </tr>
+                  </div>
+                </div>
               );
             })}
-          </tbody>
-        </table>
-      </div>
-      {users.length === 0 && !loading && (
-        <div className="text-center py-8 text-sm" style={mutedStyle}>No users found.</div>
-      )}
+          </div>
+        )}
+      </Section>
     </div>
+  );
+}
+
+function IconBtn({
+  onClick, title, color, icon,
+}: {
+  onClick: () => void;
+  title: string;
+  color: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      className="p-1.5 rounded-lg transition-colors"
+      style={{ color, background: 'transparent', border: 'none', cursor: 'pointer' }}
+      onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-hover)'; }}
+      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+    >
+      {icon}
+    </button>
   );
 }
 
@@ -351,7 +397,7 @@ function InvitesSection() {
     })();
   }, [fetchInvites]);
 
-  const createInvite = async () => {
+  const createInvite = useCallback(async () => {
     try {
       setCreating(true);
       const invite = await request<InviteCode>('/admin/invites', {
@@ -364,23 +410,23 @@ function InvitesSection() {
     } finally {
       setCreating(false);
     }
-  };
+  }, []);
 
-  const deleteInvite = async (id: string) => {
+  const deleteInvite = useCallback(async (id: string) => {
     try {
       await request<{ ok: boolean }>(`/admin/invites/${id}`, { method: 'DELETE' });
       setInvites(prev => prev.filter(x => x.id !== id));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete invite');
     }
-  };
+  }, []);
 
-  const copyCode = (invite: InviteCode) => {
+  const copyCode = useCallback((invite: InviteCode) => {
     navigator.clipboard.writeText(invite.code).then(() => {
       setCopiedId(invite.id);
       setTimeout(() => setCopiedId(null), 2000);
     });
-  };
+  }, []);
 
   const getStatus = (invite: InviteCode): { label: string; style: CSSProperties } => {
     if (invite.usedBy) return { label: 'Used', style: { background: 'var(--bg-2)', color: 'var(--fg-3)' } };
@@ -390,76 +436,69 @@ function InvitesSection() {
     return { label: 'Unused', style: { background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' } };
   };
 
-  if (loading) {
-    return <div className="text-sm" style={mutedStyle}>Loading invite codes...</div>;
-  }
-
   return (
-    <div>
-      {error && (
-        <div
-          className="mb-4 px-3 py-2 border rounded-lg text-sm"
-          style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
-        >
-          {error}
+    <div style={{ color: 'var(--fg-1)' }}>
+      {error && <div style={errorBoxStyle}>{error}</div>}
+
+      <Section title="invite codes">
+        <div style={helpText}>Generate invite codes that allow new users to register when sign-up is restricted.</div>
+
+        <Toolbar>
+          <button
+            onClick={createInvite}
+            disabled={creating}
+            style={{ ...primaryBtn, opacity: creating ? 0.5 : 1, display: 'inline-flex', alignItems: 'center', gap: 6 }}
+          >
+            <Plus size={13} />
+            {creating ? 'Creating…' : 'Create Invite'}
+          </button>
+        </Toolbar>
+
+        <div style={{ marginTop: 14 }}>
+          {loading ? (
+            <div style={helpText}>Loading invite codes...</div>
+          ) : invites.length === 0 ? (
+            <div style={helpText}>No invite codes yet.</div>
+          ) : (
+            invites.map(invite => {
+              const status = getStatus(invite);
+              return (
+                <div key={invite.id} style={rowStyle}>
+                  <div style={{ minWidth: 0, flex: 1, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <code style={{
+                      fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)',
+                      background: 'var(--bg-2)', padding: '3px 8px', borderRadius: 4,
+                    }}>
+                      {invite.code}
+                    </code>
+                    <IconBtn
+                      onClick={() => copyCode(invite)}
+                      title="Copy code"
+                      color={copiedId === invite.id ? 'var(--accent-good)' : 'var(--fg-3)'}
+                      icon={copiedId === invite.id ? <Check size={13} /> : <Copy size={13} />}
+                    />
+                    <span
+                      className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                      style={status.style}
+                    >
+                      {status.label}
+                    </span>
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-3)' }}>
+                      Created {new Date(invite.createdAt).toLocaleDateString()}
+                    </span>
+                  </div>
+                  <IconBtn
+                    onClick={() => deleteInvite(invite.id)}
+                    title="Delete invite"
+                    color="var(--accent-danger)"
+                    icon={<Trash2 size={14} />}
+                  />
+                </div>
+              );
+            })
+          )}
         </div>
-      )}
-      <div className="mb-4">
-        <button
-          onClick={createInvite}
-          disabled={creating}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50 transition-colors"
-          style={accentBtnStyle}
-        >
-          <Plus size={16} />
-          {creating ? 'Creating...' : 'Create Invite'}
-        </button>
-      </div>
-      <div className="space-y-2">
-        {invites.map(invite => {
-          const status = getStatus(invite);
-          return (
-            <div
-              key={invite.id}
-              className="flex items-center justify-between px-4 py-3 rounded-lg border"
-              style={cardStyle}
-            >
-              <div className="flex items-center gap-4">
-                <code className="text-sm font-mono px-2.5 py-1 rounded" style={{ color: 'var(--fg)', background: 'var(--bg-2)' }}>
-                  {invite.code}
-                </code>
-                <button
-                  onClick={() => copyCode(invite)}
-                  className="p-1 transition-colors"
-                  style={ghostBtnStyle}
-                  title="Copy code"
-                >
-                  {copiedId === invite.id ? <Check size={14} style={{ color: 'var(--accent-good)' }} /> : <Copy size={14} />}
-                </button>
-                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" style={status.style}>
-                  {status.label}
-                </span>
-                <span className="text-xs" style={mutedStyle}>
-                  Created {new Date(invite.createdAt).toLocaleDateString()}
-                </span>
-              </div>
-              <button
-                onClick={() => deleteInvite(invite.id)}
-                className="p-1.5 rounded-lg transition-colors"
-                style={{ color: 'var(--accent-danger)' }}
-                onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-danger) 10%, transparent)'; }}
-                onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
-                title="Delete invite"
-              >
-                <Trash2 size={15} />
-              </button>
-            </div>
-          );
-        })}
-      </div>
-      {invites.length === 0 && !loading && (
-        <div className="text-center py-8 text-sm" style={mutedStyle}>No invite codes yet.</div>
-      )}
+      </Section>
     </div>
   );
 }
@@ -472,19 +511,24 @@ function SettingsSection() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
-  useEffect(() => {
-    request<{ mode: string }>('/admin/settings/registration')
-      .then(data => {
-        setMode(data.mode);
-        setLoading(false);
-      })
-      .catch(err => {
-        setError(err instanceof Error ? err.message : 'Failed to load settings');
-        setLoading(false);
-      });
+  const loadSettings = useCallback(async () => {
+    try {
+      const data = await request<{ mode: string }>('/admin/settings/registration');
+      setMode(data.mode);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load settings');
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const updateMode = async (newMode: string) => {
+  useEffect(() => {
+    void (async () => {
+      await loadSettings();
+    })();
+  }, [loadSettings]);
+
+  const updateMode = useCallback(async (newMode: string) => {
     try {
       setSaving(true);
       const data = await request<{ mode: string }>('/admin/settings/registration', {
@@ -498,53 +542,55 @@ function SettingsSection() {
     } finally {
       setSaving(false);
     }
-  };
+  }, []);
 
-  if (loading) {
-    return <div className="text-sm" style={mutedStyle}>Loading settings...</div>;
-  }
+  const modeBtnStyle = (active: boolean): CSSProperties => ({
+    flex: 1,
+    padding: '12px 16px',
+    borderRadius: 6,
+    border: `1px solid ${active ? 'var(--accent)' : 'var(--line)'}`,
+    background: active ? 'var(--accent-soft)' : 'transparent',
+    color: active ? 'var(--accent)' : 'var(--fg-3)',
+    cursor: 'pointer',
+    textAlign: 'left',
+    fontFamily: 'var(--font-mono)',
+    fontSize: 12,
+    transition: 'background 120ms, color 120ms, border-color 120ms',
+  });
 
   return (
-    <div>
-      {error && (
-        <div
-          className="mb-4 px-3 py-2 border rounded-lg text-sm"
-          style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
-        >
-          {error}
-        </div>
-      )}
-      <div className="rounded-lg border p-6" style={cardStyle}>
-        <h3 className="font-medium mb-1" style={headingStyle}>Registration Mode</h3>
-        <p className="text-sm mb-4" style={mutedStyle}>
-          Control how new users can sign up for the application.
-        </p>
-        <div className="flex gap-3">
-          <button
-            onClick={() => updateMode('open')}
-            disabled={saving}
-            className="flex-1 px-4 py-3 rounded-lg border text-sm font-medium transition-colors disabled:opacity-50"
-            style={mode === 'open'
-              ? { borderColor: 'var(--accent)', background: 'var(--accent-soft)', color: 'var(--accent)' }
-              : { borderColor: 'var(--line)', color: 'var(--fg-3)' }}
-          >
-            <div className="font-medium mb-0.5">Open Registration</div>
-            <div className="text-xs opacity-70">Anyone can create an account</div>
-          </button>
-          <button
-            onClick={() => updateMode('invite-only')}
-            disabled={saving}
-            className="flex-1 px-4 py-3 rounded-lg border text-sm font-medium transition-colors disabled:opacity-50"
-            style={mode === 'invite-only'
-              ? { borderColor: 'var(--accent)', background: 'var(--accent-soft)', color: 'var(--accent)' }
-              : { borderColor: 'var(--line)', color: 'var(--fg-3)' }}
-          >
-            <div className="font-medium mb-0.5">Invite Only</div>
-            <div className="text-xs opacity-70">Requires a valid invite code</div>
-          </button>
-        </div>
-        {saving && <p className="text-xs mt-3" style={mutedStyle}>Saving...</p>}
-      </div>
+    <div style={{ color: 'var(--fg-1)' }}>
+      {error && <div style={errorBoxStyle}>{error}</div>}
+
+      <Section title="registration mode">
+        <div style={helpText}>Control how new users can sign up for the application.</div>
+
+        {loading ? (
+          <div style={helpText}>Loading settings...</div>
+        ) : (
+          <Field label="signup policy">
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button
+                onClick={() => updateMode('open')}
+                disabled={saving}
+                style={{ ...modeBtnStyle(mode === 'open'), opacity: saving ? 0.5 : 1 }}
+              >
+                <div style={{ fontWeight: 600, marginBottom: 2 }}>Open Registration</div>
+                <div style={{ fontSize: 11, opacity: 0.75, textTransform: 'none' }}>Anyone can create an account</div>
+              </button>
+              <button
+                onClick={() => updateMode('invite-only')}
+                disabled={saving}
+                style={{ ...modeBtnStyle(mode === 'invite-only'), opacity: saving ? 0.5 : 1 }}
+              >
+                <div style={{ fontWeight: 600, marginBottom: 2 }}>Invite Only</div>
+                <div style={{ fontSize: 11, opacity: 0.75, textTransform: 'none' }}>Requires a valid invite code</div>
+              </button>
+            </div>
+            {saving && <div style={{ ...helpText, marginTop: 8 }}>Saving…</div>}
+          </Field>
+        )}
+      </Section>
     </div>
   );
 }

--- a/packages/client/src/pages/PluginsTab.tsx
+++ b/packages/client/src/pages/PluginsTab.tsx
@@ -6,6 +6,14 @@ import {
   ToggleLeft, ToggleRight, Tag, X, Save, RotateCcw,
 } from 'lucide-react';
 import { api, RegistryPlugin, PluginUpdate } from '../lib/api';
+import { Section, Field } from '../components/Settings/settings-kit';
+import {
+  helpText,
+  inputStyle as kitInputStyle,
+  primaryBtn,
+  ghostBtn,
+  dangerBtn,
+} from '../components/Settings/settings-kit-styles';
 
 /* ─────────────────────────── types ─────────────────────────── */
 
@@ -45,27 +53,38 @@ function semverGt(a: string, b: string): boolean {
 
 /* ─────────────────────────── shared styles ─────────────────────────── */
 
-const surfaceBox: CSSProperties = {
-  background: 'var(--bg-2)',
-  borderColor: 'var(--line)',
+const cardStyle: CSSProperties = {
+  background: 'var(--bg-1)',
+  border: '1px solid var(--line)',
+  borderRadius: 6,
+  padding: '12px 14px',
+  marginBottom: 8,
 };
 
-const inputStyle: CSSProperties = {
-  background: 'var(--bg-2)',
-  borderColor: 'var(--line)',
-  color: 'var(--fg)',
+const errorBoxStyle: CSSProperties = {
+  ...helpText,
+  marginBottom: 12,
+  padding: '8px 10px',
+  borderRadius: 5,
+  background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)',
+  border: '1px solid color-mix(in oklch, var(--accent-danger) 30%, transparent)',
+  color: 'var(--accent-danger)',
+  fontFamily: 'var(--font-mono)',
 };
 
-const tabActiveStyle: CSSProperties = {
-  background: 'var(--accent)',
-  color: '#fff',
-};
-
-const tabInactiveStyle: CSSProperties = {
-  background: 'var(--bg-2)',
-  color: 'var(--fg-3)',
-  borderColor: 'var(--line)',
-};
+const subTabStyle = (active: boolean): CSSProperties => ({
+  padding: '6px 10px',
+  borderRadius: 6,
+  background: active ? 'var(--accent-soft)' : 'transparent',
+  color: active ? 'var(--accent)' : 'var(--fg-3)',
+  border: 'none',
+  cursor: 'pointer',
+  fontFamily: 'var(--font-mono)',
+  fontSize: 12,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  transition: 'background 120ms, color 120ms',
+});
 
 /* ═══════════════════════════════════════════════════════════════
    Main PluginsTab — sub-view switcher
@@ -86,26 +105,15 @@ export function PluginsTab() {
   useEffect(() => { refreshInstalledIds(); }, [refreshInstalledIds]);
 
   return (
-    <div>
-      {/* Sub-view toggle */}
-      <div className="flex gap-2 mb-6">
-        <TabButton
-          active={subView === 'installed'}
-          onClick={() => setSubView('installed')}
-          label="Installed"
-        />
-        <TabButton
-          active={subView === 'browse'}
-          onClick={() => setSubView('browse')}
-          label="Browse Registry"
-        />
+    <div style={{ color: 'var(--fg-1)' }}>
+      {/* Sub-view toggle — same mode-pill pattern as the outer tabs */}
+      <div style={{ display: 'flex', gap: 2, marginBottom: 14 }}>
+        <SubTabBtn active={subView === 'installed'} onClick={() => setSubView('installed')} label="Installed" />
+        <SubTabBtn active={subView === 'browse'} onClick={() => setSubView('browse')} label="Browse Registry" />
       </div>
 
       {subView === 'browse' && (
-        <RegistryBrowse
-          installedIds={installedIds}
-          onInstalled={refreshInstalledIds}
-        />
+        <RegistryBrowse installedIds={installedIds} onInstalled={refreshInstalledIds} />
       )}
       {subView === 'installed' && (
         <InstalledPlugins onUninstalled={refreshInstalledIds} />
@@ -114,26 +122,23 @@ export function PluginsTab() {
   );
 }
 
-function TabButton({
-  active,
-  onClick,
-  label,
-}: {
-  active: boolean;
-  onClick: () => void;
-  label: string;
-}) {
-  const [hovered, setHovered] = useState(false);
-  const style: CSSProperties = active
-    ? tabActiveStyle
-    : { ...tabInactiveStyle, color: hovered ? 'var(--fg)' : 'var(--fg-3)' };
+function SubTabBtn({ active, onClick, label }: { active: boolean; onClick: () => void; label: string }) {
   return (
     <button
       onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${active ? '' : 'border'}`}
-      style={style}
+      style={subTabStyle(active)}
+      onMouseEnter={e => {
+        if (!active) {
+          e.currentTarget.style.background = 'var(--bg-hover)';
+          e.currentTarget.style.color = 'var(--fg)';
+        }
+      }}
+      onMouseLeave={e => {
+        if (!active) {
+          e.currentTarget.style.background = 'transparent';
+          e.currentTarget.style.color = 'var(--fg-3)';
+        }
+      }}
     >
       {label}
     </button>
@@ -158,8 +163,6 @@ function RegistryBrowse({
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [installing, setInstalling] = useState<Set<string>>(new Set());
   const [installError, setInstallError] = useState<Record<string, string>>({});
-  const [searchFocused, setSearchFocused] = useState(false);
-  const [clearHovered, setClearHovered] = useState(false);
 
   const fetchRegistry = useCallback(async () => {
     try {
@@ -174,7 +177,11 @@ function RegistryBrowse({
     }
   }, []);
 
-  useEffect(() => { fetchRegistry(); }, [fetchRegistry]);
+  useEffect(() => {
+    void (async () => {
+      await fetchRegistry();
+    })();
+  }, [fetchRegistry]);
 
   const allTags = useMemo(() => {
     const set = new Set<string>();
@@ -195,7 +202,7 @@ function RegistryBrowse({
     });
   }, [registry, query, activeTag]);
 
-  const install = async (id: string) => {
+  const install = useCallback(async (id: string) => {
     setInstalling(prev => new Set(prev).add(id));
     setInstallError(prev => { const n = { ...prev }; delete n[id]; return n; });
     try {
@@ -209,98 +216,74 @@ function RegistryBrowse({
     } finally {
       setInstalling(prev => { const n = new Set(prev); n.delete(id); return n; });
     }
-  };
-
-  if (loading) {
-    return (
-      <div className="space-y-3">
-        {[1, 2, 3].map(i => (
-          <div
-            key={i}
-            className="h-24 rounded-lg animate-pulse border"
-            style={surfaceBox}
-          />
-        ))}
-      </div>
-    );
-  }
+  }, [onInstalled]);
 
   if (error) {
     return (
-      <div
-        className="px-4 py-3 border rounded-lg text-sm flex items-center justify-between"
-        style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
-      >
+      <div style={{ ...errorBoxStyle, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <span>{error}</span>
-        <button onClick={fetchRegistry} className="ml-3 underline text-xs" style={{ color: 'var(--accent-danger)' }}>
-          Retry
-        </button>
+        <button onClick={fetchRegistry} style={{ ...ghostBtn, padding: '4px 8px' }}>Retry</button>
       </div>
     );
   }
 
   return (
-    <div>
-      {/* Search + tag filters */}
-      <div className="mb-4 flex flex-col gap-3">
-        <div className="relative">
-          <Search
-            size={15}
-            className="absolute left-3 top-1/2 -translate-y-1/2"
-            style={{ color: 'var(--fg-3)' }}
-          />
+    <Section title="browse registry">
+      <div style={helpText}>Search and install plugins from the public registry.</div>
+
+      <Field label="search">
+        <div style={{ position: 'relative' }}>
+          <Search size={14} style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', color: 'var(--fg-3)' }} />
           <input
             type="text"
             value={query}
             onChange={e => setQuery(e.target.value)}
-            onFocus={() => setSearchFocused(true)}
-            onBlur={() => setSearchFocused(false)}
             placeholder="Search plugins..."
-            className="w-full pl-9 pr-4 py-2 border rounded-lg text-sm focus:outline-none transition-colors"
-            style={{
-              ...inputStyle,
-              borderColor: searchFocused ? 'var(--accent)' : 'var(--line)',
-            }}
+            style={{ ...kitInputStyle, paddingLeft: 30, paddingRight: query ? 30 : 10 }}
           />
           {query && (
             <button
               onClick={() => setQuery('')}
-              onMouseEnter={() => setClearHovered(true)}
-              onMouseLeave={() => setClearHovered(false)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 transition-colors"
-              style={{ color: clearHovered ? 'var(--fg)' : 'var(--fg-3)' }}
+              aria-label="Clear search"
+              style={{
+                position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)',
+                background: 'transparent', border: 'none', color: 'var(--fg-3)', cursor: 'pointer', padding: 2,
+              }}
             >
-              <X size={13} />
+              <X size={12} />
             </button>
           )}
         </div>
-        {allTags.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {allTags.map(tag => (
-              <TagChip
-                key={tag}
-                tag={tag}
-                active={activeTag === tag}
-                onClick={() => setActiveTag(activeTag === tag ? null : tag)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      </Field>
 
-      {/* Plugin cards */}
-      {filtered.length === 0 ? (
-        <div className="text-center py-12 text-sm" style={{ color: 'var(--fg-4)' }}>
-          No plugins match your search.
+      {allTags.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 14 }}>
+          {allTags.map(tag => (
+            <TagChip
+              key={tag}
+              tag={tag}
+              active={activeTag === tag}
+              onClick={() => setActiveTag(activeTag === tag ? null : tag)}
+            />
+          ))}
         </div>
+      )}
+
+      {loading ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {[1, 2, 3].map(i => (
+            <div key={i} style={{ ...cardStyle, height: 72, opacity: 0.5 }} />
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div style={helpText}>No plugins match your search.</div>
       ) : (
-        <div className="space-y-3">
+        <div>
           {filtered.map(plugin => {
             const isInstalled = installedIds.has(plugin.id);
             const isInstalling = installing.has(plugin.id);
             const err = installError[plugin.id];
             const incompatible = semverGt(plugin.minKrytonVersion, KRYTON_VERSION);
-
             return (
               <PluginCard
                 key={plugin.id}
@@ -315,39 +298,18 @@ function RegistryBrowse({
           })}
         </div>
       )}
-    </div>
+    </Section>
   );
 }
 
-function TagChip({
-  tag,
-  active,
-  onClick,
-}: {
-  tag: string;
-  active: boolean;
-  onClick: () => void;
-}) {
-  const [hovered, setHovered] = useState(false);
-  const baseClass = 'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border';
-  const style: CSSProperties = active
-    ? {
-      background: 'var(--accent-soft)',
-      color: 'var(--accent)',
-      borderColor: 'var(--accent)',
-    }
-    : {
-      background: 'var(--bg-2)',
-      color: hovered ? 'var(--fg)' : 'var(--fg-3)',
-      borderColor: hovered ? 'var(--line-strong)' : 'var(--line)',
-    };
+function TagChip({ tag, active, onClick }: { tag: string; active: boolean; onClick: () => void }) {
   return (
     <button
       onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      className={baseClass}
-      style={style}
+      className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border"
+      style={active
+        ? { background: 'var(--accent-soft)', color: 'var(--accent)', borderColor: 'var(--accent)' }
+        : { background: 'var(--bg-2)', color: 'var(--fg-3)', borderColor: 'var(--line)' }}
     >
       <Tag size={10} />
       {tag}
@@ -356,12 +318,7 @@ function TagChip({
 }
 
 function PluginCard({
-  plugin,
-  isInstalled,
-  isInstalling,
-  err,
-  incompatible,
-  onInstall,
+  plugin, isInstalled, isInstalling, err, incompatible, onInstall,
 }: {
   plugin: RegistryPlugin;
   isInstalled: boolean;
@@ -370,99 +327,78 @@ function PluginCard({
   incompatible: boolean;
   onInstall: () => void;
 }) {
-  const [hovered, setHovered] = useState(false);
   return (
-    <div
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      className="flex items-start justify-between px-4 py-4 rounded-lg border transition-colors"
-      style={{
-        background: 'var(--bg-2)',
-        borderColor: hovered ? 'var(--line-strong)' : 'var(--line)',
-      }}
-    >
-      <div className="flex items-start gap-3 flex-1 min-w-0">
-        <div
-          className="mt-0.5 p-2 rounded-lg shrink-0"
-          style={{ background: 'var(--accent-soft)', color: 'var(--accent)' }}
-        >
-          <Package size={16} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm font-medium" style={{ color: 'var(--fg)' }}>{plugin.name}</span>
-            <span className="text-xs" style={{ color: 'var(--fg-4)' }}>v{plugin.version}</span>
-            <span className="text-xs" style={{ color: 'var(--fg-4)' }}>by {plugin.author}</span>
-            {isInstalled && (
-              <span
-                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                style={{ background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' }}
-              >
-                <CheckCircle size={10} />
-                Installed
-              </span>
-            )}
-            {incompatible && (
-              <span
-                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                style={{ background: 'color-mix(in oklch, var(--accent-warn) 20%, transparent)', color: 'var(--accent-warn)' }}
-              >
-                <AlertCircle size={10} />
-                Requires v{plugin.minKrytonVersion}
-              </span>
-            )}
-          </div>
-          <p className="text-xs mt-1 leading-relaxed" style={{ color: 'var(--fg-3)' }}>{plugin.description}</p>
-          {plugin.tags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-2">
-              {plugin.tags.map(tag => (
-                <span
-                  key={tag}
-                  className="px-1.5 py-0.5 rounded text-xs"
-                  style={{ background: 'var(--bg-2)', color: 'var(--fg-3)' }}
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
-          {err && (
-            <p className="text-xs mt-1" style={{ color: 'var(--accent-danger)' }}>{err}</p>
-          )}
-        </div>
+    <div style={{ ...cardStyle, display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+      <div
+        style={{
+          padding: 8, borderRadius: 6, background: 'var(--accent-soft)',
+          color: 'var(--accent)', flexShrink: 0,
+        }}
+      >
+        <Package size={16} />
       </div>
-      <div className="ml-4 shrink-0">
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)', fontWeight: 500 }}>
+            {plugin.name}
+          </span>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-4)' }}>v{plugin.version}</span>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-4)' }}>by {plugin.author}</span>
+          {isInstalled && (
+            <span
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+              style={{ background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' }}
+            >
+              <CheckCircle size={10} /> Installed
+            </span>
+          )}
+          {incompatible && (
+            <span
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+              style={{ background: 'color-mix(in oklch, var(--accent-warn) 20%, transparent)', color: 'var(--accent-warn)' }}
+            >
+              <AlertCircle size={10} /> Requires v{plugin.minKrytonVersion}
+            </span>
+          )}
+        </div>
+        <p style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-3)', marginTop: 4, lineHeight: 1.5 }}>
+          {plugin.description}
+        </p>
+        {plugin.tags.length > 0 && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 6 }}>
+            {plugin.tags.map(tag => (
+              <span
+                key={tag}
+                style={{
+                  fontFamily: 'var(--font-mono)', fontSize: 10, padding: '2px 6px',
+                  borderRadius: 4, background: 'var(--bg-2)', color: 'var(--fg-3)',
+                }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+        {err && <p style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--accent-danger)', marginTop: 6 }}>{err}</p>}
+      </div>
+      <div style={{ flexShrink: 0 }}>
         {!isInstalled && (
-          <InstallButton
+          <button
             onClick={onInstall}
             disabled={isInstalling || incompatible}
-            label={isInstalling ? 'Installing...' : 'Install'}
-          />
+            style={{
+              ...primaryBtn,
+              opacity: isInstalling || incompatible ? 0.5 : 1,
+              cursor: isInstalling || incompatible ? 'not-allowed' : 'pointer',
+              display: 'inline-flex', alignItems: 'center', gap: 4,
+            }}
+          >
+            <Download size={12} />
+            {isInstalling ? 'Installing…' : 'Install'}
+          </button>
         )}
       </div>
     </div>
-  );
-}
-
-function InstallButton({
-  onClick,
-  disabled,
-  label,
-}: {
-  onClick: () => void;
-  disabled: boolean;
-  label: string;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-      style={{ background: 'var(--accent)', color: '#fff' }}
-    >
-      <Download size={13} />
-      {label}
-    </button>
   );
 }
 
@@ -497,12 +433,14 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
     }
   }, []);
 
-  useEffect(() => { fetchAll(); }, [fetchAll]);
+  useEffect(() => {
+    void (async () => {
+      await fetchAll();
+    })();
+  }, [fetchAll]);
 
-  const doAction = async (
-    id: string,
-    label: string,
-    fn: () => Promise<unknown>,
+  const doAction = useCallback(async (
+    id: string, label: string, fn: () => Promise<unknown>,
   ) => {
     setActionLoading(prev => ({ ...prev, [id]: label }));
     setActionError(prev => { const n = { ...prev }; delete n[id]; return n; });
@@ -517,288 +455,181 @@ function InstalledPlugins({ onUninstalled }: { onUninstalled: () => void }) {
     } finally {
       setActionLoading(prev => { const n = { ...prev }; delete n[id]; return n; });
     }
-  };
+  }, [fetchAll]);
 
-  const uninstall = async (id: string) => {
+  const uninstall = useCallback(async (id: string) => {
     setConfirmUninstall(null);
     await doAction(id, 'Uninstalling', () => api.uninstallPlugin(id));
     onUninstalled();
-  };
-
-  if (loading) {
-    return (
-      <div className="space-y-3">
-        {[1, 2].map(i => (
-          <div
-            key={i}
-            className="h-20 rounded-lg animate-pulse border"
-            style={surfaceBox}
-          />
-        ))}
-      </div>
-    );
-  }
+  }, [doAction, onUninstalled]);
 
   if (error) {
     return (
-      <div
-        className="px-4 py-3 border rounded-lg text-sm flex items-center justify-between"
-        style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
-      >
+      <div style={{ ...errorBoxStyle, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <span>{error}</span>
-        <button onClick={fetchAll} className="ml-3 underline text-xs" style={{ color: 'var(--accent-danger)' }}>
-          Retry
-        </button>
-      </div>
-    );
-  }
-
-  if (plugins.length === 0) {
-    return (
-      <div className="text-center py-12 text-sm" style={{ color: 'var(--fg-4)' }}>
-        No plugins installed yet. Browse the registry to find plugins.
+        <button onClick={fetchAll} style={{ ...ghostBtn, padding: '4px 8px' }}>Retry</button>
       </div>
     );
   }
 
   return (
-    <div>
+    <Section title="installed plugins">
+      <div style={helpText}>Manage plugins installed on this server — enable, disable, configure, or update them.</div>
+
       {settingsPlugin && (
-        <PluginSettingsPanel
-          plugin={settingsPlugin}
-          onClose={() => setSettingsPlugin(null)}
-        />
+        <PluginSettingsPanel plugin={settingsPlugin} onClose={() => setSettingsPlugin(null)} />
       )}
 
-      <div className="space-y-3">
-        {plugins.map(plugin => {
-          const update = updates.find(u => u.id === plugin.id);
-          const busy = actionLoading[plugin.id];
-          const err = actionError[plugin.id];
-          const isActive = plugin.state === 'active';
-          const isDisabled = plugin.state === 'disabled' || plugin.state === 'unloaded';
-          const isError = plugin.state === 'error';
+      {loading ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {[1, 2].map(i => (
+            <div key={i} style={{ ...cardStyle, height: 60, opacity: 0.5 }} />
+          ))}
+        </div>
+      ) : plugins.length === 0 ? (
+        <div style={helpText}>No plugins installed yet. Browse the registry to find plugins.</div>
+      ) : (
+        <div>
+          {plugins.map(plugin => {
+            const update = updates.find(u => u.id === plugin.id);
+            const busy = actionLoading[plugin.id];
+            const err = actionError[plugin.id];
+            const isActive = plugin.state === 'active';
+            const isDisabled = plugin.state === 'disabled' || plugin.state === 'unloaded';
+            const isError = plugin.state === 'error';
 
-          return (
-            <div
-              key={plugin.id}
-              className="px-4 py-4 rounded-lg border"
-              style={surfaceBox}
-            >
-              <div className="flex items-start justify-between gap-3">
-                {/* Left: status dot + info */}
-                <div className="flex items-start gap-3 flex-1 min-w-0">
-                  <div className="mt-1 shrink-0">
-                    <StatusDot state={plugin.state} />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-sm font-medium" style={{ color: 'var(--fg)' }}>{plugin.name}</span>
-                      <span className="text-xs" style={{ color: 'var(--fg-4)' }}>v{plugin.version}</span>
-                      <span className="text-xs" style={{ color: 'var(--fg-4)' }}>by {plugin.author}</span>
-                      <StateLabel state={plugin.state} />
-                      {update && (
-                        <span
-                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
-                          style={{ background: 'color-mix(in oklch, var(--accent-warn) 20%, transparent)', color: 'var(--accent-warn)' }}
-                        >
-                          <AlertCircle size={10} />
-                          v{update.latestVersion} available
+            return (
+              <div key={plugin.id} style={cardStyle}>
+                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, flex: 1, minWidth: 0 }}>
+                    <div style={{ marginTop: 4, flexShrink: 0 }}>
+                      <StatusDot state={plugin.state} />
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)', fontWeight: 500 }}>
+                          {plugin.name}
                         </span>
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-4)' }}>v{plugin.version}</span>
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-4)' }}>by {plugin.author}</span>
+                        <StateLabel state={plugin.state} />
+                        {update && (
+                          <span
+                            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+                            style={{ background: 'color-mix(in oklch, var(--accent-warn) 20%, transparent)', color: 'var(--accent-warn)' }}
+                          >
+                            <AlertCircle size={10} /> v{update.latestVersion} available
+                          </span>
+                        )}
+                      </div>
+                      <p style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-3)', marginTop: 2, lineHeight: 1.5 }}>
+                        {plugin.description}
+                      </p>
+                      {isError && plugin.error && (
+                        <p style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--accent-danger)', marginTop: 4 }}>{plugin.error}</p>
+                      )}
+                      {err && (
+                        <p style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--accent-danger)', marginTop: 4 }}>{err}</p>
+                      )}
+                      {busy && (
+                        <p style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-4)', marginTop: 4 }}>{busy}…</p>
                       )}
                     </div>
-                    <p className="text-xs mt-0.5 leading-relaxed" style={{ color: 'var(--fg-3)' }}>{plugin.description}</p>
-                    {isError && plugin.error && (
-                      <p className="text-xs mt-1 font-mono" style={{ color: 'var(--accent-danger)' }}>{plugin.error}</p>
+                  </div>
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+                    {plugin.settings && plugin.settings.length > 0 && (
+                      <PluginIconBtn
+                        onClick={() => setSettingsPlugin(plugin)}
+                        title="Plugin settings"
+                        color="var(--fg-3)"
+                        icon={<Settings size={14} />}
+                      />
                     )}
-                    {err && (
-                      <p className="text-xs mt-1" style={{ color: 'var(--accent-danger)' }}>{err}</p>
+                    {isDisabled ? (
+                      <PluginIconBtn
+                        onClick={() => doAction(plugin.id, 'Enabling', () => api.enablePlugin(plugin.id))}
+                        title="Enable plugin"
+                        color="var(--accent-good)"
+                        disabled={!!busy}
+                        icon={<ToggleLeft size={14} />}
+                      />
+                    ) : (
+                      <PluginIconBtn
+                        onClick={() => doAction(plugin.id, 'Disabling', () => api.disablePlugin(plugin.id))}
+                        title="Disable plugin"
+                        color="var(--accent-warn)"
+                        disabled={!!busy}
+                        icon={<ToggleRight size={14} />}
+                      />
                     )}
-                    {busy && (
-                      <p className="text-xs mt-1" style={{ color: 'var(--fg-4)' }}>{busy}...</p>
+                    {isActive && (
+                      <PluginIconBtn
+                        onClick={() => doAction(plugin.id, 'Reloading', () => api.reloadPlugin(plugin.id))}
+                        title="Reload plugin"
+                        color="var(--accent)"
+                        disabled={!!busy}
+                        icon={<RotateCcw size={14} />}
+                      />
+                    )}
+                    {update && (
+                      <PluginIconBtn
+                        onClick={() => doAction(plugin.id, 'Updating', () => api.updatePlugin(plugin.id))}
+                        title={`Update to v${update.latestVersion}`}
+                        color="var(--accent-warn)"
+                        disabled={!!busy}
+                        icon={<RefreshCw size={14} />}
+                      />
+                    )}
+                    {confirmUninstall === plugin.id ? (
+                      <>
+                        <button onClick={() => uninstall(plugin.id)} style={dangerBtn}>Confirm</button>
+                        <button onClick={() => setConfirmUninstall(null)} style={ghostBtn}>Cancel</button>
+                      </>
+                    ) : (
+                      <PluginIconBtn
+                        onClick={() => setConfirmUninstall(plugin.id)}
+                        title="Uninstall plugin"
+                        color="var(--accent-danger)"
+                        disabled={!!busy}
+                        icon={<Trash2 size={14} />}
+                      />
                     )}
                   </div>
                 </div>
-
-                {/* Right: action buttons */}
-                <div className="flex items-center gap-1 shrink-0">
-                  {/* Settings (only if plugin has settings) */}
-                  {plugin.settings && plugin.settings.length > 0 && (
-                    <IconActionButton
-                      onClick={() => setSettingsPlugin(plugin)}
-                      title="Plugin settings"
-                      icon={<Settings size={15} />}
-                    />
-                  )}
-
-                  {/* Enable / Disable toggle */}
-                  {isDisabled ? (
-                    <button
-                      onClick={() => doAction(plugin.id, 'Enabling', () => api.enablePlugin(plugin.id))}
-                      disabled={!!busy}
-                      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
-                      style={{ color: 'var(--accent-good)' }}
-                      onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-good) 10%, transparent)'; }}
-                      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
-                      title="Enable plugin"
-                    >
-                      <ToggleLeft size={15} />
-                    </button>
-                  ) : (
-                    <DisableButton
-                      onClick={() => doAction(plugin.id, 'Disabling', () => api.disablePlugin(plugin.id))}
-                      disabled={!!busy}
-                    />
-                  )}
-
-                  {/* Reload */}
-                  {isActive && (
-                    <ReloadButton
-                      onClick={() => doAction(plugin.id, 'Reloading', () => api.reloadPlugin(plugin.id))}
-                      disabled={!!busy}
-                    />
-                  )}
-
-                  {/* Update */}
-                  {update && (
-                    <button
-                      onClick={() => doAction(plugin.id, 'Updating', () => api.updatePlugin(plugin.id))}
-                      disabled={!!busy}
-                      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
-                      style={{ color: 'var(--accent-warn)' }}
-                      onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-warn) 10%, transparent)'; }}
-                      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
-                      title={`Update to v${update.latestVersion}`}
-                    >
-                      <RefreshCw size={15} />
-                    </button>
-                  )}
-
-                  {/* Uninstall */}
-                  {confirmUninstall === plugin.id ? (
-                    <div className="flex items-center gap-1">
-                      <button
-                        onClick={() => uninstall(plugin.id)}
-                        className="px-2 py-1 rounded text-xs transition-colors"
-                        style={{ background: 'var(--accent-danger)', color: 'var(--fg)' }}
-                      >
-                        Confirm
-                      </button>
-                      <CancelButton onClick={() => setConfirmUninstall(null)} />
-                    </div>
-                  ) : (
-                    <button
-                      onClick={() => setConfirmUninstall(plugin.id)}
-                      disabled={!!busy}
-                      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
-                      style={{ color: 'var(--accent-danger)' }}
-                      onMouseEnter={e => { e.currentTarget.style.background = 'color-mix(in oklch, var(--accent-danger) 10%, transparent)'; }}
-                      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
-                      title="Uninstall plugin"
-                    >
-                      <Trash2 size={15} />
-                    </button>
-                  )}
-                </div>
               </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
+            );
+          })}
+        </div>
+      )}
+    </Section>
   );
 }
 
-function IconActionButton({
-  onClick,
-  title,
-  icon,
+function PluginIconBtn({
+  onClick, title, color, icon, disabled,
 }: {
   onClick: () => void;
   title: string;
+  color: string;
   icon: React.ReactNode;
+  disabled?: boolean;
 }) {
-  const [hovered, setHovered] = useState(false);
   return (
     <button
       onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      className="p-1.5 rounded-lg transition-colors"
+      disabled={disabled}
       title={title}
+      aria-label={title}
+      className="p-1.5 rounded-lg transition-colors"
       style={{
-        color: hovered ? 'var(--fg)' : 'var(--fg-3)',
-        background: hovered ? 'var(--bg-hover)' : 'transparent',
+        color, background: 'transparent', border: 'none',
+        cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
       }}
+      onMouseEnter={e => { if (!disabled) e.currentTarget.style.background = 'var(--bg-hover)'; }}
+      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
     >
       {icon}
-    </button>
-  );
-}
-
-function DisableButton({
-  onClick,
-  disabled,
-}: {
-  onClick: () => void;
-  disabled: boolean;
-}) {
-  const [hovered, setHovered] = useState(false);
-  return (
-    <button
-      onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      disabled={disabled}
-      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
-      title="Disable plugin"
-      style={{
-        color: hovered ? 'var(--accent-warn)' : 'var(--fg-3)',
-        background: hovered ? 'color-mix(in oklch, var(--accent-warn) 10%, transparent)' : 'transparent',
-      }}
-    >
-      <ToggleRight size={15} />
-    </button>
-  );
-}
-
-function ReloadButton({
-  onClick,
-  disabled,
-}: {
-  onClick: () => void;
-  disabled: boolean;
-}) {
-  const [hovered, setHovered] = useState(false);
-  return (
-    <button
-      onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      disabled={disabled}
-      className="p-1.5 rounded-lg transition-colors disabled:opacity-50"
-      title="Reload plugin"
-      style={{
-        color: hovered ? 'var(--accent)' : 'var(--fg-3)',
-        background: hovered ? 'var(--accent-soft)' : 'transparent',
-      }}
-    >
-      <RotateCcw size={15} />
-    </button>
-  );
-}
-
-function CancelButton({ onClick }: { onClick: () => void }) {
-  const [hovered, setHovered] = useState(false);
-  return (
-    <button
-      onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      className="px-2 py-1 rounded text-xs transition-colors"
-      style={{ color: hovered ? 'var(--fg)' : 'var(--fg-3)' }}
-    >
-      Cancel
     </button>
   );
 }
@@ -806,18 +637,13 @@ function CancelButton({ onClick }: { onClick: () => void }) {
 /* ─── Status dot ─── */
 
 function StatusDot({ state }: { state: InstalledPlugin['state'] }) {
-  if (state === 'active') {
-    return <span className="inline-block w-2 h-2 rounded-full mt-1" style={{ background: 'var(--accent-good)' }} />;
-  }
-  if (state === 'error') {
-    return <span className="inline-block w-2 h-2 rounded-full mt-1" style={{ background: 'var(--accent-danger)' }} />;
-  }
-  return (
-    <span
-      className="inline-block w-2 h-2 rounded-full mt-1"
-      style={{ background: 'var(--fg-4)' }}
-    />
-  );
+  const colors: Record<InstalledPlugin['state'], string> = {
+    active: 'var(--accent-good)',
+    error: 'var(--accent-danger)',
+    disabled: 'var(--fg-4)',
+    unloaded: 'var(--fg-4)',
+  };
+  return <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: colors[state] }} />;
 }
 
 function StateLabel({ state }: { state: InstalledPlugin['state'] }) {
@@ -827,8 +653,7 @@ function StateLabel({ state }: { state: InstalledPlugin['state'] }) {
         className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
         style={{ background: 'color-mix(in oklch, var(--accent-good) 20%, transparent)', color: 'var(--accent-good)' }}
       >
-        <CheckCircle size={10} />
-        Active
+        <CheckCircle size={10} /> Active
       </span>
     );
   }
@@ -838,8 +663,7 @@ function StateLabel({ state }: { state: InstalledPlugin['state'] }) {
         className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
         style={{ background: 'color-mix(in oklch, var(--accent-danger) 20%, transparent)', color: 'var(--accent-danger)' }}
       >
-        <XCircle size={10} />
-        Error
+        <XCircle size={10} /> Error
       </span>
     );
   }
@@ -873,38 +697,39 @@ function PluginSettingsPanel({
   const [error, setError] = useState('');
   const [saved, setSaved] = useState(false);
   const [expanded, setExpanded] = useState(true);
-  const [headerHovered, setHeaderHovered] = useState(false);
-  const [closeHovered, setCloseHovered] = useState(false);
 
   const adminSettings = plugin.settings.filter(s => !s.perUser);
   const userSettings = plugin.settings.filter(s => s.perUser);
 
-  // Load current settings from the global settings store
-  useEffect(() => {
-    (async () => {
-      try {
-        setLoading(true);
-        const all = await api.getSettings();
-        const initial: Record<string, unknown> = {};
-        plugin.settings.forEach(s => {
-          const key = `plugin:${plugin.id}:${s.key}`;
-          initial[s.key] = key in all ? all[key] : s.default;
-        });
-        setValues(initial);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load settings');
-      } finally {
-        setLoading(false);
-      }
-    })();
+  const loadValues = useCallback(async () => {
+    try {
+      setLoading(true);
+      const all = await api.getSettings();
+      const initial: Record<string, unknown> = {};
+      plugin.settings.forEach(s => {
+        const key = `plugin:${plugin.id}:${s.key}`;
+        initial[s.key] = key in all ? all[key] : s.default;
+      });
+      setValues(initial);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load settings');
+    } finally {
+      setLoading(false);
+    }
   }, [plugin]);
+
+  useEffect(() => {
+    void (async () => {
+      await loadValues();
+    })();
+  }, [loadValues]);
 
   const setValue = (key: string, value: unknown) => {
     setValues(prev => ({ ...prev, [key]: value }));
     setSaved(false);
   };
 
-  const save = async () => {
+  const save = useCallback(async () => {
     try {
       setSaving(true);
       setError('');
@@ -922,52 +747,51 @@ function PluginSettingsPanel({
     } finally {
       setSaving(false);
     }
-  };
+  }, [plugin, values]);
 
   return (
     <div
-      className="mb-4 rounded-lg border"
-      style={{ borderColor: 'var(--accent)', background: 'var(--accent-soft)' }}
+      style={{
+        marginBottom: 14,
+        borderRadius: 6,
+        border: '1px solid var(--accent)',
+        background: 'var(--accent-soft)',
+      }}
     >
-      {/* Panel header */}
       <button
         onClick={() => setExpanded(v => !v)}
-        onMouseEnter={() => setHeaderHovered(true)}
-        onMouseLeave={() => setHeaderHovered(false)}
-        className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium transition-colors"
-        style={{ color: headerHovered ? 'var(--fg)' : 'var(--accent)' }}
+        style={{
+          width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '10px 12px', background: 'transparent', border: 'none',
+          color: 'var(--accent)', cursor: 'pointer',
+          fontFamily: 'var(--font-mono)', fontSize: 12, fontWeight: 500,
+        }}
       >
-        <div className="flex items-center gap-2">
-          <Settings size={15} />
+        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <Settings size={14} />
           Settings — {plugin.name}
-        </div>
-        <div className="flex items-center gap-2">
-          <button
+        </span>
+        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span
+            role="button"
+            tabIndex={0}
             onClick={e => { e.stopPropagation(); onClose(); }}
-            onMouseEnter={() => setCloseHovered(true)}
-            onMouseLeave={() => setCloseHovered(false)}
-            className="p-0.5 rounded transition-colors"
-            style={{ color: closeHovered ? 'var(--fg)' : 'var(--fg-3)' }}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); onClose(); } }}
+            aria-label="Close settings"
+            style={{ padding: 2, display: 'inline-flex', color: 'var(--fg-3)' }}
           >
-            <X size={14} />
-          </button>
-          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-        </div>
+            <X size={13} />
+          </span>
+          {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        </span>
       </button>
 
       {expanded && (
-        <div className="px-4 pb-4">
-          {error && (
-            <div
-              className="mb-3 px-3 py-2 border rounded-lg text-xs"
-              style={{ background: 'color-mix(in oklch, var(--accent-danger) 10%, transparent)', borderColor: 'color-mix(in oklch, var(--accent-danger) 30%, transparent)', color: 'var(--accent-danger)' }}
-            >
-              {error}
-            </div>
-          )}
+        <div style={{ padding: '0 12px 12px 12px' }}>
+          {error && <div style={errorBoxStyle}>{error}</div>}
 
           {loading ? (
-            <div className="text-sm py-2" style={{ color: 'var(--fg-3)' }}>Loading settings...</div>
+            <div style={helpText}>Loading settings...</div>
           ) : (
             <>
               {adminSettings.length > 0 && (
@@ -989,18 +813,20 @@ function PluginSettingsPanel({
                 />
               )}
 
-              <div className="flex items-center gap-3 mt-4">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 12 }}>
                 <button
                   onClick={save}
                   disabled={saving}
-                  className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium disabled:opacity-50 transition-colors"
-                  style={{ background: 'var(--accent)', color: '#fff' }}
+                  style={{
+                    ...primaryBtn, opacity: saving ? 0.5 : 1,
+                    display: 'inline-flex', alignItems: 'center', gap: 6,
+                  }}
                 >
-                  <Save size={14} />
-                  {saving ? 'Saving...' : 'Save'}
+                  <Save size={12} />
+                  {saving ? 'Saving…' : 'Save'}
                 </button>
                 {saved && (
-                  <span className="text-xs flex items-center gap-1" style={{ color: 'var(--accent-good)' }}>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--accent-good)', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                     <CheckCircle size={12} /> Saved
                   </span>
                 )}
@@ -1014,11 +840,7 @@ function PluginSettingsPanel({
 }
 
 function SettingsGroup({
-  title,
-  subtitle,
-  settings,
-  values,
-  onChange,
+  title, subtitle, settings, values, onChange,
 }: {
   title: string;
   subtitle: string;
@@ -1027,12 +849,17 @@ function SettingsGroup({
   onChange: (key: string, value: unknown) => void;
 }) {
   return (
-    <div className="mb-4">
-      <div className="mb-2">
-        <p className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--fg)' }}>{title}</p>
-        <p className="text-xs" style={{ color: 'var(--fg-4)' }}>{subtitle}</p>
+    <div style={{ marginBottom: 14 }}>
+      <div style={{ marginBottom: 8 }}>
+        <div style={{
+          fontFamily: 'var(--font-mono)', fontSize: 10.5, letterSpacing: '0.08em',
+          textTransform: 'uppercase', color: 'var(--fg)', fontWeight: 600,
+        }}>
+          {title}
+        </div>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-4)' }}>{subtitle}</div>
       </div>
-      <div className="space-y-3">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
         {settings.map(s => (
           <SettingField key={s.key} decl={s} value={values[s.key]} onChange={v => onChange(s.key, v)} />
         ))}
@@ -1042,36 +869,33 @@ function SettingsGroup({
 }
 
 function SettingField({
-  decl,
-  value,
-  onChange,
+  decl, value, onChange,
 }: {
   decl: SettingDecl;
   value: unknown;
   onChange: (v: unknown) => void;
 }) {
-  const [focused, setFocused] = useState(false);
-  const inputClass = 'border rounded-lg px-3 py-1.5 text-sm focus:outline-none transition-colors';
-  const inputDynamicStyle: CSSProperties = {
-    ...inputStyle,
-    borderColor: focused ? 'var(--accent)' : 'var(--line)',
-  };
-
   if (decl.type === 'boolean') {
     const checked = Boolean(value);
     return (
-      <label className="flex items-center justify-between gap-3 cursor-pointer">
-        <span className="text-sm" style={{ color: 'var(--fg)' }}>{decl.label}</span>
+      <label style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, cursor: 'pointer' }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)' }}>{decl.label}</span>
         <button
           onClick={() => onChange(!checked)}
-          className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors"
-          style={{ background: checked ? 'var(--accent)' : 'var(--fg-4)' }}
+          style={{
+            position: 'relative', display: 'inline-flex', alignItems: 'center',
+            height: 20, width: 36, borderRadius: 999, border: 'none',
+            background: checked ? 'var(--accent)' : 'var(--fg-4)', cursor: 'pointer',
+            transition: 'background 120ms',
+          }}
         >
           <span
-            className={`inline-block h-3.5 w-3.5 rounded-full transform transition-transform ${
-              checked ? 'translate-x-4' : 'translate-x-0.5'
-            }`}
-            style={{ background: 'var(--fg)' }}
+            style={{
+              display: 'inline-block', height: 14, width: 14, borderRadius: '50%',
+              background: 'var(--fg)',
+              transform: checked ? 'translateX(18px)' : 'translateX(2px)',
+              transition: 'transform 120ms',
+            }}
           />
         </button>
       </label>
@@ -1080,34 +904,26 @@ function SettingField({
 
   if (decl.type === 'number') {
     return (
-      <div className="flex items-center justify-between gap-3">
-        <label className="text-sm" style={{ color: 'var(--fg)' }}>{decl.label}</label>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+        <label style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--fg)' }}>{decl.label}</label>
         <input
           type="number"
-          value={value as number ?? 0}
+          value={(value as number) ?? 0}
           onChange={e => onChange(Number(e.target.value))}
-          onFocus={() => setFocused(true)}
-          onBlur={() => setFocused(false)}
-          className={`w-28 text-right ${inputClass}`}
-          style={inputDynamicStyle}
+          style={{ ...kitInputStyle, width: 120, textAlign: 'right' }}
         />
       </div>
     );
   }
 
-  // string (default)
   return (
-    <div className="flex flex-col gap-1.5">
-      <label className="text-sm" style={{ color: 'var(--fg)' }}>{decl.label}</label>
+    <Field label={decl.label}>
       <input
         type="text"
-        value={value as string ?? ''}
+        value={(value as string) ?? ''}
         onChange={e => onChange(e.target.value)}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
-        className={`w-full ${inputClass}`}
-        style={inputDynamicStyle}
+        style={kitInputStyle}
       />
-    </div>
+    </Field>
   );
 }

--- a/packages/server/src/plugins/openapi.ts
+++ b/packages/server/src/plugins/openapi.ts
@@ -9,6 +9,217 @@ import type { AppConfig } from "../config/index.js";
 import { APP_VERSION } from "../lib/version.js";
 import { sharedSchemaRegistry } from "../shared-schemas/index.js";
 
+/**
+ * Kryton-themed Swagger UI overrides. Inlines the dark-theme tokens from
+ * `packages/client/src/styles/tokens.css` (the swagger UI is served from a
+ * stand-alone HTML shell, so it doesn't inherit our client's CSS variables).
+ * Also hides the upstream `.topbar` (which carries the Fastify logo by
+ * default) — the operation list already has its own info header.
+ */
+const KRYTON_SWAGGER_THEME = `
+:root, .swagger-ui {
+  --bg: oklch(0.18 0.012 280);
+  --bg-1: oklch(0.205 0.014 280);
+  --bg-2: oklch(0.235 0.016 282);
+  --bg-3: oklch(0.27 0.018 282);
+  --bg-input: oklch(0.225 0.014 282);
+  --bg-hover: oklch(0.255 0.018 285 / 0.6);
+  --line: oklch(0.32 0.012 280 / 0.6);
+  --line-strong: oklch(0.4 0.014 280 / 0.7);
+  --fg: oklch(0.96 0.005 280);
+  --fg-1: oklch(0.85 0.01 280);
+  --fg-2: oklch(0.65 0.012 280);
+  --fg-3: oklch(0.5 0.012 280);
+  --accent: oklch(0.72 0.18 295);
+  --accent-soft: oklch(0.72 0.18 295 / 0.18);
+  --accent-fg: oklch(0.18 0.02 280);
+  --accent-2: oklch(0.78 0.14 200);
+  --accent-warn: oklch(0.82 0.16 75);
+  --accent-good: oklch(0.78 0.16 155);
+  --accent-danger: oklch(0.7 0.2 25);
+  --font-mono: 'JetBrains Mono', 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+}
+
+/* Hide the Fastify-branded topbar wholesale. */
+.swagger-ui .topbar { display: none !important; }
+
+html, body { background: var(--bg) !important; }
+body { font-family: 'Inter', system-ui, -apple-system, sans-serif; }
+
+.swagger-ui, .swagger-ui .info, .swagger-ui .scheme-container,
+.swagger-ui .opblock-tag, .swagger-ui .opblock,
+.swagger-ui .opblock .opblock-summary, .swagger-ui .opblock .opblock-body,
+.swagger-ui .responses-wrapper, .swagger-ui .response-col_description__inner,
+.swagger-ui .models, .swagger-ui .model,
+.swagger-ui select, .swagger-ui input, .swagger-ui textarea {
+  color: var(--fg);
+}
+
+.swagger-ui .info .title,
+.swagger-ui .info h1, .swagger-ui .info h2, .swagger-ui .info h3,
+.swagger-ui .opblock-tag,
+.swagger-ui section.models h4,
+.swagger-ui .model-title {
+  color: var(--fg) !important;
+}
+
+.swagger-ui .info .title small,
+.swagger-ui .info .title small pre,
+.swagger-ui .info p, .swagger-ui .info li,
+.swagger-ui .opblock-tag small,
+.swagger-ui .opblock-description-wrapper p,
+.swagger-ui .response-col_description__inner div.markdown p,
+.swagger-ui .parameter__name, .swagger-ui .parameter__type,
+.swagger-ui .parameter__in, .swagger-ui table thead tr th,
+.swagger-ui table thead tr td, .swagger-ui .response-col_status,
+.swagger-ui .opblock .opblock-section-header h4,
+.swagger-ui .opblock .opblock-section-header > label {
+  color: var(--fg-2) !important;
+}
+
+.swagger-ui .scheme-container {
+  background: var(--bg-1) !important;
+  border-bottom: 1px solid var(--line) !important;
+  box-shadow: none !important;
+}
+
+.swagger-ui .info {
+  margin: 24px 0 16px 0;
+}
+
+.swagger-ui .opblock-tag {
+  border-bottom: 1px solid var(--line) !important;
+}
+
+.swagger-ui .opblock {
+  background: var(--bg-1) !important;
+  border: 1px solid var(--line) !important;
+  box-shadow: none !important;
+  border-radius: 8px !important;
+  margin: 0 0 12px 0 !important;
+}
+
+.swagger-ui .opblock .opblock-summary {
+  border-bottom: 1px solid var(--line) !important;
+}
+
+.swagger-ui .opblock .opblock-summary-method {
+  font-family: var(--font-mono);
+  text-shadow: none !important;
+  background: var(--bg-2) !important;
+  color: var(--fg) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: 5px !important;
+  min-width: 80px !important;
+}
+
+.swagger-ui .opblock-get .opblock-summary-method     { background: oklch(0.4 0.12 230 / 0.4) !important; color: var(--accent-2) !important; border-color: oklch(0.4 0.12 230 / 0.5) !important; }
+.swagger-ui .opblock-post .opblock-summary-method    { background: oklch(0.4 0.16 155 / 0.4) !important; color: var(--accent-good) !important; border-color: oklch(0.4 0.16 155 / 0.5) !important; }
+.swagger-ui .opblock-put .opblock-summary-method     { background: oklch(0.4 0.16 75 / 0.4)  !important; color: var(--accent-warn) !important; border-color: oklch(0.4 0.16 75 / 0.5)  !important; }
+.swagger-ui .opblock-delete .opblock-summary-method  { background: oklch(0.4 0.2 25 / 0.4)   !important; color: var(--accent-danger) !important; border-color: oklch(0.4 0.2 25 / 0.5)   !important; }
+.swagger-ui .opblock-patch .opblock-summary-method   { background: oklch(0.4 0.18 295 / 0.4) !important; color: var(--accent) !important; border-color: oklch(0.4 0.18 295 / 0.5) !important; }
+
+.swagger-ui .opblock .opblock-summary-path,
+.swagger-ui .opblock .opblock-summary-path a,
+.swagger-ui .opblock .opblock-summary-path__deprecated,
+.swagger-ui .opblock .opblock-summary-path__deprecated a {
+  font-family: var(--font-mono);
+  color: var(--fg) !important;
+}
+
+.swagger-ui input[type=text], .swagger-ui input[type=password],
+.swagger-ui input[type=search], .swagger-ui input[type=email],
+.swagger-ui textarea, .swagger-ui select {
+  background: var(--bg-input) !important;
+  color: var(--fg) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: 5px !important;
+  box-shadow: none !important;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.swagger-ui textarea.body-param__text {
+  font-family: var(--font-mono);
+  min-height: 150px;
+}
+
+.swagger-ui .btn {
+  background: var(--bg-2) !important;
+  color: var(--fg) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: 5px !important;
+  box-shadow: none !important;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+}
+.swagger-ui .btn:hover { background: var(--bg-3) !important; }
+
+.swagger-ui .btn.execute,
+.swagger-ui .btn.authorize {
+  background: var(--accent) !important;
+  color: var(--accent-fg) !important;
+  border-color: var(--accent) !important;
+}
+.swagger-ui .btn.authorize svg { fill: var(--accent-fg) !important; }
+
+.swagger-ui .btn.cancel { background: transparent !important; color: var(--accent-danger) !important; border-color: var(--accent-danger) !important; }
+
+.swagger-ui .response, .swagger-ui .responses-wrapper {
+  background: transparent !important;
+}
+.swagger-ui table tbody tr td,
+.swagger-ui table thead tr td, .swagger-ui table thead tr th {
+  background: transparent !important;
+  border-color: var(--line) !important;
+}
+.swagger-ui .response-col_status { font-family: var(--font-mono); }
+
+.swagger-ui pre, .swagger-ui .microlight,
+.swagger-ui .highlight-code,
+.swagger-ui .body-param__text,
+.swagger-ui .markdown code, .swagger-ui .renderedMarkdown code {
+  background: var(--bg) !important;
+  color: var(--fg) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: 6px !important;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.swagger-ui .opblock-description-wrapper, .swagger-ui .opblock-external-docs-wrapper, .swagger-ui .opblock-title_normal {
+  background: transparent !important;
+}
+
+.swagger-ui section.models {
+  background: var(--bg-1) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: 8px !important;
+}
+.swagger-ui section.models.is-open h4 { border-bottom: 1px solid var(--line) !important; }
+
+.swagger-ui .model-box { background: var(--bg-2) !important; border: 1px solid var(--line) !important; }
+.swagger-ui .model, .swagger-ui .model-toggle::after { color: var(--fg) !important; }
+.swagger-ui .prop-type { color: var(--accent-2) !important; }
+.swagger-ui .prop-format { color: var(--fg-3) !important; }
+
+.swagger-ui .auth-wrapper, .swagger-ui .dialog-ux .modal-ux {
+  background: var(--bg-1) !important;
+  border: 1px solid var(--line) !important;
+  color: var(--fg) !important;
+}
+.swagger-ui .dialog-ux .modal-ux-content,
+.swagger-ui .dialog-ux .modal-ux-header h3,
+.swagger-ui .dialog-ux .modal-ux-content h4 { color: var(--fg) !important; }
+
+.swagger-ui svg { fill: var(--fg-2); }
+.swagger-ui .arrow { fill: var(--fg-2) !important; }
+
+a, .swagger-ui a { color: var(--accent) !important; }
+`;
+
 interface OpenApiOptions {
   config: AppConfig;
 }
@@ -40,8 +251,12 @@ export const openapiPlugin = fp<OpenApiOptions>(async (app, { config }) => {
   });
 
   await app.register(swaggerUi, {
-    routePrefix: "/docs",
+    routePrefix: "/api/docs",
     uiConfig: { docExpansion: "list", deepLinking: false },
     staticCSP: true,
+    theme: {
+      title: "Kryton API",
+      css: [{ filename: "kryton-theme.css", content: KRYTON_SWAGGER_THEME }],
+    },
   });
 }, { name: "openapi" });


### PR DESCRIPTION
## Summary

AdminPage was rolling its own dialog chrome and section styling: max-w-4xl shell, underline tabs (`border-b-2`), plain `h3` section headings, ad-hoc inline styles. AccountSettingsPage is the design reference with tighter max-w-2xl, mode-pill tabs, mono `// SECTION` headers via the settings-kit primitives, and consistent primary/ghost/danger button styles.

## What changed

**Outer chrome** (`AdminPage.tsx`):
- Shell: `max-w-2xl` (was 4xl), fixed `height: min(640px, 85vh)` (matches Account Settings)
- Header: added `ShieldCheck` accent icon next to "Admin Panel"
- Tab strip: switched from underline (`border-b-2`) to accent-soft pills
- Tab icons unified to size 14

**Tab content** (Users, Invite Codes, Settings):
- Wrapped each in `<Section title="...">` (mono `// section name` header)
- Form rows use `<Field label="...">`, button rows use `<Toolbar>`
- Inputs use `kitInputStyle`, buttons use `primaryBtn` / `ghostBtn` / `dangerBtn`
- Users section switched from a wide table to row-cards (PasskeyManager pattern) since `max-w-2xl` can't fit a 6-column table cleanly. Info + role/status chips stack inside each row; toggle-disabled, toggle-role, reset-password, delete actions remain as icon buttons with their confirm flows

**PluginsTab.tsx**: matching treatment — `Section` wrappers, `helpText` for descriptions, accent-soft pill sub-tabs, settings-kit buttons. All existing behavior (registry browse, install, enable/disable, reload, update, uninstall, per-plugin settings panel) preserved.

## Business logic

Unchanged. All API calls, state, error handling, confirm dialogs, copy-to-clipboard, and admin-role guard are identical to before.

## React 19 hooks compliance

All effects use the IIFE + `useCallback` pattern (same as PR #111's fix). No `set-state-in-effect` violations introduced.

## Test plan

- [x] `npm run typecheck` clean (server + client)
- [x] `npm run lint` clean (`--max-warnings 0`)
- [x] Client tests: 17/17 pass
- [x] Visual verification: logged in as admin at http://localhost:5173/, walked all 4 admin tabs, compared to Account Settings dialog — chrome and section styling now match
- [ ] Manual: confirm the row-card layout for the Users tab is acceptable (was a table) — flagging since this is the only visual layout change beyond pure styling