### PR TITLE
fix(graph): zoom indicator follows mouse-wheel zoom

### DIFF
--- a/packages/client/src/components/Graph/GraphPanel.tsx
+++ b/packages/client/src/components/Graph/GraphPanel.tsx
@@ -156,9 +156,11 @@ export function GraphPanel({
   }, []);
 
   // Dispatch a synthetic wheel event on the canvas wrapper to leverage
-  // useViewport.web's existing wheel-zoom handler. The factor used by
-  // applyWheelZoom is Math.exp(-deltaY / 300); we mirror it locally so
-  // the legend %% stays in sync with the actual transform.
+  // useViewport.web's existing wheel-zoom handler. GraphView's
+  // onZoomChange callback is the single source of truth for the
+  // indicator — it fires on this synthetic wheel, on real wheel
+  // events, and on programmatic recentre, so the legend percentage
+  // stays in sync with the actual transform without local shadowing.
   const dispatchZoom = useCallback((deltaY: number) => {
     const wrap = (expanded ? expandedCanvasWrapRef.current : canvasWrapRef.current);
     const target = wrap?.querySelector('canvas') ?? wrap;
@@ -172,11 +174,6 @@ export function GraphPanel({
       cancelable: true,
     });
     target.dispatchEvent(evt);
-    setZoom((z) => {
-      const next = z * Math.exp(-deltaY / 300);
-      // Clamp to GRAPH_CONFIG.zoom range used by useViewport (0.2 .. 5 typical).
-      return Math.max(0.1, Math.min(10, next));
-    });
   }, [expanded]);
 
   const handleRecenter = useCallback(() => {
@@ -365,6 +362,7 @@ export function GraphPanel({
               recenterRef={recenterRef}
               starredPaths={starredPaths}
               showAllLabels={fullscreen}
+              onZoomChange={setZoom}
             />
             {renderCornerControls()}
             {tooltip && renderHoverCard(tooltip)}
@@ -464,6 +462,7 @@ export function GraphPanel({
                   recenterRef={expandedRecenterRef}
                   starredPaths={starredPaths}
                   showAllLabels
+                  onZoomChange={setZoom}
                 />
                 {renderCornerControls()}
                 {tooltip && renderHoverCard(tooltip)}

--- a/packages/client/src/components/Graph/GraphPanel.tsx
+++ b/packages/client/src/components/Graph/GraphPanel.tsx
@@ -177,9 +177,15 @@ export function GraphPanel({
   }, [expanded]);
 
   const handleRecenter = useCallback(() => {
+    // Recenter changes viewport.k via fitToCanvas; GraphView's
+    // onZoomChange surfaces the new scale through setZoom. We don't
+    // force-set 1 here — the recenter may resolve to a non-1 scale
+    // (small graphs zoom in, large graphs zoom out), and if the user
+    // had only panned without changing zoom, viewport.k could even
+    // stay constant — overwriting to 1 would lie about the actual
+    // transform.
     if (expanded) expandedRecenterRef.current?.();
     else recenterRef.current?.();
-    setZoom(1);
   }, [expanded]);
 
   const nodeCount = graphData?.nodes.length ?? 0;

--- a/packages/ui/src/graph/view/GraphView.web.tsx
+++ b/packages/ui/src/graph/view/GraphView.web.tsx
@@ -24,12 +24,19 @@ export interface GraphViewProps {
   className?: string;
   /** When true, render every node's label (fullscreen graph view). Defaults to false (rail mode shows labels only on active/hover). */
   showAllLabels?: boolean;
+  /**
+   * Notified whenever the viewport scale changes — wheel zoom, pinch,
+   * programmatic recenter, etc. Lets parents that render a zoom-level
+   * indicator stay in sync with the actual transform instead of
+   * shadowing it.
+   */
+  onZoomChange?: (scale: number) => void;
 }
 
 export function GraphView({
   graphData, loading = false, activeNotePath = null, mode = "full",
   onNoteSelect, onNodeHover, recenterRef, starredPaths, className,
-  showAllLabels = false,
+  showAllLabels = false, onZoomChange,
 }: GraphViewProps) {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
   const layoutRef = React.useRef<LayoutHandle | null>(null);
@@ -49,6 +56,13 @@ export function GraphView({
   // "spider web vibration" the user reported.
   const viewportRef = React.useRef(viewport);
   React.useEffect(() => { viewportRef.current = viewport; }, [viewport]);
+
+  // Surface every scale change to the parent so a zoom-percentage
+  // indicator stays consistent across wheel zoom, pinch, and the +/−
+  // buttons (which all flow through the same viewport state).
+  React.useEffect(() => {
+    onZoomChange?.(viewport.k);
+  }, [viewport.k, onZoomChange]);
   const layoutMode: LayoutMode = mode === "full" ? "global" : "local";
 
   /**


### PR DESCRIPTION
Fixes #119.

## Summary

The graph view's zoom-percentage indicator only moved when the user clicked **+ / −**; using the mouse wheel scaled the canvas but the displayed percentage stayed put.

GraphView already owns the authoritative scale via `useViewport`, but it didn't surface it. Added `onZoomChange(scale)` that fires whenever `viewport.k` changes, so wheel zoom, pinch, the +/− buttons, and programmatic recentre all flow through the same callback. GraphPanel passes `setZoom`; the local mirror in `dispatchZoom` is removed (it could also drift once `useViewport.web`'s scaleMin/scaleMax clamps applied).

## Test plan

- [x] `npm run typecheck`, `npm run lint`, `npm run test` clean for ui + client
- [ ] Manual: open graph view, wheel-zoom in/out — indicator updates
- [ ] Manual: click +/− buttons — indicator updates (regression check)
- [ ] Manual: fullscreen graph overlay — same checks