### PR TITLE
ci(server): refactor shared helpers + enable fileParallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,25 @@ name: CI
 on:
   push:
     branches: [master]
+    # Don't burn ~8 minutes of CI on doc-only pushes to master. The
+    # release.yml workflow has its own gates so this is just the
+    # fast-tier feedback loop.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches: [master]
+    # PRs that touch only Markdown / docs don't change shipped behaviour
+    # and don't need to run the full test suite. The design-doc PRs
+    # under docs/superpowers/specs/** were sitting blocked on flaky CI
+    # for changes that couldn't possibly break tests.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 # Cancel any in-progress run on the same branch when a new push lands.
 # The self-hosted runner pool is small (single 248 box, three runners),

--- a/packages/server/src/modules/agents/__tests__/agents.test.ts
+++ b/packages/server/src/modules/agents/__tests__/agents.test.ts
@@ -1,41 +1,52 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
 import { eq } from "drizzle-orm";
-import { user } from "../../../db/schema/auth.js";
 import { agent, agentToken } from "../../../db/schema/agents.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildAgentsTestApp,
+  cleanupAgentsTestUser,
   createAgentsTestDb,
-  resetAgentsTestDb,
+  createAgentsTestUser,
+  seedAgentsTestUser,
 } from "./helpers.js";
 
-const TEST_USER = {
-  id: "u-test",
-  email: "test@example.com",
-  name: "Test",
-  role: "user",
-};
+const TEST_USER = createAgentsTestUser("owner");
+const OTHER_USER = createAgentsTestUser("other");
 
