### PR TITLE
ci: migrate ci.yml to arc-azrtydxb (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,14 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, kryton-248]
+    # ARC v2 scale-set on the kw cluster (k3s ARM64). Ephemeral runner
+    # pods with a dind sidecar; minRunners=0, maxRunners=20. The single
+    # label `arc-azrtydxb` is the only valid form — scale-set runners
+    # don't accept multi-label arrays like the old kryton-248 box did.
+    runs-on: arc-azrtydxb
     # Run inside a node container so the service-container postgres is
     # reachable via its docker-network hostname (`postgres:5432`) instead
-    # of via a host-published port. Lets multiple jobs run on the same
-    # self-hosted box in parallel without colliding on a host port.
+    # of via a host-published port.
     container:
       image: node:24
     services:
@@ -122,12 +125,12 @@ jobs:
           APP_URL: http://localhost:5173
           OPENAPI_ENABLED: "true"
 
-      - name: Restore workspace ownership to host user
-        # Container runs as root by default — files written here end up
-        # owned by root on the host runner's bind-mounted workspace.
-        # That blocks the next job's actions/checkout cleanup. Hand
-        # ownership back to piwi (1000:1000) before exiting so any
-        # subsequent host-based job can clean cleanly.
+      - name: Restore workspace ownership to runner user
+        # The job container runs as root by default but the ARC runner
+        # process is UID 1001. Files written by the job would be owned
+        # by root on the bind-mounted workspace, blocking
+        # actions/checkout's post-job cleanup. Hand ownership back so
+        # any subsequent host-based step (and post-job cleanup) works.
         # `if: always()` ensures this runs on failure too.
         if: always()
-        run: chown -R 1000:1000 . || true
+        run: chown -R 1001:1001 . || true


### PR DESCRIPTION
Phase 2 of the ARC migration plan. Moves the fast-tier CI workflow off the legacy single-node `[self-hosted, kryton-248]` runners onto the kw cluster's ARC v2 scale set.

## Why now

Phase 1 smoke test (#129) ran green on all the prerequisites that gate this PR:
- ✅ Runner pod placement + env vars + cert mounts
- ✅ `pgvector/pgvector:pg16` arm64 pulls cleanly through the registry mirror — same service-container shape works on ARC
- ✅ Native arm64 builds in the dind sidecar
- ✅ Remote BuildKit on 192.168.10.253 reachable for amd64

Push to ghcr.io is still blocked by the mirror CA-trust issue, but **this workflow doesn't push anything** — that's only a Phase 4 (release.yml) concern.

## Changes (2 lines)

1. `runs-on: [self-hosted, kryton-248]` → `runs-on: arc-azrtydxb` (ARC v2 accepts only one label, no array form)
2. `chown -R 1000:1000` → `chown -R 1001:1001` (ARC runner UID)

Everything else stays:
- `concurrency:` block from #125 (per-ref cancel-in-progress)
- `paths-ignore:` from #127 (docs-only PRs skip the workflow)
- `container: node:24` + postgres `service`
- pgvector apt install + `CREATE EXTENSION` (no custom postgres image — that's a separate cleanup)

## Test plan

This PR's own CI run **is** the test. If it goes green, ARC is verified for the real workload (not just smoke test); merge clears the way for Phase 3.

If it fails I'll need to investigate one of:
- service-container networking on ARC (Postgres reachable at `postgres:5432`?)
- testcontainers inside dind (used by global-setup)
- fileParallelism + per-fork DB pool behaviour against the service-container

Phase 3 (`e2e.yml`) is identical-shape change; Phase 4 (`release.yml` docker build) needs the ghcr.io push fix first.