### PR TITLE
ci: collapse release.yml docker matrix to single ARC job (Phase 4 full)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,7 @@ jobs:
   # build/push and the GitHub release.
   ci:
     # ARC v2 scale-set on the kw cluster (k3s ARM64). Ephemeral runner
-    # pods with a dind sidecar. The release gate doesn't push images —
-    # the `docker` matrix below still runs on GH-hosted runners until
-    # the cluster's ghcr.io push path lands (see novamem entry
-    # 01KRPPQT3RRD0XHXM2V61ZV1C8 for the workaround options).
+    # pods with a dind sidecar.
     runs-on: arc-azrtydxb
     container:
       image: node:24
@@ -112,20 +109,23 @@ jobs:
           name: server-dist
           path: packages/server/dist
 
+  # Multi-arch docker build + push, entirely on ARC. arm64 builds in
+  # the dind sidecar natively; amd64 builds on the remote BuildKit at
+  # 192.168.10.253:1234 natively (~15× faster than QEMU). Both push by
+  # digest to ghcr.io, then a single `buildx imagetools create`
+  # assembles the manifest list. Replaces the old GH-hosted matrix
+  # (ubuntu-latest amd64 + ubuntu-24.04-arm arm64) + separate manifest
+  # job.
+  #
+  # The cookbook's `--name multi --append` snippet doesn't work in
+  # current buildx (mixed drivers are unsupported). The two-builder
+  # pattern below was verified by the arc-smoke workflow.
   docker:
     needs: ci
-    runs-on: ${{ matrix.runner }}
+    runs-on: arc-azrtydxb
     permissions:
       contents: read
       packages: write
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-
     steps:
       - uses: actions/checkout@v4
 
@@ -140,62 +140,6 @@ jobs:
         with:
           name: server-dist
           path: packages/server/dist
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push (single platform)
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
-          outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digest-${{ matrix.runner }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  manifest:
-    needs: docker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digest-*
-          merge-multiple: true
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -214,19 +158,72 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Create multi-arch manifest
-        working-directory: ${{ runner.temp }}/digests
+      - name: Set up two buildx builders
+        run: |
+          # arm64 native via the dind sidecar.
+          docker buildx create \
+            --name local-arm64 \
+            --driver docker-container \
+            --platform linux/arm64
+
+          # amd64 native via the remote BuildKit on 192.168.10.253.
+          # Certs + endpoint are auto-injected into every arc-azrtydxb
+          # runner pod by the AutoscalingRunnerSet template.
+          docker buildx create \
+            --name remote-amd64 \
+            --driver remote \
+            --platform linux/amd64 \
+            --driver-opt cacert="$BUILDKIT_CLIENT_CA" \
+            --driver-opt cert="$BUILDKIT_CLIENT_CERT" \
+            --driver-opt key="$BUILDKIT_CLIENT_KEY" \
+            "$BUILDKIT_AMD64_ENDPOINT"
+
+          docker buildx inspect --bootstrap local-arm64
+          docker buildx inspect --bootstrap remote-amd64
+
+      - name: Build + push arm64 (digest only)
+        id: build_arm64
+        run: |
+          docker buildx build \
+            --builder local-arm64 \
+            --platform linux/arm64 \
+            --labels '${{ steps.meta.outputs.labels }}' \
+            --cache-from type=gha,scope=linux-arm64 \
+            --cache-to type=gha,mode=max,scope=linux-arm64 \
+            --output type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true \
+            --metadata-file arm64-meta.json \
+            .
+          ARM_DIGEST=$(jq -r '."containerimage.digest"' arm64-meta.json)
+          echo "digest=$ARM_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Build + push amd64 (digest only)
+        id: build_amd64
+        run: |
+          docker buildx build \
+            --builder remote-amd64 \
+            --platform linux/amd64 \
+            --labels '${{ steps.meta.outputs.labels }}' \
+            --cache-from type=gha,scope=linux-amd64 \
+            --cache-to type=gha,mode=max,scope=linux-amd64 \
+            --output type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true \
+            --metadata-file amd64-meta.json \
+            .
+          AMD_DIGEST=$(jq -r '."containerimage.digest"' amd64-meta.json)
+          echo "digest=$AMD_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Assemble multi-arch manifest list
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build_arm64.outputs.digest }}" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build_amd64.outputs.digest }}"
 
       - name: Inspect manifest
         run: docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
 
   release:
-    needs: [ci, manifest]
-    runs-on: ubuntu-latest
+    needs: [ci, docker]
+    runs-on: arc-azrtydxb
     permissions:
       contents: write
 


### PR DESCRIPTION
Completes the ARC migration. After this PR no workflow uses GH-hosted runners.

## Change

The old release pipeline had three docker-related jobs on GH-hosted runners: a matrix of \`ubuntu-latest\` (amd64) + \`ubuntu-24.04-arm\` (arm64), each building and pushing by digest, then a separate \`manifest\` job on \`ubuntu-latest\` to assemble the multi-arch manifest list. This PR collapses all three into one job on \`arc-azrtydxb\` using two buildx builders:

- **`local-arm64`** (`docker-container` driver) — dind sidecar, native arm64
- **`remote-amd64`** (`remote` driver) — `192.168.10.253:1234` BuildKit, native amd64 (~15× faster than QEMU)

Certs + endpoint are auto-injected by the AutoscalingRunnerSet template. Each builder pushes its arch's digest to ghcr.io; a single `buildx imagetools create` then assembles the manifest list with the semver/major.minor/latest tags from `docker/metadata-action`.

The `release` job (GH release creation) also moves from `ubuntu-latest` to `arc-azrtydxb` — no docker push, just `actions/checkout` + `orhun/git-cliff-action` + `softprops/action-gh-release`.

## Validation

The build steps were verified by the arc-smoke runs (#128, #129) — two-builder setup, env vars, certs, both arch builds all work. **The push step is the open risk**: arc-smoke run [25941324719](https://github.com/azrtydxb/kryton/actions/runs/25941324719) failed at push time with `tls: failed to verify certificate: x509: certificate signed by unknown authority` because the pod-level hostAlias routes `ghcr.io` to the cluster pull-through mirror, which serves a cluster-CA-signed cert that dind's buildkit doesn't trust. Issue #133 documents this.

If this PR's run hits the same error, #133's cluster-side fix is still needed and we'll surface the error with all the artifacts to debug. If the cluster has since gained a working push path (cert trust, write-through proxy, alternate scale set without the hostAlias), this PR fully completes the migration.

## Test plan

- [ ] Merge.
- [ ] Cut a real \`v*\` tag (or push a no-op test tag) to exercise the full pipeline.
- [ ] If push fails with the TLS error, the failure mode + fix path is already tracked in #133.