### PR TITLE
ci: migrate e2e.yml to arc-azrtydxb (Phase 3)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,9 @@ env:
 
 jobs:
   e2e:
-    runs-on: [self-hosted, kryton-248]
+    # ARC v2 scale-set on the kw cluster — see ci.yml for the same
+    # migration. Single label only; chown UID is 1001 (not 1000).
+    runs-on: arc-azrtydxb
     container:
       image: node:24
     services:
@@ -80,6 +82,9 @@ jobs:
           APP_URL: http://localhost:5173
           SEMANTIC_PROVIDER: "off"
 
-      - name: Restore workspace ownership to host user
+      - name: Restore workspace ownership to runner user
+        # ARC runner UID is 1001 (not 1000 as on the old kryton-248
+        # box). Without this the post-job actions/checkout cleanup
+        # fails on the bind-mounted workspace.
         if: always()
-        run: chown -R 1000:1000 . || true
+        run: chown -R 1001:1001 . || true


### PR DESCRIPTION
Phase 3 of the ARC migration. Same shape as #130 (Phase 2 ci.yml migration) applied to the E2E workflow.

## Change

- `runs-on: [self-hosted, kryton-248]` → `runs-on: arc-azrtydxb`
- `chown 1000:1000` → `chown 1001:1001` (ARC runner UID)

That's it. Container + services unchanged — ARC v2 supports both natively. No code or test changes.

## Risk

Low. The workflow is `workflow_dispatch` only — nothing automated runs on it, so a regression here doesn't block PRs. The pgvector arm64 image was already verified pullable through the cluster mirror in the arc-smoke run (`25941324719`).

## Test plan

- Merge.
- `gh workflow run e2e.yml` against master.
- Verify the e2e suite passes on the new pool.

## Remaining phases

- Phase 4 (`release.yml` docker job): **blocked** on the GHCR push problem — pod-level `hostAlias ghcr.io → 192.168.10.122` routes pushes through the pull-through mirror which doesn't accept writes (verified in smoke run 25941324719). Documented in the updated novamem cookbook entry. Needs cluster-admin work (write-through proxy / separate hostname / separate publish scale-set) before Phase 4 can land.
- Phase 5 (decommission kryton-248): wait until Phase 2 + Phase 3 have a clean week on ARC before removing the legacy runners.