### PR TITLE
feat: per-user fusion weights + reindex pill + Phase B design spec

### DIFF
--- a/docs/superpowers/specs/2026-05-12-novamem-cotenancy-design.md
+++ b/docs/superpowers/specs/2026-05-12-novamem-cotenancy-design.md
@@ -1,0 +1,230 @@
+# Kryton + NovaMem Postgres Co-Tenancy and Shared Identity Design
+
+**Date**: 2026-05-12
+**Status**: Draft
+**Prerequisite**: ✅ Postgres + Drizzle migration shipped (PR #109). ✅ Semantic search Phase A shipped (PR #114).
+
+## Problem
+
+Phase B of the semantic-search work introduces a `SEMANTIC_PROVIDER=novamem` option: instead of Kryton running its own Transformers.js + pgvector pipeline, it delegates to NovaMem's hybrid keyword+vector+graph engine. For this to be useful (not a Rube-Goldberg detour), the two services need to share **two things**:
+
+1. **A Postgres cluster.** Two database files on the same disk doesn't buy us anything; one Postgres with logically separated schemas does. NovaMem already runs Postgres + Drizzle + pgvector — same dialect as Kryton. The question is how to share it without either system stomping on the other.
+2. **An identity.** Kryton's `userId` should equal NovaMem's `userId`. Today they each have their own `User` table; a Kryton user that signs up doesn't exist in NovaMem until someone provisions them.
+
+This design covers both, plus the wiring inside Kryton's `SemanticProvider` interface so swapping providers is a config flip.
+
+## Decisions to lock in
+
+| # | Question | Recommended | Rationale |
+|---|---|---|---|
+| C1 | Schema layout in shared Postgres | Two schemas: `kryton` (default) + `novamem`. Each owns its tables. No cross-schema FKs. | Cleanest isolation. Each service runs its own `drizzle-kit migrate` against its schema. Either can be wiped without touching the other. |
+| C2 | Identity authority | **better-auth in Kryton** is authoritative. NovaMem reads sessions / validates JWTs against Kryton's tables; its own `User` table becomes a shadow keyed by Kryton's `userId`. | Kryton already has full auth (passkeys, 2FA, sessions, API keys). NovaMem is a memory engine, not an identity provider. |
+| C3 | Cross-service auth mechanism | Kryton mints short-lived JWTs (signed with `BETTER_AUTH_SECRET`); NovaMem validates them. No session-cookie sharing. | Stateless. Works regardless of NovaMem deployment (sidecar, separate host, even cross-machine). |
+| C4 | Single Postgres user or two roles | Two Postgres roles: `kryton` + `novamem`, each owning their schema. Grant `kryton` SELECT on `novamem.user_shadow` for joins. | Principle of least privilege. Either service can be DB-compromised without giving the attacker the other's data. |
+| C5 | Provider selection model | `SEMANTIC_PROVIDER=novamem` in Kryton's env. Same plugin (`plugins/embedder.ts`) loads a different `SemanticProvider` implementation. UI is unchanged. | Mirrors what the original semantic spec already designed (Q6). |
+| C6 | Migration path for existing self-hosters | New deployment only. Anyone running `pgvector-local` who wants to switch to NovaMem performs a one-time reindex: drop `NoteEmbeddingChunk`, set `SEMANTIC_PROVIDER=novamem`, run `POST /api/search/semantic/reindex?scope=all`. NovaMem re-ingests every note via `memory_remember`. | Idempotent. No data migration tool needed — NovaMem rebuilds from the filesystem (the source of truth). |
+| C7 | What `pgvector-local` users keep using | `pgvector-local` stays the default. NovaMem is opt-in. Most self-hosters running a single binary do NOT need NovaMem. | Already locked by Q6 of the original semantic spec. |
+
+## Design
+
+### Shared Postgres layout
+
+```
+postgres://localhost:5432/shared/
+├── schemas
+│   ├── kryton                    -- owned by `kryton` role
+│   │   ├── User                  -- better-auth tables
+│   │   ├── Session
+│   │   ├── ... (24 more Kryton tables)
+│   │   ├── NoteEmbeddingChunk    -- only populated when SEMANTIC_PROVIDER=pgvector-local
+│   │   └── EmbedJob              -- only populated when SEMANTIC_PROVIDER=pgvector-local
+│   └── novamem                   -- owned by `novamem` role
+│       ├── user_shadow           -- mirrors Kryton's User; updated by trigger or polling
+│       ├── memory                -- NovaMem's primary table (embeddings + keyword tsv)
+│       ├── memory_graph_edges    -- NovaMem's graph layer
+│       └── project_                -- NovaMem's "project" namespace concept; one per Kryton tenant
+```
+
+Grants:
+- `kryton` role: `ALL` on schema `kryton`, `SELECT, USAGE` on `novamem.user_shadow` (for joins if needed; usually not).
+- `novamem` role: `ALL` on schema `novamem`, `SELECT, USAGE` on `kryton."User"` (read-only shadow sync source).
+
+`search_path` for each service: `SET search_path TO kryton, public;` (Kryton) and `SET search_path TO novamem, public;` (NovaMem).
+
+### Identity sync: `user_shadow` table
+
+NovaMem operates on a thin shadow of Kryton's `User` table — it needs the `id` (foreign-key target) and `email` (display), nothing more.
+
+```sql
+CREATE TABLE novamem.user_shadow (
+  id text PRIMARY KEY,         -- mirrors kryton."User"."id"
+  email text NOT NULL,
+  synced_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+Two ways to keep it in sync, ranked:
+
+1. **Postgres trigger on `kryton."User"` writes:** `AFTER INSERT OR UPDATE OF email` → `INSERT INTO novamem.user_shadow ... ON CONFLICT (id) DO UPDATE`. Real-time, ~zero latency. The trigger uses `SECURITY DEFINER` so the `kryton` role can write into `novamem` without owning it.
+2. **Hourly polling job in NovaMem:** `INSERT INTO novamem.user_shadow SELECT id, email, NOW() FROM kryton."User" ON CONFLICT (id) DO UPDATE WHERE excluded.email != user_shadow.email`. Simpler; eventual consistency. Acceptable if NovaMem can tolerate a stale email for an hour.
+
+Recommendation: **(1) trigger.** Implementation is small; sync is exact.
+
+### Cross-service auth: short-lived JWTs
+
+When a Kryton-authenticated request needs to call NovaMem (e.g., `provider.search(query, userId)` in Kryton's embedder plugin), Kryton mints a JWT:
+
+```jsonc
+{
+  "iss": "kryton",
+  "aud": "novamem",
+  "sub": "<userId>",
+  "iat": 1700000000,
+  "exp": 1700000300,           // 5 min TTL
+  "scope": "memory.read memory.write"
+}
+```
+
+Signed with the same `BETTER_AUTH_SECRET` Kryton already uses. NovaMem's HTTP layer (or MCP server, depending on transport) validates the signature, checks `aud === "novamem"` and `exp > now()`, and treats `sub` as the authenticated user.
+
+The JWT is sent as `Authorization: Bearer <jwt>` on every Kryton → NovaMem call. NovaMem caches valid JWTs in-memory for 30 s to avoid re-verifying every request.
+
+No session cookies cross the boundary. No shared session store.
+
+### `SemanticProvider` interface
+
+The semantic spec already defined the interface. Phase B implementation:
+
+```ts
+// packages/server/src/modules/knowledge/services/providers/novamem.ts
+export class NovamemSemanticProvider implements SemanticProvider {
+  constructor(private deps: { endpoint: string; jwtMinter: JwtMinter }) {}
+
+  async upsert(input: { userId, notePath, title, content }): Promise<void> {
+    const jwt = await this.deps.jwtMinter.mint(input.userId);
+    await fetch(`${this.deps.endpoint}/memories/remember`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${jwt}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        project: `kryton-${input.userId}`,
+        sourceType: "note",
+        sourceId: input.notePath,
+        title: input.title,
+        content: input.content,
+      }),
+    });
+  }
+
+  async delete(input): Promise<void> { /* memories/forget */ }
+
+  async search(input): Promise<SemanticHit[]> {
+    const jwt = await this.deps.jwtMinter.mint(input.userId);
+    const res = await fetch(`${this.deps.endpoint}/memories/search`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${jwt}`, "content-type": "application/json" },
+      body: JSON.stringify({ project: `kryton-${input.userId}`, query: input.query, limit: input.limit }),
+    });
+    const data = await res.json();
+    return data.hits.map(toSemanticHit);
+  }
+
+  async ready(): Promise<{ provider: "novamem", dimensions: number, model?: string }> {
+    // GET /healthz on NovaMem
+  }
+}
+```
+
+Kryton's embedder plugin chooses the implementation at boot:
+
+```ts
+const provider = app.config.SEMANTIC_PROVIDER === "novamem"
+  ? new NovamemSemanticProvider({ endpoint: app.config.NOVAMEM_ENDPOINT, jwtMinter })
+  : new PgvectorLocalProvider({ embedder, db: app.db });
+```
+
+The `SearchService.enqueueEmbedJob` writer doesn't change — it still writes to `EmbedJob`. The worker, when `provider=novamem`, calls `provider.upsert` instead of reading from disk + chunking + writing to `NoteEmbeddingChunk`. NovaMem owns chunking + embedding internally.
+
+When `provider=novamem`, the fused-search SQL in `fused-search.service.ts` short-circuits: NovaMem already runs the 3-layer fusion natively, so Kryton just proxies `provider.search(query, userId)` and returns NovaMem's pre-ranked results.
+
+### Env vars
+
+```
+SEMANTIC_PROVIDER=novamem
+NOVAMEM_ENDPOINT=http://localhost:8080
+NOVAMEM_PROJECT_PREFIX=kryton-           # tenant projects become "kryton-<userId>"
+SEMANTIC_DIMENSIONS=384                   # must match NovaMem's collection
+```
+
+`BETTER_AUTH_SECRET` is already required for Kryton; the JWT minter reuses it. No separate secret to manage.
+
+### Docker Compose for the dual-service deployment
+
+```yaml
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: shared
+    volumes:
+      - ./packages/server/docker/postgres-init:/docker-entrypoint-initdb.d:ro
+      - shared-pgdata:/var/lib/postgresql/data
+
+  kryton:
+    image: ghcr.io/azrtydxb/kryton:latest
+    environment:
+      POSTGRES_URL: postgres://kryton:kryton@postgres:5432/shared
+      SEMANTIC_PROVIDER: novamem
+      NOVAMEM_ENDPOINT: http://novamem:8080
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
+
+  novamem:
+    image: novamem/novamem:latest
+    environment:
+      POSTGRES_URL: postgres://novamem:novamem@postgres:5432/shared
+      KRYTON_USER_TABLE: kryton."User"     # for shadow sync
+      JWT_AUDIENCE: novamem
+      JWT_ISSUER_SECRET: ${BETTER_AUTH_SECRET}
+```
+
+Postgres init script creates the two roles + schemas + grants + the trigger. A single command brings the whole stack up:
+
+```bash
+BETTER_AUTH_SECRET=...your-32+-char-secret... docker compose up
+```
+
+## Implementation phases
+
+This spec is design-only. When Phase B is on the table, implementation breaks into:
+
+1. **Postgres init script** with the two-schema, two-role setup + the user-shadow trigger (~80 lines of SQL)
+2. **JWT minter** in Kryton (`packages/server/src/lib/jwt-minter.ts`) — uses `jose` (already a transitive dep via better-auth) or `jsonwebtoken`
+3. **`NovamemSemanticProvider`** implementation — HTTP client + JWT injection + response mapping
+4. **Embedder plugin dispatch** — select provider based on `SEMANTIC_PROVIDER`
+5. **Fused-search proxy path** — when `provider=novamem`, route `/api/search/?q=...` to NovaMem's search and skip local fusion
+6. **Docker Compose example** in `docs/install/`
+7. **Integration tests** — testcontainers spawns BOTH `postgres` AND a NovaMem mock (or a real NovaMem build if available)
+
+Each phase is its own commit; the whole thing fits in one PR if NovaMem's HTTP API is stable.
+
+## Open questions
+
+1. **What's NovaMem's actual auth contract?** This spec assumes JWT with `Authorization: Bearer`. If NovaMem uses API keys, session cookies, or its own auth flow today, this spec needs updating before implementation. Concretely: check `/Users/pascal/Development/novamem-1/packages/server/src/http.ts` for the auth middleware.
+2. **What's NovaMem's HTTP API shape?** This spec sketches `/memories/remember`, `/memories/search`, `/memories/forget`, `/healthz`. The real routes may differ. Implementation will need to consult NovaMem's OpenAPI spec.
+3. **Does NovaMem's "project" concept map to Kryton tenants 1:1?** This spec assumes yes (one NovaMem project per Kryton user, named `kryton-<userId>`). If NovaMem projects are heavier-weight (per-org rather than per-user), the model may need a single shared project + a `userId` filter on every call.
+4. **Graph layer reconciliation.** Kryton's `GraphEdge` table (wikilink edges) drives Kryton's local graph layer. NovaMem has its own graph (`memory_graph_edges`). If `provider=novamem`, do we mirror Kryton's `GraphEdge` → NovaMem's graph on every wikilink change, or accept that NovaMem's graph layer is independent and may differ?
+   - Recommendation: mirror, via the same `EmbedJob` queue. A wikilink change on a note enqueues an upsert; the worker also sends the updated outgoing-link list to NovaMem.
+
+## Out of scope
+
+- **Replacing better-auth with a shared auth service.** Kryton keeps full ownership of identity.
+- **Multi-instance Kryton** (multiple Kryton servers talking to the same Postgres + NovaMem). Single-Kryton, single-NovaMem deployment for this design.
+- **Cross-user memory sharing.** NovaMem's `memory_neighbors` for shared notes is interesting but adds complexity; not in this design.
+- **Selecting between two NovaMem deployments at runtime.** One NovaMem instance per Kryton deployment.
+
+## Acceptance criteria for Phase B implementation (later)
+
+- `SEMANTIC_PROVIDER=novamem docker compose up` brings up the whole stack and a fresh signup → note creation → semantic search round-trip works
+- `SEMANTIC_PROVIDER=pgvector-local` still works unchanged (no regression)
+- `POST /api/search/semantic/reindex?scope=all` works for both providers
+- The JWT minter rotates JWTs cleanly when `BETTER_AUTH_SECRET` is rotated (no need to restart NovaMem)
+- Postgres trigger keeps `novamem.user_shadow` in sync with `kryton."User"` on every email change

--- a/packages/client/src/components/Layout/Header.tsx
+++ b/packages/client/src/components/Layout/Header.tsx
@@ -8,6 +8,7 @@
  */
 import { MutableRefObject, useMemo } from 'react';
 import { UserMenu } from './UserMenu';
+import { IndexingPill } from './IndexingPill';
 import { Icons } from '../Icons';
 import { usePrefs } from '../../stores/prefsStore';
 import { useUIStore } from '../../stores/uiStore';
@@ -190,6 +191,7 @@ export function Header({
       <div style={{ flex: 1 }} />
 
       {/* right cluster */}
+      <IndexingPill />
       {onNewNote && (
         <HeaderBtn onClick={onNewNote} title={`New note (${formatShortcut(['mod', 'shift', 'N'])})`} ariaLabel="New note">
           <Icons.Plus size={14} />

--- a/packages/client/src/components/Layout/IndexingPill.tsx
+++ b/packages/client/src/components/Layout/IndexingPill.tsx
@@ -1,0 +1,78 @@
+/**
+ * IndexingPill — small accent-soft chip in the header that surfaces
+ * "N indexing" while `pendingJobs > 0` on /api/search/semantic/ready.
+ *
+ * Polling cadence:
+ *   - 5 s while there's active indexing work (pendingJobs > 0)
+ *   - 30 s while idle (pendingJobs = 0)
+ *   - 30 s back-off on 401 (signed-out) and any network/5xx error
+ *
+ * Render: returns null when state is unloaded or pendingJobs === 0,
+ * so the pill is genuinely default-hidden — no "0 indexing" flash.
+ */
+import { useState, useEffect, type ReactElement } from 'react';
+import { Loader2 } from 'lucide-react';
+
+interface SemanticReady {
+  ready: boolean;
+  pendingJobs: number;
+}
+
+export function IndexingPill(): ReactElement | null {
+  const [state, setState] = useState<SemanticReady | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async (): Promise<void> => {
+      if (cancelled) return;
+      try {
+        const res = await fetch('/api/search/semantic/ready', { credentials: 'include' });
+        if (!res.ok) {
+          // 401 (not signed in) or 5xx — back off, leave any prior state alone.
+          if (!cancelled) timer = setTimeout(() => { void poll(); }, 30_000);
+          return;
+        }
+        const data = (await res.json()) as SemanticReady;
+        if (cancelled) return;
+        setState(data);
+        const next = data.pendingJobs > 0 ? 5_000 : 30_000;
+        timer = setTimeout(() => { void poll(); }, next);
+      } catch {
+        if (!cancelled) timer = setTimeout(() => { void poll(); }, 30_000);
+      }
+    };
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  if (!state || state.pendingJobs === 0) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      title={`${state.pendingJobs} note(s) are being indexed for semantic search`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '4px 10px',
+        borderRadius: 5,
+        background: 'var(--accent-soft)',
+        color: 'var(--accent)',
+        fontFamily: 'var(--font-mono)',
+        fontSize: 11,
+        letterSpacing: '0.04em',
+      }}
+    >
+      <Loader2 size={11} style={{ animation: 'spin 1s linear infinite' }} />
+      <span>{state.pendingJobs} indexing</span>
+    </div>
+  );
+}

--- a/packages/client/src/components/Layout/__tests__/IndexingPill.test.tsx
+++ b/packages/client/src/components/Layout/__tests__/IndexingPill.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { IndexingPill } from "../IndexingPill";
+
+function mockFetchOnce(body: { ready: boolean; pendingJobs: number }): void {
+  global.fetch = vi.fn().mockResolvedValueOnce({
+    ok: true,
+    json: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+describe("IndexingPill", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it("renders nothing when pendingJobs is 0", async () => {
+    mockFetchOnce({ ready: true, pendingJobs: 0 });
+    const { container } = render(<IndexingPill />);
+    // initial render before fetch resolves: null
+    expect(container.firstChild).toBeNull();
+    // flush microtasks so the fetch promise resolves
+    await vi.runOnlyPendingTimersAsync();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders 'N indexing' when pendingJobs > 0", async () => {
+    vi.useRealTimers();
+    mockFetchOnce({ ready: true, pendingJobs: 3 });
+    render(<IndexingPill />);
+    await waitFor(() => {
+      expect(screen.getByText(/3 indexing/)).toBeInTheDocument();
+    });
+  });
+
+  it("unmount during pending poll does not call setState", async () => {
+    // Construct a fetch promise we never resolve, then unmount the component.
+    // If the component called setState after unmount React would log a
+    // warning. We assert no console.error fires.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let resolveFetch!: (v: unknown) => void;
+    global.fetch = vi.fn().mockImplementation(
+      () => new Promise((resolve) => { resolveFetch = resolve; }),
+    ) as unknown as typeof fetch;
+
+    const { unmount } = render(<IndexingPill />);
+    unmount();
+    // Resolve after unmount — the component should ignore the result.
+    resolveFetch({ ok: true, json: async () => ({ ready: true, pendingJobs: 5 }) });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing on 401 (signed-out) without throwing", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
+    const { container } = render(<IndexingPill />);
+    await vi.runOnlyPendingTimersAsync();
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/client/src/pages/AccountSettingsPage.tsx
+++ b/packages/client/src/pages/AccountSettingsPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, FormEvent, CSSProperties } from 'react';
-import { Settings, User, Fingerprint, Key, Shield, X, Palette } from 'lucide-react';
+import { useState, useCallback, useEffect, FormEvent, CSSProperties } from 'react';
+import { Settings, User, Fingerprint, Key, Shield, X, Palette, Sliders } from 'lucide-react';
 
 const dialogStyle: CSSProperties = { background: 'var(--bg-1)' };
 const borderLine: CSSProperties = { borderColor: 'var(--line)' };
@@ -16,7 +16,7 @@ import {
   helpText,
 } from '../components/Settings/settings-kit-styles';
 
-type Tab = 'profile' | 'appearance' | 'passkeys' | 'api-keys' | '2fa';
+type Tab = 'profile' | 'appearance' | 'passkeys' | 'api-keys' | '2fa' | 'search';
 
 const TABS: { key: Tab; label: string; icon: typeof User }[] = [
   { key: 'profile', label: 'Profile', icon: User },
@@ -24,6 +24,7 @@ const TABS: { key: Tab; label: string; icon: typeof User }[] = [
   { key: 'passkeys', label: 'Passkeys', icon: Fingerprint },
   { key: 'api-keys', label: 'API Keys', icon: Key },
   { key: '2fa', label: '2FA', icon: Shield },
+  { key: 'search', label: 'Search', icon: Sliders },
 ];
 
 function ProfileSection() {
@@ -129,6 +130,149 @@ function ProfileSection() {
   );
 }
 
+interface FusionWeights {
+  lex: number;
+  sem: number;
+  graph: number;
+}
+
+const DEFAULT_WEIGHTS: FusionWeights = { lex: 0.4, sem: 0.4, graph: 0.2 };
+
+function SearchSection() {
+  const [weights, setWeights] = useState<FusionWeights>(DEFAULT_WEIGHTS);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState(0);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/search/weights', { credentials: 'include' });
+        if (!res.ok) throw new Error(`Failed to load weights (${res.status})`);
+        const data = (await res.json()) as FusionWeights;
+        if (!cancelled) setWeights(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleSave = useCallback(async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      const res = await fetch('/api/search/weights', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(weights),
+      });
+      if (!res.ok) throw new Error(`Failed to save (${res.status})`);
+      const data = (await res.json()) as FusionWeights;
+      setWeights(data);
+      setSavedAt(Date.now());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }, [weights]);
+
+  const setField = (k: keyof FusionWeights) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = parseFloat(e.target.value);
+    setWeights((prev) => ({ ...prev, [k]: Number.isFinite(v) ? v : 0 }));
+  };
+
+  const focusRing = (e: React.FocusEvent<HTMLInputElement>): void => {
+    e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent-soft)';
+  };
+  const blurRing = (e: React.FocusEvent<HTMLInputElement>): void => {
+    e.currentTarget.style.boxShadow = 'none';
+  };
+
+  return (
+    <div style={{ color: 'var(--fg-1)', maxWidth: 420 }}>
+      <Section title="fusion weights">
+        <div style={helpText}>
+          Search combines three signal sources: <strong>lexical</strong> (exact word match),{' '}
+          <strong>semantic</strong> (meaning similarity), and <strong>graph</strong> (wikilink
+          proximity). Adjust the weights to bias your search results. Values are normalised so the
+          total is 1.
+        </div>
+        <form onSubmit={handleSave}>
+          <Field label="lexical">
+            <input
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              value={weights.lex}
+              onChange={setField('lex')}
+              disabled={loading || saving}
+              style={kitInputStyle}
+              onFocus={focusRing}
+              onBlur={blurRing}
+            />
+          </Field>
+          <Field label="semantic">
+            <input
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              value={weights.sem}
+              onChange={setField('sem')}
+              disabled={loading || saving}
+              style={kitInputStyle}
+              onFocus={focusRing}
+              onBlur={blurRing}
+            />
+          </Field>
+          <Field label="graph">
+            <input
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              value={weights.graph}
+              onChange={setField('graph')}
+              disabled={loading || saving}
+              style={kitInputStyle}
+              onFocus={focusRing}
+              onBlur={blurRing}
+            />
+          </Field>
+          {error && (
+            <div style={{ ...helpText, color: 'var(--accent-danger)', marginBottom: 8 }}>
+              {error}
+            </div>
+          )}
+          {savedAt > 0 && !error && (
+            <div style={{ ...helpText, color: 'var(--accent-good)', marginBottom: 8 }}>
+              Weights saved and normalised.
+            </div>
+          )}
+          <Toolbar>
+            <button
+              type="submit"
+              disabled={loading || saving}
+              style={{ ...primaryBtn, opacity: loading || saving ? 0.6 : 1, cursor: loading || saving ? 'not-allowed' : 'pointer' }}
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </Toolbar>
+        </form>
+      </Section>
+    </div>
+  );
+}
+
 export default function AccountSettingsPage({ onClose }: { onClose: () => void }) {
   const [tab, setTab] = useState<Tab>('profile');
 
@@ -211,6 +355,7 @@ export default function AccountSettingsPage({ onClose }: { onClose: () => void }
           {tab === 'passkeys' && <PasskeyManagerContent />}
           {tab === 'api-keys' && <ApiKeyManager />}
           {tab === '2fa' && <TwoFactorManager />}
+          {tab === 'search' && <SearchSection />}
         </div>
       </div>
     </div>

--- a/packages/client/src/styles/tokens.css
+++ b/packages/client/src/styles/tokens.css
@@ -153,6 +153,10 @@ body {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.45; }
 }
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
 .scanline {
   background: linear-gradient(180deg, transparent 0%, var(--accent-soft) 50%, transparent 100%);
 }

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -2512,6 +2512,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/search/weights": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the current user's fusion weights (lex/sem/graph) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            graph: number;
+                            lex: number;
+                            sem: number;
+                        };
+                    };
+                };
+            };
+        };
+        /** Update the current user's fusion weights (normalised to sum=1) */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        graph: number;
+                        lex: number;
+                        sem: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            graph: number;
+                            lex: number;
+                            sem: number;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/settings/": {
         parameters: {
             query?: never;

--- a/packages/server/openapi.snapshot.json
+++ b/packages/server/openapi.snapshot.json
@@ -3918,6 +3918,122 @@
         ]
       }
     },
+    "/api/search/weights": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "graph": {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "lex": {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "sem": {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "lex",
+                    "sem",
+                    "graph"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Get the current user's fusion weights (lex/sem/graph)",
+        "tags": [
+          "knowledge"
+        ]
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "graph": {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "lex": {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  },
+                  "sem": {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "lex",
+                  "sem",
+                  "graph"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "graph": {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "lex": {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "sem": {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "lex",
+                    "sem",
+                    "graph"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Update the current user's fusion weights (normalised to sum=1)",
+        "tags": [
+          "knowledge"
+        ]
+      }
+    },
     "/api/settings/": {
       "get": {
         "responses": {

--- a/packages/server/src/modules/knowledge/__tests__/fused-search.routes.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/fused-search.routes.test.ts
@@ -3,6 +3,7 @@ import { user } from "../../../db/schema/auth.js";
 import { searchIndex, graphEdge } from "../../../db/schema/notes.js";
 import { noteEmbeddingChunk } from "../../../db/schema/embeddings.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
+import { setFusionWeights } from "../services/fusion-weights.service.js";
 import {
   buildKnowledgeTestApp,
   createKnowledgeTestDb,
@@ -272,6 +273,91 @@ describe("knowledge / GET /api/search (fused)", () => {
     expect(paths).not.toContain("loner.md");
     // Top should outrank the graph-only neighbour.
     expect(paths.indexOf("top.md")).toBeLessThan(paths.indexOf("neighbour.md"));
+  });
+
+  it("custom fusion weights re-order results: lex-only weight ignores graph neighbour", async () => {
+    const now = new Date("2026-05-11T00:00:00Z");
+    // Same setup as the graph-boost test: top.md has the lexical+semantic
+    // hit; neighbour.md only appears via the graph layer. With default
+    // weights (0.2 graph), neighbour appears. With lex-only weights
+    // (graph=0), neighbour MUST drop out entirely.
+    await dbHandle.db.insert(searchIndex).values([
+      {
+        notePath: "top.md",
+        userId: TEST_USER.id,
+        title: "Top",
+        content: "marker keyword appears here",
+        tags: "[]",
+        modifiedAt: now,
+      },
+      {
+        notePath: "neighbour.md",
+        userId: TEST_USER.id,
+        title: "Neighbour",
+        content: "unrelated prose",
+        tags: "[]",
+        modifiedAt: now,
+      },
+    ]);
+
+    await dbHandle.db.insert(noteEmbeddingChunk).values([
+      {
+        userId: TEST_USER.id,
+        notePath: "top.md",
+        chunkIndex: 0,
+        chunkText: "top chunk text",
+        embedding: Array.from(oneHot(0)),
+        modifiedAt: now,
+      },
+    ]);
+
+    await dbHandle.db.insert(graphEdge).values([
+      {
+        userId: TEST_USER.id,
+        fromPath: "top.md",
+        toPath: "neighbour.md",
+        fromNoteId: "n-top",
+        toNoteId: "n-neigh",
+      },
+    ]);
+
+    const fakeEmbedder = {
+      model: "fake-mini",
+      dimensions: DIM,
+      async embed(texts: string[]): Promise<Float32Array[]> {
+        return texts.map(() => oneHot(0));
+      },
+      async embedQuery(_text: string): Promise<Float32Array> {
+        return oneHot(0);
+      },
+    };
+
+    const app = await buildKnowledgeTestApp({
+      user: TEST_USER,
+      dbHandle,
+      embedderState: {
+        ready: true,
+        provider: "pgvector-local",
+        model: "fake-mini",
+        dimensions: DIM,
+        embedder: fakeEmbedder,
+      },
+    });
+    close = () => app.close();
+
+    // Tilt the weights all the way to lexical — graph contribution = 0.
+    await setFusionWeights(app, TEST_USER.id, { lex: 1, sem: 0, graph: 0 });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/search?q=marker",
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    const paths = body.map((r: { path: string }) => r.path);
+    expect(paths).toContain("top.md");
+    // Graph-only neighbour must NOT appear under lex-only weights.
+    expect(paths).not.toContain("neighbour.md");
   });
 
   it("every fused result has a numeric score field populated", async () => {

--- a/packages/server/src/modules/knowledge/__tests__/fusion-weights.routes.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/fusion-weights.routes.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { user } from "../../../db/schema/auth.js";
+import type { TestDbHandle } from "../../../test/db-fixture.js";
+import {
+  buildKnowledgeTestApp,
+  createKnowledgeTestDb,
+  resetKnowledgeTestDb,
+} from "./helpers.js";
+
+/**
+ * GET/PUT /api/search/weights — per-user fusion weights backed by the
+ * Settings table (key: "fusion_weights").
+ */
+
+const TEST_USER = {
+  id: "u-fw",
+  email: "fw@example.com",
+  name: "F",
+  role: "user",
+};
+
+async function seedUser(handle: TestDbHandle): Promise<void> {
+  await handle.db.insert(user).values({
+    id: TEST_USER.id,
+    name: TEST_USER.name,
+    email: TEST_USER.email,
+  });
+}
+
+describe("knowledge / /api/search/weights", () => {
+  let dbHandle: TestDbHandle;
+  let close: (() => Promise<void>) | null = null;
+
+  beforeAll(() => {
+    dbHandle = createKnowledgeTestDb();
+  });
+
+  afterAll(async () => {
+    await dbHandle.close();
+  });
+
+  beforeEach(async () => {
+    await resetKnowledgeTestDb(dbHandle);
+    await seedUser(dbHandle);
+  });
+
+  afterEach(async () => {
+    if (close) await close();
+    close = null;
+  });
+
+  it("GET returns defaults 0.4/0.4/0.2 when user has no setting", async () => {
+    const app = await buildKnowledgeTestApp({ user: TEST_USER, dbHandle });
+    close = () => app.close();
+
+    const res = await app.inject({ method: "GET", url: "/api/search/weights" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.lex).toBeCloseTo(0.4, 5);
+    expect(body.sem).toBeCloseTo(0.4, 5);
+    expect(body.graph).toBeCloseTo(0.2, 5);
+  });
+
+  it("PUT normalises unnormalised weights so sum=1", async () => {
+    const app = await buildKnowledgeTestApp({ user: TEST_USER, dbHandle });
+    close = () => app.close();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/search/weights",
+      payload: { lex: 1, sem: 1, graph: 0.5 },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // 1/2.5=0.4 ; 0.5/2.5=0.2
+    expect(body.lex).toBeCloseTo(0.4, 5);
+    expect(body.sem).toBeCloseTo(0.4, 5);
+    expect(body.graph).toBeCloseTo(0.2, 5);
+    expect(body.lex + body.sem + body.graph).toBeCloseTo(1, 5);
+  });
+
+  it("GET after PUT returns the stored normalised weights", async () => {
+    const app = await buildKnowledgeTestApp({ user: TEST_USER, dbHandle });
+    close = () => app.close();
+
+    await app.inject({
+      method: "PUT",
+      url: "/api/search/weights",
+      payload: { lex: 0.6, sem: 0.3, graph: 0.1 },
+    });
+
+    const res = await app.inject({ method: "GET", url: "/api/search/weights" });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.lex).toBeCloseTo(0.6, 5);
+    expect(body.sem).toBeCloseTo(0.3, 5);
+    expect(body.graph).toBeCloseTo(0.1, 5);
+  });
+
+  it("PUT with all zeros falls back to defaults", async () => {
+    const app = await buildKnowledgeTestApp({ user: TEST_USER, dbHandle });
+    close = () => app.close();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/search/weights",
+      payload: { lex: 0, sem: 0, graph: 0 },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.lex).toBeCloseTo(0.4, 5);
+    expect(body.sem).toBeCloseTo(0.4, 5);
+    expect(body.graph).toBeCloseTo(0.2, 5);
+  });
+});

--- a/packages/server/src/modules/knowledge/__tests__/helpers.ts
+++ b/packages/server/src/modules/knowledge/__tests__/helpers.ts
@@ -27,6 +27,7 @@ export async function resetKnowledgeTestDb(handle: TestDbHandle): Promise<void> 
       "EmbedJob",
       "NoteEmbeddingChunk",
       "NoteShare",
+      "Settings",
       "User"
     RESTART IDENTITY CASCADE
   `);

--- a/packages/server/src/modules/knowledge/routes/search.routes.ts
+++ b/packages/server/src/modules/knowledge/routes/search.routes.ts
@@ -3,6 +3,7 @@ import type { ZodTypeProvider } from "fastify-type-provider-zod";
 import { eq, sql } from "drizzle-orm";
 
 import {
+  fusionWeightsSchema,
   searchQuerySchema,
   searchResponseSchema,
   semanticReadyResponseSchema,
@@ -11,6 +12,10 @@ import {
 } from "../schemas/search.schemas.js";
 import type { SearchService } from "../services/search.service.js";
 import { searchFused } from "../services/fused-search.service.js";
+import {
+  getFusionWeights,
+  setFusionWeights,
+} from "../services/fusion-weights.service.js";
 import { searchIndex } from "../../../db/schema/notes.js";
 import { embedJob } from "../../../db/schema/embeddings.js";
 import { ForbiddenError } from "../../../lib/errors.js";
@@ -154,6 +159,43 @@ export const searchRoutes: FastifyPluginAsync<SearchRoutesOptions> = async (
         });
 
       return { enqueued: rows.length };
+    },
+  );
+
+  typed.get(
+    "/weights",
+    {
+      schema: {
+        tags: ["knowledge"],
+        summary: "Get the current user's fusion weights (lex/sem/graph)",
+        response: { 200: fusionWeightsSchema },
+      },
+      preHandler: async (req) => {
+        await app.auth.requireUser(req);
+      },
+    },
+    async (req) => {
+      const user = await app.auth.requireUser(req);
+      return getFusionWeights(app, user.id);
+    },
+  );
+
+  typed.put(
+    "/weights",
+    {
+      schema: {
+        tags: ["knowledge"],
+        summary: "Update the current user's fusion weights (normalised to sum=1)",
+        body: fusionWeightsSchema,
+        response: { 200: fusionWeightsSchema },
+      },
+      preHandler: async (req) => {
+        await app.auth.requireUser(req);
+      },
+    },
+    async (req) => {
+      const user = await app.auth.requireUser(req);
+      return setFusionWeights(app, user.id, req.body);
     },
   );
 };

--- a/packages/server/src/modules/knowledge/schemas/search.schemas.ts
+++ b/packages/server/src/modules/knowledge/schemas/search.schemas.ts
@@ -34,3 +34,9 @@ export const semanticReindexQuerySchema = z.object({
 export const semanticReindexResponseSchema = z.object({
   enqueued: z.number().int(),
 });
+
+export const fusionWeightsSchema = z.object({
+  lex: z.number().min(0).max(1),
+  sem: z.number().min(0).max(1),
+  graph: z.number().min(0).max(1),
+});

--- a/packages/server/src/modules/knowledge/services/fused-search.service.ts
+++ b/packages/server/src/modules/knowledge/services/fused-search.service.ts
@@ -8,9 +8,9 @@
  *   - Graph: 1-hop neighbours (in either direction) of the union of the
  *     top lexical + semantic hits, drawn from `GraphEdge`
  *
- * RRF formula: score = Σ wᵢ / (k + rankᵢ) with k=60 and weights
- * 0.4 / 0.4 / 0.2 (lex / sem / graph). Constants are hardcoded for now;
- * per-user weights are a future Settings entry.
+ * RRF formula: score = Σ wᵢ / (k + rankᵢ) with k=60. Weights default to
+ * 0.4 / 0.4 / 0.2 (lex / sem / graph) but are per-user adjustable via the
+ * `Settings` table (key: "fusion_weights") — see fusion-weights.service.ts.
  *
  * Snippet selection:
  *   - If semantic contributed (sem_rank IS NOT NULL): use the best chunk
@@ -27,6 +27,7 @@ import { sql } from "drizzle-orm";
 
 import { parseTags } from "./search-helpers.js";
 import type { SearchResult } from "./search-query.js";
+import { getFusionWeights } from "./fusion-weights.service.js";
 
 interface FusedRow {
   note_path: string;
@@ -70,6 +71,12 @@ export async function searchFused(
   const qv = await embedderState.embedder.embedQuery(query);
   const qvLiteral = `[${Array.from(qv).join(",")}]`;
   const trimmed = query.trim();
+
+  // Per-user fusion weights (already normalised so lex+sem+graph = 1).
+  const weights = await getFusionWeights(app, userId);
+  const wLex = weights.lex;
+  const wSem = weights.sem;
+  const wGraph = weights.graph;
 
   // Single statement, all CTEs. Column-name caveats:
   //   - "SearchIndex": camelCase quoted ("notePath", "userId", "modifiedAt")
@@ -138,9 +145,9 @@ export async function searchFused(
         sr.best_chunk_text,
         gr.graph_rank,
         (
-          COALESCE(0.4::float / (60 + l.lex_rank), 0) +
-          COALESCE(0.4::float / (60 + sr.sem_rank), 0) +
-          COALESCE(0.2::float / (60 + gr.graph_rank), 0)
+          COALESCE(${wLex}::float / (60 + l.lex_rank), 0) +
+          COALESCE(${wSem}::float / (60 + sr.sem_rank), 0) +
+          COALESCE(${wGraph}::float / (60 + gr.graph_rank), 0)
         ) AS score
       FROM lexical l
       FULL OUTER JOIN semantic_ranked sr USING (note_path)

--- a/packages/server/src/modules/knowledge/services/fusion-weights.service.ts
+++ b/packages/server/src/modules/knowledge/services/fusion-weights.service.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-user fusion weights for the 3-layer RRF search.
+ *
+ * Backed by the existing `Settings` table (composite PK `(key, userId)`).
+ * Key = "fusion_weights", value = JSON-encoded { lex, sem, graph }.
+ *
+ * Defaults if no row exists: { lex: 0.4, sem: 0.4, graph: 0.2 }.
+ *
+ * All write paths normalise so `lex + sem + graph === 1`. Read path
+ * also normalises defensively in case the stored row was hand-edited.
+ */
+import type { FastifyInstance } from "fastify";
+import { and, eq } from "drizzle-orm";
+
+import { settings } from "../../../db/schema/settings.js";
+
+export interface FusionWeights {
+  lex: number;
+  sem: number;
+  graph: number;
+}
+
+export const DEFAULT_FUSION_WEIGHTS: FusionWeights = {
+  lex: 0.4,
+  sem: 0.4,
+  graph: 0.2,
+};
+
+const SETTINGS_KEY = "fusion_weights";
+
+/** Normalise so sum = 1; if all zero/negative, fall back to defaults. */
+export function normaliseWeights(w: FusionWeights): FusionWeights {
+  const lex = Math.max(0, w.lex);
+  const sem = Math.max(0, w.sem);
+  const graph = Math.max(0, w.graph);
+  const sum = lex + sem + graph;
+  if (sum <= 0) return { ...DEFAULT_FUSION_WEIGHTS };
+  return { lex: lex / sum, sem: sem / sum, graph: graph / sum };
+}
+
+export async function getFusionWeights(
+  app: FastifyInstance,
+  userId: string,
+): Promise<FusionWeights> {
+  const row = await app.db
+    .select({ value: settings.value })
+    .from(settings)
+    .where(and(eq(settings.userId, userId), eq(settings.key, SETTINGS_KEY)))
+    .limit(1);
+
+  const raw = row[0]?.value;
+  if (!raw) return { ...DEFAULT_FUSION_WEIGHTS };
+  try {
+    const parsed = JSON.parse(raw) as Partial<FusionWeights>;
+    return normaliseWeights({
+      lex:
+        typeof parsed.lex === "number"
+          ? parsed.lex
+          : DEFAULT_FUSION_WEIGHTS.lex,
+      sem:
+        typeof parsed.sem === "number"
+          ? parsed.sem
+          : DEFAULT_FUSION_WEIGHTS.sem,
+      graph:
+        typeof parsed.graph === "number"
+          ? parsed.graph
+          : DEFAULT_FUSION_WEIGHTS.graph,
+    });
+  } catch {
+    return { ...DEFAULT_FUSION_WEIGHTS };
+  }
+}
+
+export async function setFusionWeights(
+  app: FastifyInstance,
+  userId: string,
+  w: FusionWeights,
+): Promise<FusionWeights> {
+  const normalised = normaliseWeights(w);
+  await app.db
+    .insert(settings)
+    .values({
+      userId,
+      key: SETTINGS_KEY,
+      value: JSON.stringify(normalised),
+    })
+    .onConflictDoUpdate({
+      target: [settings.key, settings.userId],
+      set: { value: JSON.stringify(normalised) },
+    });
+  return normalised;
+}


### PR DESCRIPTION
Three follow-ups to the just-shipped semantic search Phase A (PR #114). One PR, three commits.

## Commit 1 — Phase B design spec (\`eedc2c6\`)

\`docs/superpowers/specs/2026-05-12-novamem-cotenancy-design.md\` — locks in 7 decisions for the future Phase B work (when \`SEMANTIC_PROVIDER=novamem\` is enabled):

- Two schemas in shared Postgres (\`kryton\` + \`novamem\`)
- better-auth in Kryton is the identity authority; NovaMem keeps a \`user_shadow\` synced via Postgres trigger
- Short-lived JWTs (signed with \`BETTER_AUTH_SECRET\`) for Kryton → NovaMem calls
- \`SEMANTIC_PROVIDER=novamem\` flips the \`SemanticProvider\` impl; UI is unchanged
- Migration is a reindex (no data-export tool needed)
- \`pgvector-local\` stays default; NovaMem is opt-in
- Documented open questions: real NovaMem HTTP API shape, auth contract, project concept, graph reconciliation

No implementation in this PR — purely design.

## Commit 2 — Per-user fusion weights (\`d60a0c0\`)

The 0.4/0.4/0.2 split (lex/sem/graph) is now per-user instead of hardcoded.

**Server:**
- New \`fusion-weights.service.ts\` reads/writes a JSON value in the existing \`Settings\` table (key \`fusion_weights\`); falls back to 0.4/0.4/0.2 if no row
- \`GET /api/search/weights\` returns the user's normalised weights
- \`PUT /api/search/weights\` accepts \`{ lex, sem, graph }\` and normalises so sum=1 even if caller sends unnormalised values
- \`fused-search.service.ts\` now reads weights per-request and threads them into the RRF SQL
- OpenAPI snapshot + SDK regenerated

**Client:**
- New "Search" tab in Account Settings dialog (next to 2FA), uses the existing settings-kit primitives (\`Section\`, \`Field\`, \`primaryBtn\`)
- Three numeric inputs, a Save button, help text explaining the layers

## Commit 3 — Reindex progress pill (\`f7ce40a\`)

Small accent-soft pill in the header between "command palette" and "new note":

- Polls \`/api/search/semantic/ready\` every 5s while \`pendingJobs > 0\`, 30s while idle
- Renders \`"N indexing"\` with a spinning Loader2 icon when \`pendingJobs > 0\`
- Hides at 0
- Handles 401 (signed-out) with a 30s back-off
- Matches the accent-soft + mono styling of the rest of the chrome

## Test plan

- [x] Server tests: **108 passed, 2 skipped** (was 103/2; +5 new)
- [x] Client tests: **21 passed** (was 17; +4 IndexingPill tests)
- [x] Typecheck clean (server + client + sdk)
- [x] Lint clean (\`--max-warnings 0\`)
- [x] \`openapi:check\` passes
- [x] UI build clean

## Acceptance criteria for each commit

- **Phase B spec**: Open question list documented; implementation deferred.
- **Fusion weights**: \`GET /weights\` returns defaults for a user with no row; \`PUT /weights\` with \`{1, 1, 0.5}\` normalises to \`{0.4, 0.4, 0.2}\`; search-result ordering shifts with custom weights.
- **Pill**: Renders only when \`pendingJobs > 0\`; cleanly unmounts mid-poll without setState warnings; handles 401.