### PR TITLE
ci(release): use in-cluster zot as buildkit cache backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,15 +168,28 @@ jobs:
 
       - name: Set up two buildx builders
         run: |
-          # arm64 native via the dind sidecar.
+          # arm64 native via the dind sidecar.  The inline buildkitd
+          # config marks the cluster zot registry as insecure so this
+          # builder can push/pull cache layers without needing the
+          # cluster CA in buildkit-container's trust store.
+          cat > /tmp/buildkitd-local.toml <<'EOF'
+          [registry."192.168.10.123:5000"]
+            http = false
+            insecure = true
+          EOF
           docker buildx create \
             --name local-arm64 \
             --driver docker-container \
-            --platform linux/arm64
+            --platform linux/arm64 \
+            --buildkitd-config /tmp/buildkitd-local.toml
 
           # amd64 native via the remote BuildKit on 192.168.10.253.
           # Certs + endpoint are auto-injected into every arc-azrtydxb
-          # runner pod by the AutoscalingRunnerSet template.
+          # runner pod by the AutoscalingRunnerSet template.  The NAS
+          # buildkit already has the cluster zot registry trusted via
+          # /etc/buildkit/buildkitd.toml (registry."192.168.10.123:5000"
+          # with cluster-ca.crt), so no inline config is needed here —
+          # remote-driver builders inherit the daemon's config.
           docker buildx create \
             --name remote-amd64 \
             --driver remote \
@@ -197,8 +210,13 @@ jobs:
           builder: local-arm64
           platforms: linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=linux-arm64
-          cache-to: type=gha,mode=max,scope=linux-arm64
+          # Buildkit cache lives in the in-cluster zot registry at
+          # 192.168.10.123:5000 — pushes/pulls over the cluster LAN
+          # instead of GHA cache over the NAS uplink. mode=max stores
+          # all intermediate layers (full hit rate); image-manifest=true
+          # uses OCI manifest format which buildx and crane both prefer.
+          cache-from: type=registry,ref=192.168.10.123:5000/buildcache/kryton:linux-arm64
+          cache-to: type=registry,ref=192.168.10.123:5000/buildcache/kryton:linux-arm64,mode=max,image-manifest=true
           outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Build + push amd64 (digest only)
@@ -209,8 +227,8 @@ jobs:
           builder: remote-amd64
           platforms: linux/amd64
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=linux-amd64
-          cache-to: type=gha,mode=max,scope=linux-amd64
+          cache-from: type=registry,ref=192.168.10.123:5000/buildcache/kryton:linux-amd64
+          cache-to: type=registry,ref=192.168.10.123:5000/buildcache/kryton:linux-amd64,mode=max,image-manifest=true
           outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Assemble multi-arch manifest list


### PR DESCRIPTION
The v4.4.0-pre.10 amd64 build hit a 3-hour wall time, which the user observed as \"used emulation for amd64\". Investigation showed it was not emulation — the build itself ran natively on the remote BuildKit on 192.168.10.253 in ~6 min. The remaining 3 hours were \`cache-to: type=gha,mode=max\` exporting hundreds of MB of intermediate layers from the NAS uplink up to \`results-receiver.actions.githubusercontent.com\`.

Smoke test on \`arc-azrtydxb-publish\` for a trivial alpine image (PR #139, dispatch run 25964993654) finished build + push + manifest assembly in 21s — proving the build path is healthy. The slowness is purely the GHA cache export.

## Change

Switch buildkit cache to the in-cluster **zot** registry at \`192.168.10.123:5000\`:

- Push/pull stays inside the cluster LAN (gigabit) instead of NAS-to-GHA over the WAN
- Cache repo: \`192.168.10.123:5000/buildcache/kryton:linux-{amd64,arm64}\`
- \`image-manifest=true\` for OCI manifest format
- For \`remote-amd64\`: NAS \`buildkitd.toml\` already had a \`[registry.\"192.168.10.123\"]\` block trusting cluster-ca.crt — except it was missing the \`:5000\` port. Fixed on the host alongside this commit; daemon restarted.
- For \`local-arm64\` (dind sidecar): pass an inline \`--buildkitd-config\` marking \`192.168.10.123:5000\` as \`insecure = true\`. buildkit-container inside dind doesn't have cluster CA in its trust store; the registry is LAN-only so skipping TLS verify here is fine.

## Expected result

amd64 build wall time should drop from ~3 h → ~10 min (the build itself + cache traffic over LAN). arm64 should stay around 12 min.

## Test plan

- [ ] Merge.
- [ ] Re-tag \`v4.4.0-pre.10\` to the new merge commit (or push \`v4.4.0-pre.11\`).
- [ ] Watch the docker job timings; confirm cache export at the end is seconds, not hours.
- [ ] Confirm a second release run reuses the cache (cache-from hit; build is faster).