### PR TITLE
ci: cap runner contention (serialise per-branch + clamp vitest fork pool)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,16 @@ on:
   pull_request:
     branches: [master]
 
+# Cancel any in-progress run on the same branch when a new push lands.
+# The self-hosted runner pool is small (single 248 box, three runners),
+# and stacking two CI runs from the same PR — the second push and the
+# leftover first push — was hitting vitest worker-spawn timeouts and
+# fastify boot timeouts because the runner was CPU-starved. Cancelling
+# the older run frees the runner for the newest commit.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -19,9 +19,11 @@ export default defineConfig({
         minForks: 1,
       },
     },
-    // Same justification as packages/server/vitest.config.ts — fastify
-    // boot inside jsdom tests can take several seconds under load. 30s
-    // is the honest envelope.
+    // jsdom + react-testing-library setup, plus the heavier
+    // integration-shaped tests (HttpAdapter, Yjs adapter wiring) take
+    // several seconds under CI contention. The default 5s timeout
+    // tripped on slower runner conditions; 30s matches the server
+    // envelope and is well past anything a healthy test should take.
     testTimeout: 30_000,
     hookTimeout: 30_000,
     coverage: {

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -8,6 +8,22 @@ export default defineConfig({
     environment: "jsdom",
     include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
     setupFiles: ["./src/test-setup.ts"],
+    // The self-hosted CI runner has limited CPU headroom; spawning one
+    // worker per core was triggering "Timeout waiting for worker to
+    // respond" failures because every fork was contending. Cap forks
+    // to a small number so the runner doesn't saturate.
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks: 2,
+        minForks: 1,
+      },
+    },
+    // Same justification as packages/server/vitest.config.ts — fastify
+    // boot inside jsdom tests can take several seconds under load. 30s
+    // is the honest envelope.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -14,8 +14,10 @@ export default defineConfig({
     // 30s envelope was tripping during contended CI runs (an 11-test
     // file finishing in 91s wall-time, one test hitting 30s). 60s is
     // generous but anything beyond that is genuinely stuck and worth
-    // failing on. CI runs are also now serialised via concurrency:
-    // group in .github/workflows/ci.yml so contention should ease too.
+    // failing on. The per-branch concurrency block in
+    // .github/workflows/ci.yml also cancels older runs for the same
+    // ref so a single PR's stacked pushes can't double-load the
+    // runner — different PRs can still run concurrently though.
     testTimeout: 60_000,
     hookTimeout: 60_000,
     coverage: {

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -10,11 +10,14 @@ export default defineConfig({
     include: ["src/**/__tests__/**/*.test.ts"],
     globalSetup: ["./src/test/global-setup.ts"],
     // The self-hosted runner shares CPU with other workloads, so the
-    // per-test fastify boot can take several seconds on a bad day. 30 s
-    // is an honest envelope — if a test actually does anything that
-    // takes that long the timeout still flags a real bug.
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
+    // per-test fastify boot can take several seconds on a bad day. The
+    // 30s envelope was tripping during contended CI runs (an 11-test
+    // file finishing in 91s wall-time, one test hitting 30s). 60s is
+    // generous but anything beyond that is genuinely stuck and worth
+    // failing on. CI runs are also now serialised via concurrency:
+    // group in .github/workflows/ci.yml so contention should ease too.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
The 5 docs/quick-win PRs (#121–#124) have all been hitting CI infrastructure flakes — never on the actual code under review, always on:

- `Timeout waiting for worker to respond` in vitest pool runner (multiple forks saturating CPU, can't respond before the pool's spawn deadline)
- Fastify boot inside per-test `buildTestApp()` taking >30s and hitting the server test timeout (an 11-test file finished in 91s wall-time on one run)
- avvio plugin-ready timeout in `admin-tunnel.routes.test.ts` because the event loop was wedged

Root cause is the self-hosted CI runner pool on the 248 box being CPU-starved when more than one run is active on it. Three fixes that combine to cut the flake rate.

## Changes

**`.github/workflows/ci.yml`** — add `concurrency` block keyed on `workflow + ref` with `cancel-in-progress: true`. A second push to the same PR cancels the older in-progress run instead of stacking on the runner. Different PRs still run in parallel, but the bigger win is never running two builds of the same branch concurrently.

**`packages/client/vitest.config.ts`** — pin the fork pool to `maxForks: 2 / minForks: 1`. Default was one worker per CPU; on the runner that meant ~12 forks competing for the same shared cores. Also adds 30s `testTimeout` / `hookTimeout` (matches server config).

**`packages/server/vitest.config.ts`** — bump `testTimeout` / `hookTimeout` from 30s → 60s. The 30s envelope was tripping under contention; 60s is generous but anything past that is genuinely stuck and worth failing on.

No test-isolation or test-correctness changes.

## Test plan

- [x] `npm run typecheck` clean (server + client)
- [x] `npm run --workspace=@azrtydxb/client test` clean locally
- [ ] CI runs cleanly on this PR (the test that proves the fix worked)