-async function seedUser(dbHandle: TestDbHandle, id = TEST_USER.id): Promise<void> {
-  await dbHandle.db.insert(user).values({
-    id,
-    name: id === TEST_USER.id ? TEST_USER.name : id,
-    email: id === TEST_USER.id ? TEST_USER.email : `${id}@example.com`,
-  });
-}
+// Per-suite unique resource ids. With fileParallelism: true the agents
+// table is shared across parallel suites, so the previous "ag1" / "tid1"
+// constants would collide.
+const SUITE_SUFFIX = `${Math.floor(Math.random() * 1e9)}-${process.pid}`;
+const AGENT_ID = `ag1-${SUITE_SUFFIX}`;
+const TOKEN_ID = `tid1-${SUITE_SUFFIX}`;
 
 describe("agents routes", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createAgentsTestDb();
+    await seedAgentsTestUser(dbHandle, TEST_USER);
+    await seedAgentsTestUser(dbHandle, OTHER_USER);
   });
   afterAll(async () => {
+    await cleanupAgentsTestUser(dbHandle, TEST_USER.id);
+    await cleanupAgentsTestUser(dbHandle, OTHER_USER.id);
     await dbHandle.close();
   });
   beforeEach(async () => {
-    await resetAgentsTestDb(dbHandle);
+    // Per-test cleanup: delete only this suite's user's agents (cascade
+    // removes their tokens). Don't touch other suites' rows.
+    await dbHandle.db.delete(agent).where(eq(agent.ownerUserId, TEST_USER.id));
+    await dbHandle.db.delete(agent).where(eq(agent.ownerUserId, OTHER_USER.id));
   });
   afterEach(async () => {
     if (close) await close();
@@ -44,7 +55,6 @@ describe("agents routes", () => {
 
   describe("POST /api/agents", () => {
     it("creates an agent and returns 201", async () => {
-      await seedUser(dbHandle);
       const app = await buildAgentsTestApp({ user: TEST_USER, dbHandle });
       close = () => app.close();
 
@@ -59,7 +69,7 @@ describe("agents routes", () => {
       expect(body.id).toBeTruthy();
       expect(body.name).toBe("claude");
       expect(body.label).toBe("Claude");
-      expect(body.ownerUserId).toBe("u-test");
+      expect(body.ownerUserId).toBe(TEST_USER.id);
       expect(body.policyText).toBeNull();
 
       const rows = await dbHandle.db
@@ -67,11 +77,10 @@ describe("agents routes", () => {
         .from(agent)
         .where(eq(agent.id, body.id));
       expect(rows).toHaveLength(1);
-      expect(rows[0].ownerUserId).toBe("u-test");
+      expect(rows[0].ownerUserId).toBe(TEST_USER.id);
     });
 
     it("returns 400 for missing required fields", async () => {
-      await seedUser(dbHandle);
       const app = await buildAgentsTestApp({ user: TEST_USER, dbHandle });
       close = () => app.close();
       const res = await app.inject({
@@ -96,10 +105,9 @@ describe("agents routes", () => {
 
   describe("GET /api/agents", () => {
     it("returns the agent list", async () => {
-      await seedUser(dbHandle);
       await dbHandle.db.insert(agent).values({
-        id: "ag1",
-        ownerUserId: "u-test",
+        id: AGENT_ID,
+        ownerUserId: TEST_USER.id,
         name: "bot",
         label: "Bot",
       });
@@ -110,62 +118,57 @@ describe("agents routes", () => {
       const res = await app.inject({ method: "GET", url: "/api/agents" });
       expect(res.statusCode).toBe(200);
       expect(res.json().agents).toHaveLength(1);
-      expect(res.json().agents[0].id).toBe("ag1");
+      expect(res.json().agents[0].id).toBe(AGENT_ID);
     });
   });
 
   describe("DELETE /api/agents/:id", () => {
     it("deletes owned agent and returns 204", async () => {
-      await seedUser(dbHandle);
       await dbHandle.db.insert(agent).values({
-        id: "ag1",
-        ownerUserId: "u-test",
+        id: AGENT_ID,
+        ownerUserId: TEST_USER.id,
         name: "bot",
         label: "Bot",
       });
       const app = await buildAgentsTestApp({ user: TEST_USER, dbHandle });
       close = () => app.close();
 
-      const res = await app.inject({ method: "DELETE", url: "/api/agents/ag1" });
+      const res = await app.inject({ method: "DELETE", url: `/api/agents/${AGENT_ID}` });
       expect(res.statusCode).toBe(204);
       const remaining = await dbHandle.db
         .select()
         .from(agent)
-        .where(eq(agent.id, "ag1"));
+        .where(eq(agent.id, AGENT_ID));
       expect(remaining).toHaveLength(0);
     });
 
     it("returns 404 for unowned agent", async () => {
-      await seedUser(dbHandle);
-      await seedUser(dbHandle, "other");
       await dbHandle.db.insert(agent).values({
-        id: "ag1",
-        ownerUserId: "other",
+        id: AGENT_ID,
+        ownerUserId: OTHER_USER.id,
         name: "bot",
         label: "Bot",
       });
       const app = await buildAgentsTestApp({ user: TEST_USER, dbHandle });
       close = () => app.close();
 
-      const res = await app.inject({ method: "DELETE", url: "/api/agents/ag1" });
+      const res = await app.inject({ method: "DELETE", url: `/api/agents/${AGENT_ID}` });
       expect(res.statusCode).toBe(404);
     });
 
     it("returns 404 when agent missing", async () => {
-      await seedUser(dbHandle);
       const app = await buildAgentsTestApp({ user: TEST_USER, dbHandle });
       close = () => app.close();
-      const res = await app.inject({ method: "DELETE", url: "/api/agents/missing" });
+      const res = await app.inject({ method: "DELETE", url: `/api/agents/missing-${SUITE_SUFFIX}` });
       expect(res.statusCode).toBe(404);
     });
   });
 
   describe("POST /api/agents/:id/policies", () => {
     it("sets policy and returns 204", async () => {
-      await seedUser(dbHandle);
       await dbHandle.db.insert(agent).values({
-        id: "ag1",
-        ownerUserId: "u-test",
+        id: AGENT_ID,
+        ownerUserId: TEST_USER.id,
         name: "bot",
         label: "Bot",
       });
@@ -174,24 +177,23 @@ describe("agents routes", () => {
 
       const res = await app.inject({
         method: "POST",
-        url: "/api/agents/ag1/policies",
+        url: `/api/agents/${AGENT_ID}/policies`,
         payload: { policyText: "permit(principal, action, resource);" },
       });
       expect(res.statusCode).toBe(204);
       const row = await dbHandle.db
         .select()
         .from(agent)
-        .where(eq(agent.id, "ag1"));
+        .where(eq(agent.id, AGENT_ID));
       expect(row[0].policyText).toBe("permit(principal, action, resource);");
     });
   });
 
   describe("POST /api/agents/:id/tokens", () => {
     it("mints a token and returns 201", async () => {
-      await seedUser(dbHandle);
       await dbHandle.db.insert(agent).values({
-        id: "ag1",
-        ownerUserId: "u-test",
+        id: AGENT_ID,
+        ownerUserId: TEST_USER.id,
         name: "bot",
         label: "Bot",
       });
@@ -200,7 +202,7 @@ describe("agents routes", () => {
 
       const res = await app.inject({
         method: "POST",
-        url: "/api/agents/ag1/tokens",
+        url: `/api/agents/${AGENT_ID}/tokens`,
         payload: { expiresInSeconds: 3600 },
       });
       expect(res.statusCode).toBe(201);
@@ -213,22 +215,21 @@ describe("agents routes", () => {
         .from(agentToken)
         .where(eq(agentToken.id, body.tokenId));
       expect(stored).toHaveLength(1);
-      expect(stored[0].agentId).toBe("ag1");
+      expect(stored[0].agentId).toBe(AGENT_ID);
     });
   });
 
   describe("POST /api/agents/tokens/:tokenId/revoke", () => {
     it("revokes a token and returns 204", async () => {
-      await seedUser(dbHandle);
       await dbHandle.db.insert(agent).values({
-        id: "ag1",
-        ownerUserId: "u-test",
+        id: AGENT_ID,
+        ownerUserId: TEST_USER.id,
         name: "bot",
         label: "Bot",
       });
       await dbHandle.db.insert(agentToken).values({
-        id: "tid1",
-        agentId: "ag1",
+        id: TOKEN_ID,
+        agentId: AGENT_ID,
         tokenHash: "h",
         expiresAt: new Date("2099-01-01"),
       });
@@ -237,23 +238,22 @@ describe("agents routes", () => {
 
       const res = await app.inject({
         method: "POST",
-        url: "/api/agents/tokens/tid1/revoke",
+        url: `/api/agents/tokens/${TOKEN_ID}/revoke`,
       });
       expect(res.statusCode).toBe(204);
       const row = await dbHandle.db
         .select()
         .from(agentToken)
-        .where(eq(agentToken.id, "tid1"));
+        .where(eq(agentToken.id, TOKEN_ID));
       expect(row[0].revokedAt).toBeInstanceOf(Date);
     });
 
     it("returns 404 for missing token", async () => {
-      await seedUser(dbHandle);
       const app = await buildAgentsTestApp({ user: TEST_USER, dbHandle });
       close = () => app.close();
       const res = await app.inject({
         method: "POST",
-        url: "/api/agents/tokens/unknown/revoke",
+        url: `/api/agents/tokens/unknown-${SUITE_SUFFIX}/revoke`,
       });
       expect(res.statusCode).toBe(404);
     });

--- a/packages/server/src/modules/agents/__tests__/helpers.ts
+++ b/packages/server/src/modules/agents/__tests__/helpers.ts
@@ -1,5 +1,5 @@
 import Fastify, { type FastifyInstance } from "fastify";
-import { sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { zodPlugin } from "../../../plugins/zod.js";
 import { errorsPlugin } from "../../../plugins/errors.js";
 import { AuthError, ForbiddenError } from "../../../lib/errors.js";
@@ -7,6 +7,7 @@ import { agentsRoutes } from "../routes/agents.routes.js";
 import { AgentService } from "../services/agent.service.js";
 import type { AuthApi, AuthContext, AuthUser } from "../../../plugins/auth.js";
 import { createTestDb, type TestDbHandle } from "../../../test/db-fixture.js";
+import { user as userTable } from "../../../db/schema/auth.js";
 
 export interface AgentsTestAppOptions {
   /** The user returned by auth helpers. Set to null to simulate anonymous. */
@@ -17,28 +18,55 @@ export interface AgentsTestAppOptions {
 
 /**
  * Shared Drizzle test DB handle. Agents tests share a single connection to
- * the testcontainers Postgres started by the vitest global setup; rows are
- * cleared between tests via `resetAgentsTestDb()` instead of opening a new
- * pool per app.
+ * the testcontainers Postgres started by the vitest global setup; under
+ * fileParallelism: true rows are scoped via per-suite unique userIds (see
+ * `createAgentsTestUser`) rather than truncated between tests.
  */
 export function createAgentsTestDb(): TestDbHandle {
   return createTestDb();
 }
 
 /**
- * Truncate all tables touched by the agents tests. Call from `beforeEach`
- * (or `afterEach`) to keep tests isolated.
+ * Build a per-suite unique test user. The id satisfies SAFE_USER_ID_REGEX in
+ * services/user-notes-dir.service.ts (`/^[a-zA-Z0-9_-]{8,64}$/`), and the
+ * random suffix + pid keeps two parallel suites from colliding on a single
+ * shared Postgres database under fileParallelism: true.
  */
-export async function resetAgentsTestDb(handle: TestDbHandle): Promise<void> {
-  // RESTART IDENTITY + CASCADE so dependent FKs (AgentToken -> Agent -> User)
-  // clear in one shot.
-  await handle.db.execute(sql`
-    TRUNCATE TABLE
-      "AgentToken",
-      "Agent",
-      "User"
-    RESTART IDENTITY CASCADE
-  `);
+export function createAgentsTestUser(tag: string = "ag"): AuthUser {
+  const rand = Math.floor(Math.random() * 1e9);
+  return {
+    id: `u-${tag}-${rand}-${process.pid}`,
+    email: `${tag}-${rand}-${process.pid}@test.local`,
+    name: tag,
+    role: "user",
+  };
+}
+
+/**
+ * Seed a User row. With per-suite unique ids there's no expected conflict —
+ * we deliberately don't use ON CONFLICT DO NOTHING so any collision surfaces
+ * as a failure.
+ */
+export async function seedAgentsTestUser(
+  handle: TestDbHandle,
+  user: AuthUser,
+): Promise<void> {
+  await handle.db.insert(userTable).values({
+    id: user.id,
+    name: user.name,
+    email: user.email,
+  });
+}
+
+/**
+ * Delete a suite's user. FK cascade handles Agent + AgentToken rows owned by
+ * the user. Call from `afterAll`.
+ */
+export async function cleanupAgentsTestUser(
+  handle: TestDbHandle,
+  userId: string,
+): Promise<void> {
+  await handle.db.delete(userTable).where(eq(userTable.id, userId));
 }
 
 /**

--- a/packages/server/src/modules/collab/__tests__/yjs-bytea.test.ts
+++ b/packages/server/src/modules/collab/__tests__/yjs-bytea.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
-import { sql, eq } from "drizzle-orm";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
 import * as Y from "yjs";
 import { createTestDb, type TestDbHandle } from "../../../test/db-fixture.js";
 import { user as userTable } from "../../../db/schema/auth.js";
@@ -11,36 +11,32 @@ import { YjsPersistence } from "../ws/persistence.js";
  * Drizzle's `bytea` custom type (pg Buffer) byte-for-byte, including non-
  * trivial payloads (>100 KB). This guards against any future change to the
  * bytea encoder/decoder that would silently corrupt collaborative state.
+ *
+ * Per-suite unique userId + docId so this file is safe under
+ * fileParallelism: true. Cleanup uses scoped DELETE (FK cascade through
+ * User) — no TRUNCATE.
  */
 describe("yjs bytea round-trip (Drizzle)", () => {
   let handle: TestDbHandle;
   let persistence: YjsPersistence;
-  let userId: string;
+  // Satisfies SAFE_USER_ID_REGEX in services/user-notes-dir.service.ts.
+  const userId = `u-bytea-${Math.floor(Math.random() * 1e9)}-${process.pid}`;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     handle = createTestDb();
     persistence = new YjsPersistence(handle.db);
-  });
-
-  afterAll(async () => {
-    // Leave the DB clean so other test files relying on empty tables pass.
-    await handle.db.execute(sql`
-      TRUNCATE TABLE "YjsUpdate", "YjsDocument", "User" RESTART IDENTITY CASCADE
-    `);
-    await handle.close();
-  });
-
-  beforeEach(async () => {
-    await handle.db.execute(sql`
-      TRUNCATE TABLE "YjsUpdate", "YjsDocument", "User" RESTART IDENTITY CASCADE
-    `);
-    userId = `u-bytea-${Date.now()}-${Math.random()}`;
     await handle.db.insert(userTable).values({
       id: userId,
       email: `${userId}@test.local`,
       name: "Bytea Test",
       emailVerified: false,
     });
+  });
+
+  afterAll(async () => {
+    // FK cascade removes YjsDocument / YjsUpdate rows owned by this user.
+    await handle.db.delete(userTable).where(eq(userTable.id, userId));
+    await handle.close();
   });
 
   it("round-trips a >100 KB Yjs snapshot byte-for-byte", async () => {
@@ -55,7 +51,7 @@ describe("yjs bytea round-trip (Drizzle)", () => {
     const encoded = Y.encodeStateAsUpdate(doc);
     expect(encoded.byteLength).toBeGreaterThan(100 * 1024);
 
-    const docId = `bytea-doc-${Date.now()}`;
+    const docId = `bytea-doc-${Math.floor(Math.random() * 1e9)}-${process.pid}`;
     await persistence.saveYjsSnapshot(docId, userId, doc);
 
     // Verify raw bytes in storage match exactly.
@@ -78,7 +74,7 @@ describe("yjs bytea round-trip (Drizzle)", () => {
     doc.getText("t").insert(0, "hello world");
     const update = Y.encodeStateAsUpdate(doc);
 
-    const docId = `bytea-upd-${Date.now()}`;
+    const docId = `bytea-upd-${Math.floor(Math.random() * 1e9)}-${process.pid}`;
     await persistence.appendYjsUpdate(docId, update, null);
 
     const rows = await handle.db.query.yjsUpdate.findMany({

--- a/packages/server/src/modules/identity/__tests__/api-keys.routes.test.ts
+++ b/packages/server/src/modules/identity/__tests__/api-keys.routes.test.ts
@@ -1,35 +1,40 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
 import { eq } from "drizzle-orm";
-import { apiKey, user } from "../../../db/schema/auth.js";
+import { apiKey } from "../../../db/schema/auth.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildIdentityTestApp,
+  cleanupIdentityTestUser,
   createIdentityTestDb,
-  resetIdentityTestDb,
+  createIdentityTestUser,
+  seedIdentityTestUser,
 } from "./helpers.js";
 
-const TEST_USER = { id: "u-1", email: "alice@example.com", name: "Alice", role: "user" };
-
-async function seedUser(dbHandle: TestDbHandle): Promise<void> {
-  await dbHandle.db.insert(user).values({
-    id: TEST_USER.id,
-    name: TEST_USER.name,
-    email: TEST_USER.email,
-  });
-}
+const TEST_USER = createIdentityTestUser("apikeys");
 
 describe("identity / api-keys routes", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createIdentityTestDb();
+    await seedIdentityTestUser(dbHandle, TEST_USER);
   });
   afterAll(async () => {
+    await cleanupIdentityTestUser(dbHandle, TEST_USER.id);
     await dbHandle.close();
   });
   beforeEach(async () => {
-    await resetIdentityTestDb(dbHandle);
+    // Per-test scoped cleanup: only this suite's user's keys.
+    await dbHandle.db.delete(apiKey).where(eq(apiKey.userId, TEST_USER.id));
   });
   afterEach(async () => {
     if (close) await close();
@@ -37,7 +42,6 @@ describe("identity / api-keys routes", () => {
   });
 
   it("POST /api/api-keys creates a key and returns the raw value once", async () => {
-    await seedUser(dbHandle);
     const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
     close = () => app.close();
 
@@ -57,7 +61,6 @@ describe("identity / api-keys routes", () => {
   // BLOCKED: see users.routes.test.ts — validation-failure path crashes
   // inside fastify-type-provider-zod 4.0.2 against Zod 4.
   it.skip("POST /api/api-keys validates body", async () => {
-    await seedUser(dbHandle);
     const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
     close = () => app.close();
 
@@ -70,7 +73,6 @@ describe("identity / api-keys routes", () => {
   });
 
   it("POST /api/api-keys rejects API-key-based callers (session-only)", async () => {
-    await seedUser(dbHandle);
     const app = await buildIdentityTestApp({
       user: TEST_USER,
       apiKey: { id: "k-existing", scope: "read-write" },
@@ -87,9 +89,9 @@ describe("identity / api-keys routes", () => {
   });
 
   it("GET /api/api-keys lists user's keys", async () => {
-    await seedUser(dbHandle);
+    const keyId = `k-list-${Math.floor(Math.random() * 1e9)}`;
     await dbHandle.db.insert(apiKey).values({
-      id: "k-1",
+      id: keyId,
       userId: TEST_USER.id,
       name: "key-a",
       keyHash: "hash-a",
@@ -106,14 +108,14 @@ describe("identity / api-keys routes", () => {
     expect(res.statusCode).toBe(200);
     const list = res.json();
     expect(list).toHaveLength(1);
-    expect(list[0].id).toBe("k-1");
+    expect(list[0].id).toBe(keyId);
     expect(list[0].name).toBe("key-a");
   });
 
   it("DELETE /api/api-keys/:id revokes the key", async () => {
-    await seedUser(dbHandle);
+    const keyId = `k-del-${Math.floor(Math.random() * 1e9)}`;
     await dbHandle.db.insert(apiKey).values({
-      id: "k-1",
+      id: keyId,
       userId: TEST_USER.id,
       name: "key-a",
       keyHash: "hash-a",
@@ -123,21 +125,20 @@ describe("identity / api-keys routes", () => {
     const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
     close = () => app.close();
 
-    const res = await app.inject({ method: "DELETE", url: "/api/api-keys/k-1" });
+    const res = await app.inject({ method: "DELETE", url: `/api/api-keys/${keyId}` });
     expect(res.statusCode).toBe(204);
     const remaining = await dbHandle.db
       .select()
       .from(apiKey)
-      .where(eq(apiKey.id, "k-1"));
+      .where(eq(apiKey.id, keyId));
     expect(remaining).toHaveLength(0);
   });
 
   it("DELETE /api/api-keys/:id returns 404 for unknown key", async () => {
-    await seedUser(dbHandle);
     const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
     close = () => app.close();
 
-    const res = await app.inject({ method: "DELETE", url: "/api/api-keys/missing" });
+    const res = await app.inject({ method: "DELETE", url: "/api/api-keys/missing-xyz" });
     expect(res.statusCode).toBe(404);
   });
 });

--- a/packages/server/src/modules/identity/__tests__/helpers.ts
+++ b/packages/server/src/modules/identity/__tests__/helpers.ts
@@ -1,11 +1,12 @@
 import Fastify, { type FastifyInstance } from "fastify";
-import { sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { zodPlugin } from "../../../plugins/zod.js";
 import { errorsPlugin } from "../../../plugins/errors.js";
 import { AuthError, ForbiddenError } from "../../../lib/errors.js";
 import { identityModule } from "../index.js";
 import type { AuthApi, AuthContext, AuthUser } from "../../../plugins/auth.js";
 import { createTestDb, type TestDbHandle } from "../../../test/db-fixture.js";
+import { user as userTable } from "../../../db/schema/auth.js";
 
 export interface IdentityTestAppOptions {
   /** The user returned by auth helpers. Set to null to simulate anonymous. */
@@ -18,35 +19,57 @@ export interface IdentityTestAppOptions {
 
 /**
  * Shared Drizzle test DB handle. Identity tests share a single connection to
- * the testcontainers Postgres started by the vitest global setup; rows are
- * cleared between tests via `resetIdentityTestDb()` instead of opening a
- * new pool per app.
+ * the testcontainers Postgres started by the vitest global setup; under
+ * fileParallelism: true rows are scoped via per-suite unique userIds (see
+ * `createIdentityTestUser`) rather than truncated between tests.
  */
 export function createIdentityTestDb(): TestDbHandle {
   return createTestDb();
 }
 
 /**
- * Truncate all tables touched by the identity tests. Call from `beforeEach`
- * (or `afterEach`) to keep tests isolated.
+ * Build a per-suite unique test user. The id satisfies SAFE_USER_ID_REGEX in
+ * services/user-notes-dir.service.ts (`/^[a-zA-Z0-9_-]{8,64}$/`), and the
+ * random suffix + pid keeps two parallel suites from colliding on a single
+ * shared Postgres database under fileParallelism: true.
  */
-export async function resetIdentityTestDb(handle: TestDbHandle): Promise<void> {
-  // RESTART IDENTITY + CASCADE so dependent FKs (Session, ApiKey, ...) clear
-  // in one shot. Only the tables identity routes/services touch are listed,
-  // but CASCADE handles any rows in unrelated tables that reference them.
-  await handle.db.execute(sql`
-    TRUNCATE TABLE
-      "ApiKey",
-      "Session",
-      "Account",
-      "Passkey",
-      "TwoFactor",
-      "InviteCode",
-      "Settings",
-      "McpSession",
-      "User"
-    RESTART IDENTITY CASCADE
-  `);
+export function createIdentityTestUser(tag: string = "id"): AuthUser {
+  const rand = Math.floor(Math.random() * 1e9);
+  return {
+    id: `u-${tag}-${rand}-${process.pid}`,
+    email: `${tag}-${rand}-${process.pid}@test.local`,
+    name: tag,
+    role: "user",
+  };
+}
+
+/**
+ * Seed the User row for a suite. Call once from `beforeAll`. With per-suite
+ * unique ids there's no expected conflict — we deliberately don't use
+ * ON CONFLICT DO NOTHING so any ID collision surfaces as a failure instead
+ * of silently overlapping with another suite's data.
+ */
+export async function seedIdentityTestUser(
+  handle: TestDbHandle,
+  user: AuthUser,
+): Promise<void> {
+  await handle.db.insert(userTable).values({
+    id: user.id,
+    name: user.name,
+    email: user.email,
+  });
+}
+
+/**
+ * Delete a suite's user. FK cascade handles dependent rows (Session,
+ * Account, ApiKey, Passkey, TwoFactor, Settings, McpSession). Call from
+ * `afterAll`.
+ */
+export async function cleanupIdentityTestUser(
+  handle: TestDbHandle,
+  userId: string,
+): Promise<void> {
+  await handle.db.delete(userTable).where(eq(userTable.id, userId));
 }
 
 /**

--- a/packages/server/src/modules/identity/__tests__/users.routes.test.ts
+++ b/packages/server/src/modules/identity/__tests__/users.routes.test.ts
@@ -1,26 +1,38 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
 import { user } from "../../../db/schema/auth.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildIdentityTestApp,
+  cleanupIdentityTestUser,
   createIdentityTestDb,
-  resetIdentityTestDb,
+  createIdentityTestUser,
 } from "./helpers.js";
 
-const TEST_USER = { id: "u-1", email: "alice@example.com", name: "Alice", role: "user" };
+const TEST_USER = createIdentityTestUser("users");
+const BOB_ID = `u-users-bob-${Math.floor(Math.random() * 1e9)}-${process.pid}`;
 
 describe("identity / users routes", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createIdentityTestDb();
+    await dbHandle.db.insert(user).values({
+      id: TEST_USER.id,
+      name: TEST_USER.name,
+      email: TEST_USER.email,
+    });
+    await dbHandle.db.insert(user).values({
+      id: BOB_ID,
+      name: "Bob",
+      email: `bob-${process.pid}@example.com`,
+    });
   });
   afterAll(async () => {
+    await cleanupIdentityTestUser(dbHandle, TEST_USER.id);
+    await dbHandle.db.delete(user).where(eq(user.id, BOB_ID));
     await dbHandle.close();
-  });
-  beforeEach(async () => {
-    await resetIdentityTestDb(dbHandle);
   });
   afterEach(async () => {
     if (close) await close();
@@ -28,21 +40,19 @@ describe("identity / users routes", () => {
   });
 
   it("GET /api/users/search returns the user when found", async () => {
-    await dbHandle.db.insert(user).values({
-      id: "u-bob",
-      name: "Bob",
-      email: "bob@example.com",
-    });
-
     const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
     close = () => app.close();
 
     const res = await app.inject({
       method: "GET",
-      url: "/api/users/search?email=bob@example.com",
+      url: `/api/users/search?email=bob-${process.pid}@example.com`,
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ id: "u-bob", name: "Bob", email: "bob@example.com" });
+    expect(res.json()).toEqual({
+      id: BOB_ID,
+      name: "Bob",
+      email: `bob-${process.pid}@example.com`,
+    });
   });
 
   it("GET /api/users/search returns 404 when not found", async () => {
@@ -51,7 +61,7 @@ describe("identity / users routes", () => {
 
     const res = await app.inject({
       method: "GET",
-      url: "/api/users/search?email=nope@example.com",
+      url: "/api/users/search?email=nope-no-one@example.com",
     });
     expect(res.statusCode).toBe(404);
     expect(res.json().error.code).toBe("NOT_FOUND");

--- a/packages/server/src/modules/knowledge/__tests__/enqueue-on-mutate.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/enqueue-on-mutate.test.ts
@@ -1,14 +1,23 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
 import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { user } from "../../../db/schema/auth.js";
 import { searchIndex } from "../../../db/schema/notes.js";
 import { embedJob } from "../../../db/schema/embeddings.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildKnowledgeTestApp,
+  cleanupKnowledgeTestUser,
   createKnowledgeTestDb,
-  resetKnowledgeTestDb,
+  createKnowledgeTestUser,
+  seedKnowledgeTestUser,
 } from "./helpers.js";
 
 /**
@@ -20,31 +29,27 @@ import {
  * worker is active to drain them.
  */
 
-const TEST_USER = { id: "u-1", email: "alice@example.com", name: "Alice", role: "user" };
-
-async function seedUser(dbHandle: TestDbHandle): Promise<void> {
-  await dbHandle.db.insert(user).values({
-    id: TEST_USER.id,
-    name: TEST_USER.name,
-    email: TEST_USER.email,
-  });
-}
+const TEST_USER = createKnowledgeTestUser("enq");
 
 describe("SearchService → EmbedJob enqueue", () => {
   let dbHandle: TestDbHandle;
   let app: FastifyInstance | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createKnowledgeTestDb();
+    await seedKnowledgeTestUser(dbHandle, TEST_USER);
   });
 
   afterAll(async () => {
+    await cleanupKnowledgeTestUser(dbHandle, TEST_USER.id);
     await dbHandle.close();
   });
 
   beforeEach(async () => {
-    await resetKnowledgeTestDb(dbHandle);
-    await seedUser(dbHandle);
+    await dbHandle.db.delete(embedJob).where(eq(embedJob.userId, TEST_USER.id));
+    await dbHandle.db
+      .delete(searchIndex)
+      .where(eq(searchIndex.userId, TEST_USER.id));
     app = await buildKnowledgeTestApp({
       user: TEST_USER,
       dbHandle,
@@ -60,11 +65,17 @@ describe("SearchService → EmbedJob enqueue", () => {
   it("indexNote enqueues an upsert job alongside the SearchIndex write", async () => {
     await app!.knowledge.indexNote("test/foo.md", "# Foo\n\nbody", TEST_USER.id);
 
-    const idx = await dbHandle.db.select().from(searchIndex);
+    const idx = await dbHandle.db
+      .select()
+      .from(searchIndex)
+      .where(eq(searchIndex.userId, TEST_USER.id));
     expect(idx).toHaveLength(1);
     expect(idx[0].notePath).toBe("test/foo.md");
 
-    const jobs = await dbHandle.db.select().from(embedJob);
+    const jobs = await dbHandle.db
+      .select()
+      .from(embedJob)
+      .where(eq(embedJob.userId, TEST_USER.id));
     expect(jobs).toHaveLength(1);
     expect(jobs[0]).toMatchObject({
       userId: TEST_USER.id,
@@ -78,14 +89,20 @@ describe("SearchService → EmbedJob enqueue", () => {
   it("removeFromIndex enqueues a delete job", async () => {
     await app!.knowledge.indexNote("test/foo.md", "# Foo\n\nbody", TEST_USER.id);
     // Clear the upsert job so we can observe just the delete.
-    await dbHandle.db.delete(embedJob);
+    await dbHandle.db.delete(embedJob).where(eq(embedJob.userId, TEST_USER.id));
 
     await app!.knowledge.removeFromIndex("test/foo.md", TEST_USER.id);
 
-    const idx = await dbHandle.db.select().from(searchIndex);
+    const idx = await dbHandle.db
+      .select()
+      .from(searchIndex)
+      .where(eq(searchIndex.userId, TEST_USER.id));
     expect(idx).toHaveLength(0);
 
-    const jobs = await dbHandle.db.select().from(embedJob);
+    const jobs = await dbHandle.db
+      .select()
+      .from(embedJob)
+      .where(eq(embedJob.userId, TEST_USER.id));
     expect(jobs).toHaveLength(1);
     expect(jobs[0]).toMatchObject({
       userId: TEST_USER.id,
@@ -96,17 +113,21 @@ describe("SearchService → EmbedJob enqueue", () => {
 
   it("renameInIndex enqueues a delete + an upsert", async () => {
     await app!.knowledge.indexNote("test/old.md", "# Old\n\nbody", TEST_USER.id);
-    await dbHandle.db.delete(embedJob);
+    await dbHandle.db.delete(embedJob).where(eq(embedJob.userId, TEST_USER.id));
 
     await app!.knowledge.renameInIndex("test/old.md", "test/new.md", TEST_USER.id);
 
-    const idx = await dbHandle.db.select().from(searchIndex);
+    const idx = await dbHandle.db
+      .select()
+      .from(searchIndex)
+      .where(eq(searchIndex.userId, TEST_USER.id));
     expect(idx).toHaveLength(1);
     expect(idx[0].notePath).toBe("test/new.md");
 
     const jobs = await dbHandle.db
       .select()
       .from(embedJob)
+      .where(eq(embedJob.userId, TEST_USER.id))
       .orderBy(embedJob.notePath);
     expect(jobs).toHaveLength(2);
     const byPath = Object.fromEntries(jobs.map((j) => [j.notePath, j]));
@@ -130,7 +151,10 @@ describe("SearchService → EmbedJob enqueue", () => {
     await app!.knowledge.indexNote("test/foo.md", "# v2", TEST_USER.id);
     await app!.knowledge.indexNote("test/foo.md", "# v3", TEST_USER.id);
 
-    const jobs = await dbHandle.db.select().from(embedJob);
+    const jobs = await dbHandle.db
+      .select()
+      .from(embedJob)
+      .where(eq(embedJob.userId, TEST_USER.id));
     expect(jobs).toHaveLength(1);
     expect(jobs[0].op).toBe("upsert");
     expect(jobs[0].attempts).toBe(0);
@@ -138,23 +162,29 @@ describe("SearchService → EmbedJob enqueue", () => {
   });
 });
 
+const OFF_USER = createKnowledgeTestUser("enqoff");
+
 describe("SearchService → EmbedJob enqueue (provider=off)", () => {
   let dbHandle: TestDbHandle;
   let app: FastifyInstance | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createKnowledgeTestDb();
+    await seedKnowledgeTestUser(dbHandle, OFF_USER);
   });
 
   afterAll(async () => {
+    await cleanupKnowledgeTestUser(dbHandle, OFF_USER.id);
     await dbHandle.close();
   });
 
   beforeEach(async () => {
-    await resetKnowledgeTestDb(dbHandle);
-    await seedUser(dbHandle);
+    await dbHandle.db.delete(embedJob).where(eq(embedJob.userId, OFF_USER.id));
+    await dbHandle.db
+      .delete(searchIndex)
+      .where(eq(searchIndex.userId, OFF_USER.id));
     app = await buildKnowledgeTestApp({
-      user: TEST_USER,
+      user: OFF_USER,
       dbHandle,
       embedderProvider: "off",
     });
@@ -166,12 +196,18 @@ describe("SearchService → EmbedJob enqueue (provider=off)", () => {
   });
 
   it("does NOT enqueue when embedderState.provider is 'off'", async () => {
-    await app!.knowledge.indexNote("test/foo.md", "# Foo", TEST_USER.id);
+    await app!.knowledge.indexNote("test/foo.md", "# Foo", OFF_USER.id);
 
-    const idx = await dbHandle.db.select().from(searchIndex);
+    const idx = await dbHandle.db
+      .select()
+      .from(searchIndex)
+      .where(eq(searchIndex.userId, OFF_USER.id));
     expect(idx).toHaveLength(1);
 
-    const jobs = await dbHandle.db.select().from(embedJob);
+    const jobs = await dbHandle.db
+      .select()
+      .from(embedJob)
+      .where(eq(embedJob.userId, OFF_USER.id));
     expect(jobs).toHaveLength(0);
   });
 });

--- a/packages/server/src/modules/knowledge/__tests__/fused-search.routes.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/fused-search.routes.test.ts
@@ -1,13 +1,23 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { user } from "../../../db/schema/auth.js";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { eq } from "drizzle-orm";
 import { searchIndex, graphEdge } from "../../../db/schema/notes.js";
 import { noteEmbeddingChunk } from "../../../db/schema/embeddings.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import { setFusionWeights } from "../services/fusion-weights.service.js";
 import {
   buildKnowledgeTestApp,
+  cleanupKnowledgeTestUser,
   createKnowledgeTestDb,
-  resetKnowledgeTestDb,
+  createKnowledgeTestUser,
+  seedKnowledgeTestUser,
 } from "./helpers.js";
 
 /**
@@ -26,36 +36,33 @@ function oneHot(idx: number): Float32Array {
   return v;
 }
 
-const TEST_USER = {
-  id: "u-fused",
-  email: "fused@example.com",
-  name: "F",
-  role: "user",
-};
-
-async function seedUser(handle: TestDbHandle): Promise<void> {
-  await handle.db.insert(user).values({
-    id: TEST_USER.id,
-    name: TEST_USER.name,
-    email: TEST_USER.email,
-  });
-}
+const TEST_USER = createKnowledgeTestUser("fused");
 
 describe("knowledge / GET /api/search (fused)", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createKnowledgeTestDb();
+    await seedKnowledgeTestUser(dbHandle, TEST_USER);
   });
 
   afterAll(async () => {
+    await cleanupKnowledgeTestUser(dbHandle, TEST_USER.id);
     await dbHandle.close();
   });
 
   beforeEach(async () => {
-    await resetKnowledgeTestDb(dbHandle);
-    await seedUser(dbHandle);
+    // Per-test scoped reset for this user's rows only.
+    await dbHandle.db
+      .delete(noteEmbeddingChunk)
+      .where(eq(noteEmbeddingChunk.userId, TEST_USER.id));
+    await dbHandle.db
+      .delete(graphEdge)
+      .where(eq(graphEdge.userId, TEST_USER.id));
+    await dbHandle.db
+      .delete(searchIndex)
+      .where(eq(searchIndex.userId, TEST_USER.id));
   });
 
   afterEach(async () => {
@@ -104,9 +111,6 @@ describe("knowledge / GET /api/search (fused)", () => {
 
   it("fused happy path: semantic boost lifts the closer note", async () => {
     const now = new Date("2026-05-11T00:00:00Z");
-    // Both notes share a lexical token so they appear in lexical results
-    // tied. The fake embedder maps the query to oneHot(0); near.md owns
-    // oneHot(0), far.md owns oneHot(1). Sem rank should put near.md first.
     await dbHandle.db.insert(searchIndex).values([
       {
         notePath: "near.md",
@@ -177,7 +181,6 @@ describe("knowledge / GET /api/search (fused)", () => {
     const body = res.json();
     expect(body.length).toBeGreaterThanOrEqual(2);
     expect(body[0].path).toBe("near.md");
-    // Snippet should be drawn from the best semantic chunk.
     expect(body[0].snippet).toContain("semantically nearest");
     expect(body[0].score).toBeGreaterThan(body[1].score);
     expect(typeof body[0].score).toBe("number");
@@ -185,10 +188,6 @@ describe("knowledge / GET /api/search (fused)", () => {
 
   it("graph boost: neighbour of a top hit gets ranked above an unconnected weak match", async () => {
     const now = new Date("2026-05-11T00:00:00Z");
-    // top.md is the obvious lexical+semantic winner. neighbour.md has no
-    // lexical match and no embedding (so no semantic match either) but is
-    // graph-linked to top.md. loner.md has no lexical match, no embedding,
-    // and no graph connection — it should not appear at all.
     await dbHandle.db.insert(searchIndex).values([
       {
         notePath: "top.md",
@@ -271,16 +270,11 @@ describe("knowledge / GET /api/search (fused)", () => {
     expect(paths).toContain("top.md");
     expect(paths).toContain("neighbour.md");
     expect(paths).not.toContain("loner.md");
-    // Top should outrank the graph-only neighbour.
     expect(paths.indexOf("top.md")).toBeLessThan(paths.indexOf("neighbour.md"));
   });
 
   it("custom fusion weights re-order results: lex-only weight ignores graph neighbour", async () => {
     const now = new Date("2026-05-11T00:00:00Z");
-    // Same setup as the graph-boost test: top.md has the lexical+semantic
-    // hit; neighbour.md only appears via the graph layer. With default
-    // weights (0.2 graph), neighbour appears. With lex-only weights
-    // (graph=0), neighbour MUST drop out entirely.
     await dbHandle.db.insert(searchIndex).values([
       {
         notePath: "top.md",
@@ -345,7 +339,6 @@ describe("knowledge / GET /api/search (fused)", () => {
     });
     close = () => app.close();
 
-    // Tilt the weights all the way to lexical — graph contribution = 0.
     await setFusionWeights(app, TEST_USER.id, { lex: 1, sem: 0, graph: 0 });
 
     const res = await app.inject({
@@ -356,7 +349,6 @@ describe("knowledge / GET /api/search (fused)", () => {
     const body = res.json();
     const paths = body.map((r: { path: string }) => r.path);
     expect(paths).toContain("top.md");
-    // Graph-only neighbour must NOT appear under lex-only weights.
     expect(paths).not.toContain("neighbour.md");
   });
 

--- a/packages/server/src/modules/knowledge/__tests__/fusion-weights.routes.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/fusion-weights.routes.test.ts
@@ -1,10 +1,21 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { user } from "../../../db/schema/auth.js";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { eq } from "drizzle-orm";
+import { settings } from "../../../db/schema/settings.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildKnowledgeTestApp,
+  cleanupKnowledgeTestUser,
   createKnowledgeTestDb,
-  resetKnowledgeTestDb,
+  createKnowledgeTestUser,
+  seedKnowledgeTestUser,
 } from "./helpers.js";
 
 /**
@@ -12,36 +23,26 @@ import {
  * Settings table (key: "fusion_weights").
  */
 
-const TEST_USER = {
-  id: "u-fw",
-  email: "fw@example.com",
-  name: "F",
-  role: "user",
-};
-
-async function seedUser(handle: TestDbHandle): Promise<void> {
-  await handle.db.insert(user).values({
-    id: TEST_USER.id,
-    name: TEST_USER.name,
-    email: TEST_USER.email,
-  });
-}
+const TEST_USER = createKnowledgeTestUser("fw");
 
 describe("knowledge / /api/search/weights", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createKnowledgeTestDb();
+    await seedKnowledgeTestUser(dbHandle, TEST_USER);
   });
 
   afterAll(async () => {
+    await cleanupKnowledgeTestUser(dbHandle, TEST_USER.id);
     await dbHandle.close();
   });
 
   beforeEach(async () => {
-    await resetKnowledgeTestDb(dbHandle);
-    await seedUser(dbHandle);
+    // Clear this user's Settings rows so each test starts from "no
+    // stored weights → defaults".
+    await dbHandle.db.delete(settings).where(eq(settings.userId, TEST_USER.id));
   });
 
   afterEach(async () => {
@@ -72,7 +73,6 @@ describe("knowledge / /api/search/weights", () => {
     });
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    // 1/2.5=0.4 ; 0.5/2.5=0.2
     expect(body.lex).toBeCloseTo(0.4, 5);
     expect(body.sem).toBeCloseTo(0.4, 5);
     expect(body.graph).toBeCloseTo(0.2, 5);

--- a/packages/server/src/modules/knowledge/__tests__/graph.routes.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/graph.routes.test.ts
@@ -1,21 +1,26 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { user } from "../../../db/schema/auth.js";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { eq } from "drizzle-orm";
 import { graphEdge, searchIndex } from "../../../db/schema/notes.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildKnowledgeTestApp,
+  cleanupKnowledgeTestUser,
   createKnowledgeTestDb,
-  resetKnowledgeTestDb,
+  createKnowledgeTestUser,
+  seedKnowledgeTestUser,
 } from "./helpers.js";
 
-const TEST_USER = { id: "u-1", email: "alice@example.com", name: "Alice", role: "user" };
+const TEST_USER = createKnowledgeTestUser("graph");
 
 async function seedGraph(dbHandle: TestDbHandle): Promise<void> {
-  await dbHandle.db.insert(user).values({
-    id: TEST_USER.id,
-    name: TEST_USER.name,
-    email: TEST_USER.email,
-  });
   await dbHandle.db.insert(searchIndex).values([
     {
       notePath: "A.md",
@@ -47,14 +52,21 @@ describe("knowledge / graph routes", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createKnowledgeTestDb();
+    await seedKnowledgeTestUser(dbHandle, TEST_USER);
   });
   afterAll(async () => {
+    await cleanupKnowledgeTestUser(dbHandle, TEST_USER.id);
     await dbHandle.close();
   });
   beforeEach(async () => {
-    await resetKnowledgeTestDb(dbHandle);
+    await dbHandle.db
+      .delete(graphEdge)
+      .where(eq(graphEdge.userId, TEST_USER.id));
+    await dbHandle.db
+      .delete(searchIndex)
+      .where(eq(searchIndex.userId, TEST_USER.id));
   });
   afterEach(async () => {
     if (close) await close();

--- a/packages/server/src/modules/knowledge/__tests__/helpers.ts
+++ b/packages/server/src/modules/knowledge/__tests__/helpers.ts
@@ -1,36 +1,67 @@
 import Fastify, { type FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
 import { zodPlugin } from "../../../plugins/zod.js";
 import { errorsPlugin } from "../../../plugins/errors.js";
 import { AuthError, ForbiddenError } from "../../../lib/errors.js";
 import { knowledgeModule } from "../index.js";
 import type { AuthApi, AuthContext, AuthUser } from "../../../plugins/auth.js";
-import { sql } from "drizzle-orm";
 import { createTestDb, type TestDbHandle } from "../../../test/db-fixture.js";
+import { user as userTable } from "../../../db/schema/auth.js";
 
 /**
- * Shared Drizzle test DB handle for knowledge tests. Mirrors the identity
- * helpers pattern.
+ * Shared Drizzle test DB handle for knowledge tests. Under fileParallelism:
+ * true rows are scoped via per-suite unique userIds (see
+ * `createKnowledgeTestUser`) rather than truncated between tests.
  */
 export function createKnowledgeTestDb(): TestDbHandle {
   return createTestDb();
 }
 
 /**
- * Truncate tables touched by knowledge graph/search routes. Call from
- * `beforeEach` for test isolation.
+ * Build a per-suite unique test user. The id satisfies SAFE_USER_ID_REGEX in
+ * services/user-notes-dir.service.ts (`/^[a-zA-Z0-9_-]{8,64}$/`), and the
+ * random suffix + pid keeps two parallel suites from colliding on a single
+ * shared Postgres database under fileParallelism: true.
  */
-export async function resetKnowledgeTestDb(handle: TestDbHandle): Promise<void> {
-  await handle.db.execute(sql`
-    TRUNCATE TABLE
-      "GraphEdge",
-      "SearchIndex",
-      "EmbedJob",
-      "NoteEmbeddingChunk",
-      "NoteShare",
-      "Settings",
-      "User"
-    RESTART IDENTITY CASCADE
-  `);
+export function createKnowledgeTestUser(
+  tag: string = "k",
+  role: AuthUser["role"] = "user",
+): AuthUser {
+  const rand = Math.floor(Math.random() * 1e9);
+  return {
+    id: `u-${tag}-${rand}-${process.pid}`,
+    email: `${tag}-${rand}-${process.pid}@test.local`,
+    name: tag,
+    role,
+  };
+}
+
+/**
+ * Seed a User row. With per-suite unique ids there's no expected conflict —
+ * we deliberately don't use ON CONFLICT DO NOTHING so any collision surfaces
+ * as a failure.
+ */
+export async function seedKnowledgeTestUser(
+  handle: TestDbHandle,
+  user: AuthUser,
+): Promise<void> {
+  await handle.db.insert(userTable).values({
+    id: user.id,
+    name: user.name,
+    email: user.email,
+  });
+}
+
+/**
+ * Delete a suite's user. FK cascade handles dependent rows owned by the
+ * user (SearchIndex, GraphEdge, NoteEmbeddingChunk, EmbedJob, NoteShare,
+ * Settings). Call from `afterAll`.
+ */
+export async function cleanupKnowledgeTestUser(
+  handle: TestDbHandle,
+  userId: string,
+): Promise<void> {
+  await handle.db.delete(userTable).where(eq(userTable.id, userId));
 }
 
 export interface KnowledgeTestAppOptions {

--- a/packages/server/src/modules/knowledge/__tests__/search.routes.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/search.routes.test.ts
@@ -1,37 +1,44 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { user } from "../../../db/schema/auth.js";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { eq } from "drizzle-orm";
 import { searchIndex } from "../../../db/schema/notes.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildKnowledgeTestApp,
+  cleanupKnowledgeTestUser,
   createKnowledgeTestDb,
-  resetKnowledgeTestDb,
+  createKnowledgeTestUser,
+  seedKnowledgeTestUser,
 } from "./helpers.js";
 
-const TEST_USER = { id: "u-1", email: "alice@example.com", name: "Alice", role: "user" };
-
-async function seedUser(dbHandle: TestDbHandle): Promise<void> {
-  await dbHandle.db.insert(user).values({
-    id: TEST_USER.id,
-    name: TEST_USER.name,
-    email: TEST_USER.email,
-  });
-}
+const TEST_USER = createKnowledgeTestUser("search");
 
 describe("knowledge / search routes", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createKnowledgeTestDb();
+    await seedKnowledgeTestUser(dbHandle, TEST_USER);
   });
 
   afterAll(async () => {
+    await cleanupKnowledgeTestUser(dbHandle, TEST_USER.id);
     await dbHandle.close();
   });
 
   beforeEach(async () => {
-    await resetKnowledgeTestDb(dbHandle);
+    // Per-test scoped reset: only this suite's user's index rows.
+    await dbHandle.db
+      .delete(searchIndex)
+      .where(eq(searchIndex.userId, TEST_USER.id));
   });
 
   afterEach(async () => {
@@ -40,7 +47,6 @@ describe("knowledge / search routes", () => {
   });
 
   it("GET /api/search returns FTS-matched rows from the user's index", async () => {
-    await seedUser(dbHandle);
     await dbHandle.db.insert(searchIndex).values([
       {
         notePath: "Welcome.md",
@@ -79,7 +85,6 @@ describe("knowledge / search routes", () => {
   });
 
   it("GET /api/search uses English stemming (running matches run)", async () => {
-    await seedUser(dbHandle);
     await dbHandle.db.insert(searchIndex).values({
       notePath: "Run.md",
       userId: TEST_USER.id,

--- a/packages/server/src/modules/knowledge/__tests__/semantic-search-ready.routes.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/semantic-search-ready.routes.test.ts
@@ -1,12 +1,21 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
 import { eq } from "drizzle-orm";
-import { user } from "../../../db/schema/auth.js";
 import { embedJob } from "../../../db/schema/embeddings.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildKnowledgeTestApp,
+  cleanupKnowledgeTestUser,
   createKnowledgeTestDb,
-  resetKnowledgeTestDb,
+  createKnowledgeTestUser,
+  seedKnowledgeTestUser,
 } from "./helpers.js";
 
 /**
@@ -18,31 +27,24 @@ import {
  * up the real EmbedWorker.
  */
 
-const TEST_USER = { id: "u-ready", email: "ready@example.com", name: "R", role: "user" };
-
-async function seedUser(handle: TestDbHandle): Promise<void> {
-  await handle.db.insert(user).values({
-    id: TEST_USER.id,
-    name: TEST_USER.name,
-    email: TEST_USER.email,
-  });
-}
+const TEST_USER = createKnowledgeTestUser("ready");
 
 describe("knowledge / GET /api/search/semantic/ready", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createKnowledgeTestDb();
+    await seedKnowledgeTestUser(dbHandle, TEST_USER);
   });
 
   afterAll(async () => {
+    await cleanupKnowledgeTestUser(dbHandle, TEST_USER.id);
     await dbHandle.close();
   });
 
   beforeEach(async () => {
-    await resetKnowledgeTestDb(dbHandle);
-    await seedUser(dbHandle);
+    await dbHandle.db.delete(embedJob).where(eq(embedJob.userId, TEST_USER.id));
   });
 
   afterEach(async () => {
@@ -76,8 +78,6 @@ describe("knowledge / GET /api/search/semantic/ready", () => {
   });
 
   it("reports pendingJobs for the calling user from the worker decorator", async () => {
-    // Seed a couple of jobs so the stub worker's pendingCount has something
-    // to return; the stub itself just runs a count against EmbedJob.
     await dbHandle.db.insert(embedJob).values([
       { userId: TEST_USER.id, notePath: "a.md", op: "upsert", attempts: 0 },
       { userId: TEST_USER.id, notePath: "b.md", op: "upsert", attempts: 0 },

--- a/packages/server/src/modules/knowledge/__tests__/semantic-search-reindex.routes.test.ts
+++ b/packages/server/src/modules/knowledge/__tests__/semantic-search-reindex.routes.test.ts
@@ -1,47 +1,61 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
 import { eq } from "drizzle-orm";
-import { user } from "../../../db/schema/auth.js";
 import { searchIndex } from "../../../db/schema/notes.js";
 import { embedJob } from "../../../db/schema/embeddings.js";
 import type { TestDbHandle } from "../../../test/db-fixture.js";
 import {
   buildKnowledgeTestApp,
+  cleanupKnowledgeTestUser,
   createKnowledgeTestDb,
-  resetKnowledgeTestDb,
+  createKnowledgeTestUser,
+  seedKnowledgeTestUser,
 } from "./helpers.js";
 
 /**
  * Phase 5 — POST /api/search/semantic/reindex.
  *
  * scope=self enqueues an upsert job for every SearchIndex row owned by the
- * caller; scope=all does the same across every user (admin only).
+ * caller; scope=all does the same across every user (admin only). Tests run
+ * with per-suite unique userIds so the scope=all assertion is bounded to
+ * this suite's rows (filtered by ALICE/ADMIN ids).
  */
 
-const ALICE = { id: "u-alice", email: "alice@example.com", name: "Alice", role: "user" };
-const ADMIN = { id: "u-admin", email: "admin@example.com", name: "Admin", role: "admin" };
-
-async function seedUsers(handle: TestDbHandle): Promise<void> {
-  await handle.db.insert(user).values([
-    { id: ALICE.id, name: ALICE.name, email: ALICE.email },
-    { id: ADMIN.id, name: ADMIN.name, email: ADMIN.email },
-  ]);
-}
+const ALICE = createKnowledgeTestUser("alice");
+const ADMIN = createKnowledgeTestUser("admin", "admin");
 
 describe("knowledge / POST /api/search/semantic/reindex", () => {
   let dbHandle: TestDbHandle;
   let close: (() => Promise<void>) | null = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dbHandle = createKnowledgeTestDb();
+    await seedKnowledgeTestUser(dbHandle, ALICE);
+    await seedKnowledgeTestUser(dbHandle, ADMIN);
   });
 
   afterAll(async () => {
+    await cleanupKnowledgeTestUser(dbHandle, ALICE.id);
+    await cleanupKnowledgeTestUser(dbHandle, ADMIN.id);
     await dbHandle.close();
   });
 
   beforeEach(async () => {
-    await resetKnowledgeTestDb(dbHandle);
-    await seedUsers(dbHandle);
+    await dbHandle.db.delete(embedJob).where(eq(embedJob.userId, ALICE.id));
+    await dbHandle.db.delete(embedJob).where(eq(embedJob.userId, ADMIN.id));
+    await dbHandle.db
+      .delete(searchIndex)
+      .where(eq(searchIndex.userId, ALICE.id));
+    await dbHandle.db
+      .delete(searchIndex)
+      .where(eq(searchIndex.userId, ADMIN.id));
   });
 
   afterEach(async () => {
@@ -126,7 +140,11 @@ describe("knowledge / POST /api/search/semantic/reindex", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ enqueued: 0 });
 
-    const jobs = await dbHandle.db.select().from(embedJob);
+    // Scope to ALICE — other parallel suites may have their own jobs.
+    const jobs = await dbHandle.db
+      .select()
+      .from(embedJob)
+      .where(eq(embedJob.userId, ALICE.id));
     expect(jobs).toHaveLength(0);
   });
 });

--- a/packages/server/src/modules/knowledge/services/__tests__/embed-worker.smoke.test.ts
+++ b/packages/server/src/modules/knowledge/services/__tests__/embed-worker.smoke.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -36,8 +36,6 @@ function makeFakeEmbedder(): Embedder {
 }
 
 const silentLog = {
-  // Cast through unknown to satisfy the structural FastifyBaseLogger type
-  // without dragging in pino. The worker only uses .info/.warn/.error.
   info: () => {},
   warn: () => {},
   error: () => {},
@@ -48,7 +46,9 @@ const silentLog = {
   level: "silent",
 } as unknown as FastifyBaseLogger;
 
-const TEST_USER_ID = "u-embed-worker-smoke";
+// Per-suite unique userId so this file is safe under fileParallelism: true.
+// Satisfies SAFE_USER_ID_REGEX in services/user-notes-dir.service.ts.
+const TEST_USER_ID = `u-emb-${Math.floor(Math.random() * 1e9)}-${process.pid}`;
 
 describe("EmbedWorker (smoke)", () => {
   let handle: TestDbHandle;
@@ -58,29 +58,30 @@ describe("EmbedWorker (smoke)", () => {
     handle = createTestDb();
     notesDir = await fs.mkdtemp(path.join(os.tmpdir(), "embed-worker-smoke-"));
     await fs.mkdir(path.join(notesDir, TEST_USER_ID), { recursive: true });
+    await handle.db.insert(user).values({
+      id: TEST_USER_ID,
+      email: `embed-worker-${process.pid}@test.local`,
+      name: "Embed Worker Test",
+    });
   });
 
   afterAll(async () => {
+    // FK cascade removes SearchIndex / EmbedJob / NoteEmbeddingChunk rows
+    // owned by this user.
+    await handle.db.delete(user).where(eq(user.id, TEST_USER_ID));
     await handle.close();
     await fs.rm(notesDir, { recursive: true, force: true });
   });
 
   beforeEach(async () => {
-    // Reset just the tables this test touches. Cascade from User clears
-    // SearchIndex / EmbedJob / NoteEmbeddingChunk by FK.
-    await handle.db.execute(sql`
-      TRUNCATE TABLE
-        "NoteEmbeddingChunk",
-        "EmbedJob",
-        "SearchIndex",
-        "User"
-      RESTART IDENTITY CASCADE
-    `);
-    await handle.db.insert(user).values({
-      id: TEST_USER_ID,
-      email: "embed-worker@test.local",
-      name: "Embed Worker Test",
-    });
+    // Per-test scoped reset: only this suite's user's rows.
+    await handle.db
+      .delete(noteEmbeddingChunk)
+      .where(eq(noteEmbeddingChunk.userId, TEST_USER_ID));
+    await handle.db.delete(embedJob).where(eq(embedJob.userId, TEST_USER_ID));
+    await handle.db
+      .delete(searchIndex)
+      .where(eq(searchIndex.userId, TEST_USER_ID));
   });
 
   it("processes an upsert job: writes chunks and removes the job row", async () => {

--- a/packages/server/src/modules/notes/__tests__/aux-routes.test.ts
+++ b/packages/server/src/modules/notes/__tests__/aux-routes.test.ts
@@ -16,7 +16,7 @@ import {
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
-import { sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import { canvasRoutes } from "../routes/canvas.routes.js";
 import { backlinksRoutes } from "../routes/backlinks.routes.js";
@@ -24,8 +24,16 @@ import { historyRoutes } from "../routes/history.routes.js";
 import { attachmentsRoutes } from "../routes/attachments.routes.js";
 import { createTestDb, type TestDbHandle } from "../../../test/db-fixture.js";
 import { user as userTable } from "../../../db/schema/auth.js";
+import { attachment as attachmentTable } from "../../../db/schema/notes.js";
 
-const TEST_USER = { id: "u-aux-test", email: "aux@test", name: "Aux", role: "user" };
+// Per-suite unique userId so this file is safe under fileParallelism: true.
+// Satisfies SAFE_USER_ID_REGEX in services/user-notes-dir.service.ts.
+const TEST_USER = {
+  id: `u-aux-${Math.floor(Math.random() * 1e9)}-${process.pid}`,
+  email: `aux-${process.pid}@test.local`,
+  name: "Aux",
+  role: "user",
+};
 
 async function buildAuxTestApp(
   notesDir: string,
@@ -134,20 +142,10 @@ describe("notes-aux routes", () => {
   let app: FastifyInstance;
   let handle: TestDbHandle;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     handle = createTestDb();
-  });
-
-  afterAll(async () => {
-    await handle.close();
-  });
-
-  beforeEach(async () => {
-    notesDir = await fs.mkdtemp(path.join(os.tmpdir(), "kaux-"));
-    // Reset attachment-related tables and reseed the test user.
-    await handle.db.execute(sql`
-      TRUNCATE TABLE "Attachment", "User" RESTART IDENTITY CASCADE
-    `);
+    // Seed the per-suite user once. With per-suite unique ids there's no
+    // expected conflict.
     await handle.db.insert(userTable).values({
       id: TEST_USER.id,
       email: TEST_USER.email,
@@ -157,6 +155,20 @@ describe("notes-aux routes", () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     });
+  });
+
+  afterAll(async () => {
+    // FK cascade clears Attachment rows owned by this user.
+    await handle.db.delete(userTable).where(eq(userTable.id, TEST_USER.id));
+    await handle.close();
+  });
+
+  beforeEach(async () => {
+    notesDir = await fs.mkdtemp(path.join(os.tmpdir(), "kaux-"));
+    // Scoped cleanup: only delete attachments owned by this suite's user.
+    await handle.db
+      .delete(attachmentTable)
+      .where(eq(attachmentTable.userId, TEST_USER.id));
     app = await buildAuxTestApp(notesDir, handle);
   });
 

--- a/packages/server/src/modules/notes/__tests__/daily.routes.test.ts
+++ b/packages/server/src/modules/notes/__tests__/daily.routes.test.ts
@@ -1,10 +1,23 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { buildNotesTestApp, type NotesTestApp } from "./helpers.js";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import {
+  buildNotesTestApp,
+  cleanupNotesTestUser,
+  createNotesTestUser,
+  seedNotesTestUser,
+  type NotesTestApp,
+} from "./helpers.js";
 
-const TEST_USER = { id: "user1234", email: "a@b.co", name: "Alice", role: "user" };
+const TEST_USER = createNotesTestUser("daily");
 
 describe("notes module / daily routes", () => {
   let ctx: NotesTestApp | null = null;
+
+  beforeAll(async () => {
+    await seedNotesTestUser(TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupNotesTestUser(TEST_USER.id);
+  });
   afterEach(async () => {
     if (ctx) await ctx.cleanup();
     ctx = null;

--- a/packages/server/src/modules/notes/__tests__/folders.routes.test.ts
+++ b/packages/server/src/modules/notes/__tests__/folders.routes.test.ts
@@ -1,12 +1,25 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { buildNotesTestApp, type NotesTestApp } from "./helpers.js";
+import {
+  buildNotesTestApp,
+  cleanupNotesTestUser,
+  createNotesTestUser,
+  seedNotesTestUser,
+  type NotesTestApp,
+} from "./helpers.js";
 
-const TEST_USER = { id: "user1234", email: "a@b.co", name: "Alice", role: "user" };
+const TEST_USER = createNotesTestUser("folders");
 
 describe("notes module / folders routes", () => {
   let ctx: NotesTestApp | null = null;
+
+  beforeAll(async () => {
+    await seedNotesTestUser(TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupNotesTestUser(TEST_USER.id);
+  });
   afterEach(async () => {
     if (ctx) await ctx.cleanup();
     ctx = null;

--- a/packages/server/src/modules/notes/__tests__/helpers.ts
+++ b/packages/server/src/modules/notes/__tests__/helpers.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
-import { sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import Fastify, { type FastifyInstance } from "fastify";
 import { zodPlugin } from "../../../plugins/zod.js";
 import { errorsPlugin } from "../../../plugins/errors.js";
@@ -12,9 +12,9 @@ import { user as userTable } from "../../../db/schema/auth.js";
 
 /**
  * Shared Drizzle handle for notes tests. Lazily created on first call and
- * reused across the file. The notes test suite touches: SearchIndex, Folder,
- * Tag, NoteTag, TrashItem, Settings, NoteShare, Attachment, GraphEdge,
- * NoteVersion, NoteRevision — all truncated below.
+ * reused across the file. Under fileParallelism: true the suite no longer
+ * TRUNCATEs shared tables — each suite picks a per-suite unique userId
+ * (see `createNotesTestUser` below) and only touches its own rows.
  */
 let sharedHandle: TestDbHandle | null = null;
 function getHandle(): TestDbHandle {
@@ -22,27 +22,50 @@ function getHandle(): TestDbHandle {
   return sharedHandle;
 }
 
-async function resetNotesTestDb(handle: TestDbHandle): Promise<void> {
-  // Listing every table explicitly (including the newer McpSession that
-  // FKs to User) keeps the planner from chasing the CASCADE chain on
-  // each test reset — a small but measurable win on a slow runner.
-  await handle.db.execute(sql`
-    TRUNCATE TABLE
-      "Attachment",
-      "NoteRevision",
-      "NoteVersion",
-      "NoteTag",
-      "Tag",
-      "Folder",
-      "TrashItem",
-      "Settings",
-      "NoteShare",
-      "GraphEdge",
-      "SearchIndex",
-      "McpSession",
-      "User"
-    RESTART IDENTITY CASCADE
-  `);
+/**
+ * Build a per-suite unique test user. The id satisfies SAFE_USER_ID_REGEX in
+ * services/user-notes-dir.service.ts (`/^[a-zA-Z0-9_-]{8,64}$/`), and the
+ * random suffix + pid keeps two parallel suites from colliding on a single
+ * shared Postgres database under fileParallelism: true.
+ */
+export function createNotesTestUser(tag: string = "notes"): AuthUser {
+  const rand = Math.floor(Math.random() * 1e9);
+  return {
+    id: `u-${tag}-${rand}-${process.pid}`,
+    email: `${tag}-${rand}-${process.pid}@test.local`,
+    name: tag,
+    role: "user",
+  };
+}
+
+/**
+ * Seed the User row for a suite. Call once from `beforeAll`. With per-suite
+ * unique ids there's no expected conflict — we deliberately don't use
+ * ON CONFLICT DO NOTHING so any genuine ID collision surfaces as a failure
+ * instead of silently overlapping with another suite's data.
+ */
+export async function seedNotesTestUser(user: AuthUser): Promise<void> {
+  const handle = getHandle();
+  await handle.db.insert(userTable).values({
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    emailVerified: false,
+    role: user.role,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+/**
+ * Delete a suite's user. FK cascade handles every dependent row this suite
+ * touched (Folder, Tag, NoteTag, NoteShare, Settings, GraphEdge,
+ * SearchIndex, Attachment, NoteVersion, NoteRevision, TrashItem, McpSession).
+ * Call from `afterAll`.
+ */
+export async function cleanupNotesTestUser(userId: string): Promise<void> {
+  const handle = getHandle();
+  await handle.db.delete(userTable).where(eq(userTable.id, userId));
 }
 
 export interface NotesTestAppOptions {
@@ -59,7 +82,8 @@ export interface NotesTestApp {
 }
 
 /** Build a Fastify app with the notes module wired up against the
- * testcontainers Postgres. */
+ * testcontainers Postgres. The User row is NOT seeded by this helper —
+ * call `seedNotesTestUser` once from `beforeAll` instead. */
 export async function buildNotesTestApp(
   opts: NotesTestAppOptions = {},
 ): Promise<NotesTestApp> {
@@ -68,24 +92,8 @@ export async function buildNotesTestApp(
     (await fs.mkdtemp(path.join(os.tmpdir(), "kryton-notes-test-")));
 
   const handle = getHandle();
-  await resetNotesTestDb(handle);
 
   const user = opts.user ?? null;
-  // Seed the User row when an authenticated user is configured — every
-  // table that references User via FK (Folder, Tag, NoteTag, NoteShare, …)
-  // is cascade-deleted via the truncate above, so we must
-  // re-insert the user row for each test that needs one.
-  if (user) {
-    await handle.db.insert(userTable).values({
-      id: user.id,
-      email: user.email,
-      name: user.name,
-      emailVerified: false,
-      role: user.role,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-  }
 
   const app = Fastify({ logger: false });
 

--- a/packages/server/src/modules/notes/__tests__/notes.routes.test.ts
+++ b/packages/server/src/modules/notes/__tests__/notes.routes.test.ts
@@ -1,10 +1,24 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { buildNotesTestApp, type NotesTestApp } from "./helpers.js";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import {
+  buildNotesTestApp,
+  cleanupNotesTestUser,
+  createNotesTestUser,
+  seedNotesTestUser,
+  type NotesTestApp,
+} from "./helpers.js";
 
-const TEST_USER = { id: "user1234", email: "a@b.co", name: "Alice", role: "user" };
+const TEST_USER = createNotesTestUser("notes");
 
 describe("notes module / notes routes", () => {
   let ctx: NotesTestApp | null = null;
+
+  beforeAll(async () => {
+    await seedNotesTestUser(TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupNotesTestUser(TEST_USER.id);
+  });
+
   afterEach(async () => {
     if (ctx) await ctx.cleanup();
     ctx = null;

--- a/packages/server/src/modules/notes/__tests__/tags.routes.test.ts
+++ b/packages/server/src/modules/notes/__tests__/tags.routes.test.ts
@@ -1,10 +1,23 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { buildNotesTestApp, type NotesTestApp } from "./helpers.js";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import {
+  buildNotesTestApp,
+  cleanupNotesTestUser,
+  createNotesTestUser,
+  seedNotesTestUser,
+  type NotesTestApp,
+} from "./helpers.js";
 
-const TEST_USER = { id: "user1234", email: "a@b.co", name: "Alice", role: "user" };
+const TEST_USER = createNotesTestUser("tags");
 
 describe("notes module / tags routes", () => {
   let ctx: NotesTestApp | null = null;
+
+  beforeAll(async () => {
+    await seedNotesTestUser(TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupNotesTestUser(TEST_USER.id);
+  });
   afterEach(async () => {
     if (ctx) await ctx.cleanup();
     ctx = null;

--- a/packages/server/src/modules/notes/__tests__/templates.routes.test.ts
+++ b/packages/server/src/modules/notes/__tests__/templates.routes.test.ts
@@ -1,10 +1,23 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { buildNotesTestApp, type NotesTestApp } from "./helpers.js";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import {
+  buildNotesTestApp,
+  cleanupNotesTestUser,
+  createNotesTestUser,
+  seedNotesTestUser,
+  type NotesTestApp,
+} from "./helpers.js";
 
-const TEST_USER = { id: "user1234", email: "a@b.co", name: "Alice", role: "user" };
+const TEST_USER = createNotesTestUser("templates");
 
 describe("notes module / templates routes", () => {
   let ctx: NotesTestApp | null = null;
+
+  beforeAll(async () => {
+    await seedNotesTestUser(TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupNotesTestUser(TEST_USER.id);
+  });
   afterEach(async () => {
     if (ctx) await ctx.cleanup();
     ctx = null;

--- a/packages/server/src/modules/notes/__tests__/trash.routes.test.ts
+++ b/packages/server/src/modules/notes/__tests__/trash.routes.test.ts
@@ -1,10 +1,23 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { buildNotesTestApp, type NotesTestApp } from "./helpers.js";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import {
+  buildNotesTestApp,
+  cleanupNotesTestUser,
+  createNotesTestUser,
+  seedNotesTestUser,
+  type NotesTestApp,
+} from "./helpers.js";
 
-const TEST_USER = { id: "user1234", email: "a@b.co", name: "Alice", role: "user" };
+const TEST_USER = createNotesTestUser("trash");
 
 describe("notes module / trash routes", () => {
   let ctx: NotesTestApp | null = null;
+
+  beforeAll(async () => {
+    await seedNotesTestUser(TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupNotesTestUser(TEST_USER.id);
+  });
   afterEach(async () => {
     if (ctx) await ctx.cleanup();
     ctx = null;

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -4,9 +4,20 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    // Disable file-level parallelism so the shared Postgres test database
-    // (booted in global-setup) isn't hammered by concurrent test suites.
-    fileParallelism: false,
+    // File-level parallelism is enabled. Every test suite uses per-suite
+    // unique userIds + scoped DELETE cleanups (see helpers.ts files in
+    // modules/{notes,identity,agents,knowledge}/__tests__/). Do not
+    // re-introduce TRUNCATE CASCADE in any test or helper without going
+    // back to fileParallelism: false — under parallelism a truncate in
+    // one suite blows away rows owned by another.
+    fileParallelism: true,
+    // Cap concurrent forks so the self-hosted runner (shared CPU) doesn't
+    // get hammered. Mirrors the client-side cap added in PR #125. 4 forks
+    // matches the runner's effective core budget under the per-branch
+    // concurrency block in ci.yml. Vitest 4 moved this from
+    // `poolOptions.forks.maxForks` to a top-level option.
+    maxWorkers: 4,
+    minWorkers: 1,
     include: ["src/**/__tests__/**/*.test.ts"],
     globalSetup: ["./src/test/global-setup.ts"],
     // The self-hosted runner shares CPU with other workloads, so the


### PR DESCRIPTION
Supersedes #126 — folds in the paths-ignore commit and finishes the parallelism work that #126 stopped short of.

## Changes

**1. Refactor 4 shared helpers** (`__tests__/helpers.ts` in `notes/`, `identity/`, `agents/`, `knowledge/`) — they were the actual blocker for `fileParallelism: true`. Each TRUNCATEd shared tables (`User`, etc.) on setup, which works only when test files run serially. Now each helper:
- generates a per-suite unique userId (`u-<tag>-<rand>-<pid>`, satisfies `SAFE_USER_ID_REGEX`)
- seeds only that user
- on cleanup, DELETEs only its own rows (FK cascade handles children)

**2. Re-refactor 3 direct test files** (`yjs-bytea`, `aux-routes`, `embed-worker.smoke`) — #126's commit message described scoping these but the subagent that did it discovered the helpers were a bigger blocker and committed only the helper-comment update. This PR re-does those three with the verified-under-parallelism pattern.

**3. Fold in 24 call-site updates** across notes/identity/agents/knowledge test files so they pull the per-suite user from the helper instead of relying on a shared constant.

**4. Flip `fileParallelism: true`** in `packages/server/vitest.config.ts` plus `maxWorkers: 4` / `minWorkers: 1` (vitest 4 deprecated `poolOptions.forks.maxForks`).

**5. `paths-ignore` for docs-only PRs** (cherry-picked from #126) — `docs/**`, `*.md`, `LICENSE`, `.gitignore` skip the workflow entirely.

## Verification

Local wall-time on M-class hardware:
- Serial baseline: **22.69s**
- Parallel run 1: **8.23s** ✓ 132 passed / 2 skipped
- Parallel run 2: **6.42s** ✓ 132 passed / 2 skipped
- Parallel run 3: **6.59s** ✓ 132 passed / 2 skipped

CI projection: server tests **287s → ~80s** under 4 parallel forks (proportional to local speedup, accounting for runner contention).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` clean — 3 parallel runs in a row, no flakes
- [ ] CI on this branch goes green
- [ ] Server test step time falls from ~287s baseline to ~80-100s