### PR TITLE
ci(release): route docker job to arc-azrtydxb-publish (no hostAlias)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,15 @@ jobs:
   # pattern below was verified by the arc-smoke workflow.
   docker:
     needs: ci
-    runs-on: arc-azrtydxb
+    # `arc-azrtydxb-publish` is identical to `arc-azrtydxb` except its
+    # pod template omits the `ghcr.io → 192.168.10.122` hostAlias. The
+    # mirror is a pull-through cache that doesn't accept writes AND
+    # serves a cluster-CA-signed cert that buildkit-container doesn't
+    # trust — both made push from inside dind fail with a TLS
+    # 'unknown authority' error on the regular arc-azrtydxb scale set.
+    # Without the hostAlias, ghcr.io resolves to its real public CDN
+    # via CoreDNS and pushes work with the standard public TLS chain.
+    runs-on: arc-azrtydxb-publish
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Fixes the ghcr.io push TLS error that the v4.4.0-pre.10 release run hit twice (#134 / #136 attempts).

## Root cause (now confirmed)

The base \`arc-azrtydxb\` scale set has a pod-level hostAlias mapping \`ghcr.io → 192.168.10.122\` so PULLS go through the cluster's pull-through registry cache (fast, no rate-limited PAT). That works for pulls. **Pushes from inside the dind sidecar's buildkit-container fail**: the mirror serves a cluster-CA-signed cert that buildkit-container's standard CA bundle doesn't trust, and \`registry:2\` in proxy mode doesn't accept writes anyway. Error from the release runs:

> failed to push ghcr.io/azrtydxb/kryton/kryton: failed to authorize: failed to fetch oauth token: Post "https://ghcr.io/token": tls: failed to verify certificate: x509: certificate signed by unknown authority

## Fix (cluster side, already applied)

Spun up a second helm release \`arc-azrtydxb-publish\` from the same \`gha-runner-scale-set\` chart (v0.13.1), with identical helm values to \`arc-azrtydxb\` except the \`hostAliases\` block is removed. \`ghcr.io\` now resolves to the real public CDN via CoreDNS, so buildkit-container's push hits the standard public TLS chain and succeeds.

\`\`\`
$ kubectl -n arc-runners get autoscalingrunnerset
NAME                   MINIMUM RUNNERS   MAXIMUM RUNNERS
arc-azrtydxb           0                 20
arc-azrtydxb-publish   0                 20
\`\`\`

## Workflow change

Only the \`docker\` job moves to the new scale set. \`ci\` (gate) and \`release\` (GitHub release) stay on \`arc-azrtydxb\` — neither does a ghcr.io push, both benefit from the mirror for image pulls.

## Test plan

- [ ] Merge.
- [ ] Re-tag (or push \`v4.4.0-pre.11\`) to retrigger the release pipeline.
- [ ] Manifest list should land on ghcr.io with both \`linux/amd64\` and \`linux/arm64\` entries.