### PR TITLE
ci: paths-ignore for docs-only PRs + safe fileParallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,25 @@ name: CI
 on:
   push:
     branches: [master]
+    # Don't burn ~8 minutes of CI on doc-only pushes to master. The
+    # release.yml workflow has its own gates so this is just the
+    # fast-tier feedback loop.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [master]
+    # PRs that touch only Markdown / docs don't change shipped behaviour
+    # and don't need to run the full test suite. The design-doc PRs
+    # under docs/superpowers/specs/** were sitting blocked on flaky CI
+    # for changes that couldn't possibly break tests.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 # Cancel any in-progress run on the same branch when a new push lands.
 # The self-hosted runner pool is small (single 248 box, three runners),

--- a/packages/server/src/modules/collab/__tests__/yjs-bytea.test.ts
+++ b/packages/server/src/modules/collab/__tests__/yjs-bytea.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
-import { sql, eq } from "drizzle-orm";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
 import * as Y from "yjs";
 import { createTestDb, type TestDbHandle } from "../../../test/db-fixture.js";
 import { user as userTable } from "../../../db/schema/auth.js";
@@ -16,6 +16,7 @@ describe("yjs bytea round-trip (Drizzle)", () => {
   let handle: TestDbHandle;
   let persistence: YjsPersistence;
   let userId: string;
+  let createdDocIds: string[] = [];
 
   beforeAll(() => {
     handle = createTestDb();
@@ -23,24 +24,32 @@ describe("yjs bytea round-trip (Drizzle)", () => {
   });
 
   afterAll(async () => {
-    // Leave the DB clean so other test files relying on empty tables pass.
-    await handle.db.execute(sql`
-      TRUNCATE TABLE "YjsUpdate", "YjsDocument", "User" RESTART IDENTITY CASCADE
-    `);
     await handle.close();
   });
 
   beforeEach(async () => {
-    await handle.db.execute(sql`
-      TRUNCATE TABLE "YjsUpdate", "YjsDocument", "User" RESTART IDENTITY CASCADE
-    `);
-    userId = `u-bytea-${Date.now()}-${Math.random()}`;
+    // Per-suite unique userId — avoids TRUNCATE (which would nuke
+    // sibling suites running in parallel). Math.floor avoids the `.`
+    // in Math.random() so the id matches the SAFE_USER_ID_REGEX in
+    // services/user-notes-dir.service.ts (/^[a-zA-Z0-9_-]{8,64}$/).
+    userId = `u-bytea-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    createdDocIds = [];
     await handle.db.insert(userTable).values({
       id: userId,
       email: `${userId}@test.local`,
       name: "Bytea Test",
       emailVerified: false,
     });
+  });
+
+  afterEach(async () => {
+    // Scoped cleanup: delete only rows this test inserted, leaving
+    // any concurrent suites' data alone.
+    for (const docId of createdDocIds) {
+      await handle.db.delete(yjsUpdate).where(eq(yjsUpdate.docId, docId));
+      await handle.db.delete(yjsDocument).where(eq(yjsDocument.docId, docId));
+    }
+    await handle.db.delete(userTable).where(eq(userTable.id, userId));
   });
 
   it("round-trips a >100 KB Yjs snapshot byte-for-byte", async () => {
@@ -55,7 +64,8 @@ describe("yjs bytea round-trip (Drizzle)", () => {
     const encoded = Y.encodeStateAsUpdate(doc);
     expect(encoded.byteLength).toBeGreaterThan(100 * 1024);
 
-    const docId = `bytea-doc-${Date.now()}`;
+    const docId = `bytea-doc-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    createdDocIds.push(docId);
     await persistence.saveYjsSnapshot(docId, userId, doc);
 
     // Verify raw bytes in storage match exactly.
@@ -78,7 +88,8 @@ describe("yjs bytea round-trip (Drizzle)", () => {
     doc.getText("t").insert(0, "hello world");
     const update = Y.encodeStateAsUpdate(doc);
 
-    const docId = `bytea-upd-${Date.now()}`;
+    const docId = `bytea-upd-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+    createdDocIds.push(docId);
     await persistence.appendYjsUpdate(docId, update, null);
 
     const rows = await handle.db.query.yjsUpdate.findMany({

--- a/packages/server/src/modules/knowledge/services/__tests__/embed-worker.smoke.test.ts
+++ b/packages/server/src/modules/knowledge/services/__tests__/embed-worker.smoke.test.ts
@@ -6,7 +6,7 @@
  * → write → delete-job round trip works against actual SQL.
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { and, eq } from "drizzle-orm";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/server/src/modules/knowledge/services/__tests__/embed-worker.smoke.test.ts
+++ b/packages/server/src/modules/knowledge/services/__tests__/embed-worker.smoke.test.ts
@@ -6,8 +6,8 @@
  * → write → delete-job round trip works against actual SQL.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { and, eq } from "drizzle-orm";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -48,7 +48,10 @@ const silentLog = {
   level: "silent",
 } as unknown as FastifyBaseLogger;
 
-const TEST_USER_ID = "u-embed-worker-smoke";
+// Per-suite unique userId so this file is safe under fileParallelism:
+// true. Satisfies SAFE_USER_ID_REGEX in
+// services/user-notes-dir.service.ts (/^[a-zA-Z0-9_-]{8,64}$/).
+const TEST_USER_ID = `u-embed-${Math.floor(Math.random() * 1e9)}-${process.pid}`;
 
 describe("EmbedWorker (smoke)", () => {
   let handle: TestDbHandle;
@@ -58,29 +61,35 @@ describe("EmbedWorker (smoke)", () => {
     handle = createTestDb();
     notesDir = await fs.mkdtemp(path.join(os.tmpdir(), "embed-worker-smoke-"));
     await fs.mkdir(path.join(notesDir, TEST_USER_ID), { recursive: true });
+    // Seed the suite-scoped user once. Per-test cleanup wipes only
+    // this user's rows; the user itself lives for the whole suite.
+    await handle.db
+      .insert(user)
+      .values({
+        id: TEST_USER_ID,
+        email: `embed-worker-${process.pid}@test.local`,
+        name: "Embed Worker Test",
+      })
+      .onConflictDoNothing();
   });
 
   afterAll(async () => {
+    // Scoped cleanup: only delete rows owned by this suite's user.
+    // Cascade from User clears SearchIndex / EmbedJob /
+    // NoteEmbeddingChunk by FK.
+    await handle.db.delete(user).where(eq(user.id, TEST_USER_ID));
     await handle.close();
     await fs.rm(notesDir, { recursive: true, force: true });
   });
 
   beforeEach(async () => {
-    // Reset just the tables this test touches. Cascade from User clears
-    // SearchIndex / EmbedJob / NoteEmbeddingChunk by FK.
-    await handle.db.execute(sql`
-      TRUNCATE TABLE
-        "NoteEmbeddingChunk",
-        "EmbedJob",
-        "SearchIndex",
-        "User"
-      RESTART IDENTITY CASCADE
-    `);
-    await handle.db.insert(user).values({
-      id: TEST_USER_ID,
-      email: "embed-worker@test.local",
-      name: "Embed Worker Test",
-    });
+    // Targeted reset of this user's child rows between tests. We
+    // avoid TRUNCATE because parallel suites share the same DB.
+    await handle.db
+      .delete(noteEmbeddingChunk)
+      .where(eq(noteEmbeddingChunk.userId, TEST_USER_ID));
+    await handle.db.delete(embedJob).where(eq(embedJob.userId, TEST_USER_ID));
+    await handle.db.delete(searchIndex).where(eq(searchIndex.userId, TEST_USER_ID));
   });
 
   it("processes an upsert job: writes chunks and removes the job row", async () => {

--- a/packages/server/src/modules/notes/__tests__/aux-routes.test.ts
+++ b/packages/server/src/modules/notes/__tests__/aux-routes.test.ts
@@ -16,7 +16,7 @@ import {
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
-import { sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import { canvasRoutes } from "../routes/canvas.routes.js";
 import { backlinksRoutes } from "../routes/backlinks.routes.js";
@@ -24,8 +24,17 @@ import { historyRoutes } from "../routes/history.routes.js";
 import { attachmentsRoutes } from "../routes/attachments.routes.js";
 import { createTestDb, type TestDbHandle } from "../../../test/db-fixture.js";
 import { user as userTable } from "../../../db/schema/auth.js";
+import { attachment as attachmentTable } from "../../../db/schema/notes.js";
 
-const TEST_USER = { id: "u-aux-test", email: "aux@test", name: "Aux", role: "user" };
+// Per-suite unique userId so this file is safe under fileParallelism:
+// true. Satisfies SAFE_USER_ID_REGEX in
+// services/user-notes-dir.service.ts (/^[a-zA-Z0-9_-]{8,64}$/).
+const TEST_USER = {
+  id: `u-aux-${Math.floor(Math.random() * 1e9)}-${process.pid}`,
+  email: `aux-${process.pid}@test.local`,
+  name: "Aux",
+  role: "user",
+};
 
 async function buildAuxTestApp(
   notesDir: string,
@@ -134,33 +143,45 @@ describe("notes-aux routes", () => {
   let app: FastifyInstance;
   let handle: TestDbHandle;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     handle = createTestDb();
+    // Seed the per-suite user once. ON CONFLICT DO NOTHING guards
+    // against ID collisions on the off-chance two suites picked the
+    // same random suffix.
+    await handle.db
+      .insert(userTable)
+      .values({
+        id: TEST_USER.id,
+        email: TEST_USER.email,
+        name: TEST_USER.name,
+        emailVerified: false,
+        role: TEST_USER.role,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .onConflictDoNothing();
   });
 
   afterAll(async () => {
+    // Scoped cleanup: only delete rows owned by this suite's user.
+    await handle.db
+      .delete(attachmentTable)
+      .where(eq(attachmentTable.userId, TEST_USER.id));
+    await handle.db.delete(userTable).where(eq(userTable.id, TEST_USER.id));
     await handle.close();
   });
 
   beforeEach(async () => {
     notesDir = await fs.mkdtemp(path.join(os.tmpdir(), "kaux-"));
-    // Reset attachment-related tables and reseed the test user.
-    await handle.db.execute(sql`
-      TRUNCATE TABLE "Attachment", "User" RESTART IDENTITY CASCADE
-    `);
-    await handle.db.insert(userTable).values({
-      id: TEST_USER.id,
-      email: TEST_USER.email,
-      name: TEST_USER.name,
-      emailVerified: false,
-      role: TEST_USER.role,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
     app = await buildAuxTestApp(notesDir, handle);
   });
 
   afterEach(async () => {
+    // Targeted cleanup so the next test starts with no attachments
+    // for our user, without nuking other suites' rows.
+    await handle.db
+      .delete(attachmentTable)
+      .where(eq(attachmentTable.userId, TEST_USER.id));
     await app.close();
     await fs.rm(notesDir, { recursive: true, force: true });
   });

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -6,6 +6,13 @@ export default defineConfig({
     environment: "node",
     // Disable file-level parallelism so the shared Postgres test database
     // (booted in global-setup) isn't hammered by concurrent test suites.
+    // NOTE: yjs-bytea, aux-routes, and embed-worker.smoke have already been
+    // refactored to drop TRUNCATE CASCADE in favour of per-suite unique
+    // userIds + scoped DELETE cleanup. The blocker for fileParallelism:
+    // true is the shared helpers (notes/identity/agents/knowledge
+    // __tests__/helpers.ts) which still TRUNCATE shared tables; flipping
+    // the flag before those are refactored produces deadlocks and
+    // cross-file row collisions.
     fileParallelism: false,
     include: ["src/**/__tests__/**/*.test.ts"],
     globalSetup: ["./src/test/global-setup.ts"],


### PR DESCRIPTION
Two changes targeting the slow-CI complaint.

**Commit 1 — `paths-ignore` for docs-only PRs**

Skip the whole CI workflow for PRs that touch only `docs/**`, `*.md`, `LICENSE`, or `.gitignore`. The three design-doc PRs (#121, #122, #123) each sat blocked for ~8 minutes × multiple reruns on flaky CI for changes that physically couldn't break any test.

Release / E2E workflows are separate files with their own gates so they're unaffected.

**Commit 2 — scope-clean 3 destructive test files (prep for fileParallelism)**

The original plan was to also flip `fileParallelism: true` in `packages/server/vitest.config.ts`. Investigation found that's larger than expected — four shared `__tests__/helpers.ts` files (`notes`, `identity`, `agents`, `knowledge`) also TRUNCATE shared tables and are imported transitively by most server test files. Flipping the flag without refactoring them produced **51 failures + Postgres deadlocks**.

This commit lands the clean prep — the three previously-known-destructive test files (`yjs-bytea`, `aux-routes`, `embed-worker.smoke`) now use per-suite unique ids + scoped DELETE cleanup instead of `TRUNCATE CASCADE`. That's a strictly cleaner pattern regardless of the parallelism flag.

The flag itself **stays `false`** in this PR. The vitest config gets an updated comment naming the four helpers as the remaining blocker so the next attempt doesn't re-introduce TRUNCATEs.

A follow-up PR will refactor those four helpers and finally flip the flag — that one is realistically a bigger change since it touches most server test files transitively.

## Expected impact

- **Doc-only PRs**: 0s CI cost (was ~8 min × N reruns).
- **Code PRs**: identical wall time to today, no behavioural change. The parallelism win is deferred to the helpers PR.

## Test plan

- [x] `npm run typecheck` clean (server)
- [x] `npm run --workspace=@azrtydxb/server test` clean — 132 passed / 2 skipped, same as before; local wall time 24.2s → 21.2s (small win from fewer TRUNCATEs)
- [ ] CI on this PR goes green