### PR TITLE
ci: migrate release.yml gate job to arc-azrtydxb (Phase 4 partial)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,12 @@ jobs:
   # ci.yml's build job, plus the e2e step. A red here blocks the docker
   # build/push and the GitHub release.
   ci:
-    runs-on: [self-hosted, kryton-248]
+    # ARC v2 scale-set on the kw cluster (k3s ARM64). Ephemeral runner
+    # pods with a dind sidecar. The release gate doesn't push images —
+    # the `docker` matrix below still runs on GH-hosted runners until
+    # the cluster's ghcr.io push path lands (see novamem entry
+    # 01KRPPQT3RRD0XHXM2V61ZV1C8 for the workaround options).
+    runs-on: arc-azrtydxb
     container:
       image: node:24
     services:
@@ -88,9 +93,12 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Restore workspace ownership to host user
+      - name: Restore workspace ownership to runner user
+        # ARC runner UID is 1001; the job container runs as root and
+        # would otherwise leave root-owned files in the bind-mounted
+        # workspace, blocking post-job cleanup.
         if: always()
-        run: chown -R 1000:1000 . || true
+        run: chown -R 1001:1001 . || true
 
       - name: Upload client dist
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Final removal of \`[self-hosted, kryton-248]\` from the workflow tree. The \`ci\` gate job in \`release.yml\` (typecheck, lint, unit tests, full E2E suite) now lands on \`arc-azrtydxb\`, same as #130/#131.

## What this PR does

- \`runs-on: [self-hosted, kryton-248]\` → \`runs-on: arc-azrtydxb\` on the \`ci\` gate job only
- \`chown -R 1000:1000\` → \`chown -R 1001:1001\` (ARC runner UID)

## What it does NOT do

The \`docker\` matrix in this workflow still runs on GH-hosted \`ubuntu-latest\` + \`ubuntu-24.04-arm\` runners. The \`manifest\` and \`release\` jobs likewise stay on \`ubuntu-latest\`. Moving the docker build/push to ARC is blocked on the cluster's \`ghcr.io\` push path — the pod-level hostAlias routes \`ghcr.io\` to the pull-only mirror, so pushes fail with a TLS / \"unknown authority\" error from inside dind. Verified by the arc-smoke runs (#128/#129).

Workarounds for the cluster side (out of scope for this PR):
- Replace \`registry:2\` mirror with Harbor or a write-through proxy.
- Spin a second ARC scale-set \`arc-azrtydxb-publish\` without the \`ghcr.io\` hostAlias.
- Push from a GH-hosted step that downloads the ARC-built image as an artifact.

## Test plan

- [ ] Cut a \`v*\` tag (or push a no-op tag) to exercise the full release pipeline end-to-end with the gate on ARC. Optional — tags are infrequent, so merging this without dispatching is acceptable; the first real release will be the validation.