### PR TITLE
fix(mcp): canonical Templates/Daily folders + favorites follow renames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,34 +179,26 @@ jobs:
           install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform
           helm version
           kubeconform -v
-      - name: Fetch helm chart dependencies
+      - name: Fetch + unpack helm chart dependencies
         shell: bash
         run: |
           set -euo pipefail
-          # sync:check shells out to `helm template charts/kryton`. helm's
-          # CheckDependencies refuses to load when Chart.lock + the on-disk
-          # tarball + the freshly-published upstream chart disagree on digest
-          # (bitnami occasionally republishes the same version). Wipe the
-          # tracked tarball + lock first so `dependency update` resolves
-          # everything in one consistent fetch.
+          # sync:check shells out to `helm template charts/kryton`. Two
+          # quirks need handling:
+          #   1. bitnami occasionally republishes the same postgresql version
+          #      with a new digest, so a committed Chart.lock + .tgz drift out
+          #      of sync. Wiping both before `dependency update` resolves
+          #      everything in one consistent fetch.
+          #   2. helm 3.16.3 fails to load the bitnami postgresql .tgz as a
+          #      subchart on this runner (helm dep list reports "ok", but
+          #      lint/template both insist the dep is missing). Unpacking the
+          #      tarball into a sibling directory makes the loader find it
+          #      reliably.
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update bitnami
           rm -f charts/kryton/Chart.lock charts/kryton/charts/*.tgz
           helm dependency update charts/kryton
-          ls -la charts/kryton/charts/
-          cat charts/kryton/Chart.lock
-          echo '--- helm version ---'
-          helm version
-          echo '--- subchart tarball metadata ---'
-          ls -la charts/kryton/charts/
-          file charts/kryton/charts/postgresql-16.4.5.tgz || true
-          echo '--- unpack the tarball manually so the loader can find it ---'
-          # helm 3.16.3 fails to load the bitnami postgresql tarball as a
-          # subchart in this runner; unpacked-dir form loads reliably.
           tar -xzf charts/kryton/charts/postgresql-16.4.5.tgz -C charts/kryton/charts/
-          ls -la charts/kryton/charts/
-          echo '--- helm lint after unpack ---'
-          helm lint charts/kryton
       - name: Deployment sync check
         run: npm run sync:check
       - name: Restore workspace ownership to runner user

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Install helm + kubeconform
+        shell: bash
         run: |
           set -euo pipefail
           apt-get update -qq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,24 +195,20 @@ jobs:
           helm dependency update charts/kryton
           ls -la charts/kryton/charts/
           cat charts/kryton/Chart.lock
-          echo '--- helm dependency build (post-update sanity) ---'
-          helm dependency build charts/kryton
-          echo '--- helm lint ---'
-          helm lint charts/kryton || true
-          echo '--- helm template (verify) ---'
-          helm template charts/kryton --debug 2>&1 | tail -20 || true
+          echo '--- helm version ---'
+          helm version
+          echo '--- subchart tarball metadata ---'
+          ls -la charts/kryton/charts/
+          file charts/kryton/charts/postgresql-16.4.5.tgz || true
+          echo '--- unpack the tarball manually so the loader can find it ---'
+          # helm 3.16.3 fails to load the bitnami postgresql tarball as a
+          # subchart in this runner; unpacked-dir form loads reliably.
+          tar -xzf charts/kryton/charts/postgresql-16.4.5.tgz -C charts/kryton/charts/
+          ls -la charts/kryton/charts/
+          echo '--- helm lint after unpack ---'
+          helm lint charts/kryton
       - name: Deployment sync check
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Debug: confirm the dep tarball is still on disk before sync:check.
-          ls -la charts/kryton/charts/ || true
-          helm dependency list charts/kryton || true
-          echo '--- Chart.lock ---'
-          cat charts/kryton/Chart.lock
-          echo '--- direct helm template (full stderr) ---'
-          helm template charts/kryton --debug 2>&1 | head -30 || true
-          npm run sync:check
+        run: npm run sync:check
       - name: Restore workspace ownership to runner user
         if: always()
         run: chown -R 1001:1001 . || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,15 @@ jobs:
           install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform
           helm version
           kubeconform -v
+      - name: Fetch helm chart dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          # sync:check shells out to `helm template charts/kryton`, which
+          # requires subchart tarballs to be present in charts/kryton/charts/.
+          # `helm dependency build` resolves them from Chart.lock without
+          # touching the network beyond the declared repos.
+          helm dependency build charts/kryton
       - name: Deployment sync check
         run: npm run sync:check
       - name: Restore workspace ownership to runner user

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,12 @@ jobs:
           # then reconstitutes the subchart from Chart.lock.
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update bitnami
-          helm dependency build charts/kryton
+          # `update` is permissive: it refreshes the local subchart cache and
+          # rewrites Chart.lock if upstream republished with a new digest.
+          # `build` was rejecting the existing tarball as outdated and then
+          # leaving charts/ empty, causing `helm template` to fail downstream.
+          helm dependency update charts/kryton
+          ls -la charts/kryton/charts/
       - name: Deployment sync check
         run: npm run sync:check
       - name: Restore workspace ownership to runner user

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,12 +195,12 @@ jobs:
           helm dependency update charts/kryton
           ls -la charts/kryton/charts/
           cat charts/kryton/Chart.lock
-          echo '--- tarball top-level entries ---'
-          tar -tzf charts/kryton/charts/postgresql-16.4.5.tgz | head -5
-          echo '--- inner Chart.yaml ---'
-          tar -xzOf charts/kryton/charts/postgresql-16.4.5.tgz postgresql/Chart.yaml | head -10 || true
-          echo '--- helm show chart (loader sees) ---'
-          helm show chart charts/kryton/charts/postgresql-16.4.5.tgz | head -10 || true
+          echo '--- helm dependency build (post-update sanity) ---'
+          helm dependency build charts/kryton
+          echo '--- helm lint ---'
+          helm lint charts/kryton || true
+          echo '--- helm template (verify) ---'
+          helm template charts/kryton --debug 2>&1 | tail -20 || true
       - name: Deployment sync check
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,10 +165,16 @@ jobs:
           set -euo pipefail
           apt-get update -qq
           apt-get install -y -qq --no-install-recommends curl ca-certificates
-          curl -fsSL https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz \
+          # arc-azrtydxb is ARM64 — pick the right arch instead of hard-coding amd64.
+          case "$(uname -m)" in
+            aarch64|arm64) ARCH=arm64 ;;
+            x86_64) ARCH=amd64 ;;
+            *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -fsSL "https://get.helm.sh/helm-v3.16.3-linux-${ARCH}.tar.gz" \
             | tar -xz -C /tmp
-          install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
-          curl -fsSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+          install -m 0755 "/tmp/linux-${ARCH}/helm" /usr/local/bin/helm
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-${ARCH}.tar.gz" \
             | tar -xz -C /tmp
           install -m 0755 /tmp/kubeconform /usr/local/bin/kubeconform
           helm version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,18 +183,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # sync:check shells out to `helm template charts/kryton`, which
-          # requires subchart tarballs to be present in charts/kryton/charts/.
-          # `helm dependency build` needs the bitnami repo registered first,
-          # then reconstitutes the subchart from Chart.lock.
+          # sync:check shells out to `helm template charts/kryton`. helm's
+          # CheckDependencies refuses to load when Chart.lock + the on-disk
+          # tarball + the freshly-published upstream chart disagree on digest
+          # (bitnami occasionally republishes the same version). Wipe the
+          # tracked tarball + lock first so `dependency update` resolves
+          # everything in one consistent fetch.
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update bitnami
-          # `update` is permissive: it refreshes the local subchart cache and
-          # rewrites Chart.lock if upstream republished with a new digest.
-          # `build` was rejecting the existing tarball as outdated and then
-          # leaving charts/ empty, causing `helm template` to fail downstream.
+          rm -f charts/kryton/Chart.lock charts/kryton/charts/*.tgz
           helm dependency update charts/kryton
           ls -la charts/kryton/charts/
+          cat charts/kryton/Chart.lock
       - name: Deployment sync check
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,12 @@ jobs:
           helm dependency update charts/kryton
           ls -la charts/kryton/charts/
           cat charts/kryton/Chart.lock
+          echo '--- tarball top-level entries ---'
+          tar -tzf charts/kryton/charts/postgresql-16.4.5.tgz | head -5
+          echo '--- inner Chart.yaml ---'
+          tar -xzOf charts/kryton/charts/postgresql-16.4.5.tgz postgresql/Chart.yaml | head -10 || true
+          echo '--- helm show chart (loader sees) ---'
+          helm show chart charts/kryton/charts/postgresql-16.4.5.tgz | head -10 || true
       - name: Deployment sync check
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,13 @@ jobs:
           helm dependency update charts/kryton
           ls -la charts/kryton/charts/
       - name: Deployment sync check
-        run: npm run sync:check
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Debug: confirm the dep tarball is still on disk before sync:check.
+          ls -la charts/kryton/charts/ || true
+          helm dependency list charts/kryton || true
+          npm run sync:check
       - name: Restore workspace ownership to runner user
         if: always()
         run: chown -R 1001:1001 . || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,10 @@ jobs:
           set -euo pipefail
           # sync:check shells out to `helm template charts/kryton`, which
           # requires subchart tarballs to be present in charts/kryton/charts/.
-          # `helm dependency build` resolves them from Chart.lock without
-          # touching the network beyond the declared repos.
+          # `helm dependency build` needs the bitnami repo registered first,
+          # then reconstitutes the subchart from Chart.lock.
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update bitnami
           helm dependency build charts/kryton
       - name: Deployment sync check
         run: npm run sync:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,8 @@ jobs:
           # Debug: confirm the dep tarball is still on disk before sync:check.
           ls -la charts/kryton/charts/ || true
           helm dependency list charts/kryton || true
+          echo '--- direct helm template ---'
+          helm template charts/kryton >/dev/null && echo 'helm template OK' || echo 'helm template FAILED'
           npm run sync:check
       - name: Restore workspace ownership to runner user
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,10 @@ jobs:
           # Debug: confirm the dep tarball is still on disk before sync:check.
           ls -la charts/kryton/charts/ || true
           helm dependency list charts/kryton || true
-          echo '--- direct helm template ---'
-          helm template charts/kryton >/dev/null && echo 'helm template OK' || echo 'helm template FAILED'
+          echo '--- Chart.lock ---'
+          cat charts/kryton/Chart.lock
+          echo '--- direct helm template (full stderr) ---'
+          helm template charts/kryton --debug 2>&1 | head -30 || true
           npm run sync:check
       - name: Restore workspace ownership to runner user
         if: always()

--- a/packages/server/src/modules/agents/__tests__/mcp-tools.test.ts
+++ b/packages/server/src/modules/agents/__tests__/mcp-tools.test.ts
@@ -34,6 +34,12 @@ async function readStarredRow(
   return JSON.parse(row.value) as string[];
 }
 
+async function clearStarred(ctx: NotesTestApp, userId: string): Promise<void> {
+  await ctx.app.db
+    .delete(settings)
+    .where(and(eq(settings.userId, userId), eq(settings.key, "starred")));
+}
+
 describe("MCP tools / canonical Templates and Daily folders", () => {
   let ctx: NotesTestApp | null = null;
 
@@ -172,10 +178,7 @@ describe("MCP tools / canonical Templates and Daily folders", () => {
     )) as Array<{ path: string }>;
 
     const paths = result.map((r) => r.path).sort();
-    expect(paths).toEqual([
-      expect.stringMatching(/Daily\/2026-05-17\.md$/),
-      expect.stringMatching(/Daily\/2026-05-18\.md$/),
-    ]);
+    expect(paths).toEqual(["Daily/2026-05-17.md", "Daily/2026-05-18.md"]);
   });
 });
 
@@ -189,7 +192,12 @@ describe("MCP tools / favorites follow renames", () => {
     await cleanupNotesTestUser(TEST_USER.id);
   });
   afterEach(async () => {
-    if (ctx) await ctx.cleanup();
+    if (ctx) {
+      // Wipe the starred row so favorites don't bleed between tests sharing
+      // a single test user.
+      await clearStarred(ctx, TEST_USER.id);
+      await ctx.cleanup();
+    }
     ctx = null;
   });
 

--- a/packages/server/src/modules/agents/__tests__/mcp-tools.test.ts
+++ b/packages/server/src/modules/agents/__tests__/mcp-tools.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { format } from "date-fns";
+import { and, eq } from "drizzle-orm";
+import { executeTool } from "../mcp/tools.js";
+import { settings } from "../../../db/schema/settings.js";
+import {
+  buildNotesTestApp,
+  cleanupNotesTestUser,
+  createNotesTestUser,
+  seedNotesTestUser,
+  type NotesTestApp,
+} from "../../notes/__tests__/helpers.js";
+
+/**
+ * Regression tests for MCP tool path-casing + favorites-follow-rename bugs:
+ *   - templates lookup must use the canonical `Templates/` folder (not `templates/`)
+ *   - daily notes must read/write `Daily/YYYY-MM-DD.md` (not `daily/...`)
+ *   - rename_note / rename_folder must update the user's starred list so
+ *     favorites follow the new path instead of orphaning.
+ */
+
+const TEST_USER = createNotesTestUser("mcp-tools");
+
+async function readStarredRow(
+  ctx: NotesTestApp,
+  userId: string,
+): Promise<string[]> {
+  const row = await ctx.app.db.query.settings.findFirst({
+    where: and(eq(settings.userId, userId), eq(settings.key, "starred")),
+  });
+  if (!row?.value) return [];
+  return JSON.parse(row.value) as string[];
+}
+
+describe("MCP tools / canonical Templates and Daily folders", () => {
+  let ctx: NotesTestApp | null = null;
+
+  beforeAll(async () => {
+    await seedNotesTestUser(TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupNotesTestUser(TEST_USER.id);
+  });
+  afterEach(async () => {
+    if (ctx) await ctx.cleanup();
+    ctx = null;
+  });
+
+  it("list_templates reads from Templates/ (capital T)", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+    const userDir = await ctx.app.notes.getUserNotesDir(TEST_USER.id);
+    await fs.mkdir(path.join(userDir, "Templates"), { recursive: true });
+    await fs.writeFile(
+      path.join(userDir, "Templates", "Project.md"),
+      "# {{title}}\n\nA project template.\n",
+      "utf8",
+    );
+
+    const result = (await executeTool(
+      ctx.app,
+      "list_templates",
+      {},
+      TEST_USER.id,
+    )) as Array<{ name: string; path: string }>;
+
+    const names = result.map((e) => e.name);
+    expect(names).toContain("Project.md");
+  });
+
+  it("list_templates returns [] when Templates/ does not exist", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+    const result = await executeTool(
+      ctx.app,
+      "list_templates",
+      {},
+      TEST_USER.id,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("create_note_from_template resolves from Templates/<name>.md", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+    const userDir = await ctx.app.notes.getUserNotesDir(TEST_USER.id);
+    await fs.mkdir(path.join(userDir, "Templates"), { recursive: true });
+    await fs.writeFile(
+      path.join(userDir, "Templates", "Meeting Notes.md"),
+      "# Meeting\n\nAttendees:\n",
+      "utf8",
+    );
+
+    const result = (await executeTool(
+      ctx.app,
+      "create_note_from_template",
+      { templateName: "Meeting Notes", notePath: "from-template.md" },
+      TEST_USER.id,
+    )) as { success: boolean; path: string };
+
+    expect(result.success).toBe(true);
+
+    const created = await fs.readFile(
+      path.join(userDir, "from-template.md"),
+      "utf8",
+    );
+    expect(created).toContain("Attendees:");
+  });
+
+  it("get_daily_note reports Daily/ (capital D) as the expected path", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+    const result = (await executeTool(
+      ctx.app,
+      "get_daily_note",
+      {},
+      TEST_USER.id,
+    )) as { exists: boolean; expectedPath: string };
+
+    expect(result.exists).toBe(false);
+    expect(result.expectedPath).toMatch(/^Daily\/\d{4}-\d{2}-\d{2}\.md$/);
+  });
+
+  it("write_daily_note writes to Daily/YYYY-MM-DD.md and round-trips", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+    const today = format(new Date(), "yyyy-MM-dd");
+
+    const writeResult = (await executeTool(
+      ctx.app,
+      "write_daily_note",
+      { content: "# Daily\n\nhello\n" },
+      TEST_USER.id,
+    )) as { success: boolean; path: string };
+
+    expect(writeResult.path).toBe(`Daily/${today}.md`);
+
+    const userDir = await ctx.app.notes.getUserNotesDir(TEST_USER.id);
+    const onDisk = await fs.readFile(
+      path.join(userDir, "Daily", `${today}.md`),
+      "utf8",
+    );
+    expect(onDisk).toContain("hello");
+
+    // get_daily_note should now resolve the freshly-written note.
+    const getResult = (await executeTool(
+      ctx.app,
+      "get_daily_note",
+      {},
+      TEST_USER.id,
+    )) as { content: string };
+    expect(getResult.content).toContain("hello");
+  });
+
+  it("list_daily_notes scans Daily/ (capital D)", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+    const userDir = await ctx.app.notes.getUserNotesDir(TEST_USER.id);
+    await fs.mkdir(path.join(userDir, "Daily"), { recursive: true });
+    await fs.writeFile(
+      path.join(userDir, "Daily", "2026-05-17.md"),
+      "yesterday\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(userDir, "Daily", "2026-05-18.md"),
+      "today\n",
+      "utf8",
+    );
+
+    const result = (await executeTool(
+      ctx.app,
+      "list_daily_notes",
+      { limit: 10 },
+      TEST_USER.id,
+    )) as Array<{ path: string }>;
+
+    const paths = result.map((r) => r.path).sort();
+    expect(paths).toEqual([
+      expect.stringMatching(/Daily\/2026-05-17\.md$/),
+      expect.stringMatching(/Daily\/2026-05-18\.md$/),
+    ]);
+  });
+});
+
+describe("MCP tools / favorites follow renames", () => {
+  let ctx: NotesTestApp | null = null;
+
+  beforeAll(async () => {
+    await seedNotesTestUser(TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupNotesTestUser(TEST_USER.id);
+  });
+  afterEach(async () => {
+    if (ctx) await ctx.cleanup();
+    ctx = null;
+  });
+
+  it("rename_note updates the starred entry to the new path", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+
+    await executeTool(
+      ctx.app,
+      "create_note",
+      { path: "fav/old.md", content: "# old\n" },
+      TEST_USER.id,
+    );
+    await executeTool(
+      ctx.app,
+      "add_favorite",
+      { path: "fav/old.md" },
+      TEST_USER.id,
+    );
+    expect(await readStarredRow(ctx, TEST_USER.id)).toEqual(["fav/old.md"]);
+
+    await executeTool(
+      ctx.app,
+      "rename_note",
+      { oldPath: "fav/old.md", newPath: "fav/new.md" },
+      TEST_USER.id,
+    );
+
+    expect(await readStarredRow(ctx, TEST_USER.id)).toEqual(["fav/new.md"]);
+
+    const list = (await executeTool(
+      ctx.app,
+      "list_favorites",
+      {},
+      TEST_USER.id,
+    )) as { paths: string[] };
+    expect(list.paths).toEqual(["fav/new.md"]);
+  });
+
+  it("rename_note leaves unrelated favorites untouched", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+
+    await executeTool(
+      ctx.app,
+      "create_note",
+      { path: "a.md", content: "a" },
+      TEST_USER.id,
+    );
+    await executeTool(
+      ctx.app,
+      "create_note",
+      { path: "b.md", content: "b" },
+      TEST_USER.id,
+    );
+    await executeTool(ctx.app, "add_favorite", { path: "a.md" }, TEST_USER.id);
+    await executeTool(ctx.app, "add_favorite", { path: "b.md" }, TEST_USER.id);
+
+    await executeTool(
+      ctx.app,
+      "rename_note",
+      { oldPath: "a.md", newPath: "a-renamed.md" },
+      TEST_USER.id,
+    );
+
+    const starred = await readStarredRow(ctx, TEST_USER.id);
+    expect(starred.sort()).toEqual(["a-renamed.md", "b.md"]);
+  });
+
+  it("rename_folder rewrites the prefix of each affected favorite", async () => {
+    ctx = await buildNotesTestApp({ user: TEST_USER });
+
+    await executeTool(
+      ctx.app,
+      "create_folder",
+      { path: "moveable" },
+      TEST_USER.id,
+    );
+    await executeTool(
+      ctx.app,
+      "create_note",
+      { path: "moveable/one.md", content: "1" },
+      TEST_USER.id,
+    );
+    await executeTool(
+      ctx.app,
+      "create_note",
+      { path: "moveable/sub/two.md", content: "2" },
+      TEST_USER.id,
+    );
+    await executeTool(
+      ctx.app,
+      "create_note",
+      { path: "other/three.md", content: "3" },
+      TEST_USER.id,
+    );
+
+    await executeTool(
+      ctx.app,
+      "add_favorite",
+      { path: "moveable/one.md" },
+      TEST_USER.id,
+    );
+    await executeTool(
+      ctx.app,
+      "add_favorite",
+      { path: "moveable/sub/two.md" },
+      TEST_USER.id,
+    );
+    await executeTool(
+      ctx.app,
+      "add_favorite",
+      { path: "other/three.md" },
+      TEST_USER.id,
+    );
+
+    await executeTool(
+      ctx.app,
+      "rename_folder",
+      { oldPath: "moveable", newPath: "moved" },
+      TEST_USER.id,
+    );
+
+    const starred = (await readStarredRow(ctx, TEST_USER.id)).sort();
+    expect(starred).toEqual([
+      "moved/one.md",
+      "moved/sub/two.md",
+      "other/three.md",
+    ]);
+  });
+});

--- a/packages/server/src/modules/agents/mcp/tools.ts
+++ b/packages/server/src/modules/agents/mcp/tools.ts
@@ -34,6 +34,28 @@ async function writeStarred(
     });
 }
 
+// Rewrite favorites after a rename so stars follow the note/folder
+// to its new location instead of being orphaned.
+async function rewriteStarred(
+  app: FastifyInstance,
+  userId: string,
+  rewrite: (p: string) => string | null,
+): Promise<void> {
+  const current = await readStarred(app, userId);
+  let changed = false;
+  const next: string[] = [];
+  for (const p of current) {
+    const mapped = rewrite(p);
+    if (mapped === null) {
+      changed = true;
+      continue;
+    }
+    if (mapped !== p) changed = true;
+    next.push(mapped);
+  }
+  if (changed) await writeStarred(app, userId, next);
+}
+
 interface ToolDefinition {
   name: string;
   description: string;
@@ -218,7 +240,7 @@ export function getToolDefinitions(): ToolDefinition[] {
     },
     {
       name: "write_daily_note",
-      description: "Create or replace today's daily note (at daily/YYYY-MM-DD.md). Use append_to_note instead if you want to add to existing content without overwriting.",
+      description: "Create or replace today's daily note (at Daily/YYYY-MM-DD.md). Use append_to_note instead if you want to add to existing content without overwriting.",
       inputSchema: {
         type: "object",
         properties: {
@@ -284,7 +306,7 @@ export function getToolDefinitions(): ToolDefinition[] {
     },
     {
       name: "list_daily_notes",
-      description: "List all daily notes (daily/YYYY-MM-DD.md), newest first.",
+      description: "List all daily notes (Daily/YYYY-MM-DD.md), newest first.",
       inputSchema: {
         type: "object",
         properties: {
@@ -437,7 +459,7 @@ export async function executeTool(
     }
     case "get_daily_note": {
       const { format } = await import("date-fns");
-      const dailyPath = `daily/${format(new Date(), "yyyy-MM-dd")}.md`;
+      const dailyPath = `Daily/${format(new Date(), "yyyy-MM-dd")}.md`;
       try {
         return await app.notes.readNote(dailyPath, userId);
       } catch {
@@ -450,10 +472,10 @@ export async function executeTool(
         const noteSvc = await import("../../notes/services/note.service.js");
         const svc = new noteSvc.NoteService(app);
         // Must `await` so the ENOENT rejection from a missing
-        // templates/ folder lands in this catch — `return svc.…`
+        // Templates/ folder lands in this catch — `return svc.…`
         // hands an unresolved promise back to the caller and the
         // rejection escapes the try/catch.
-        return await svc.scanDirectory(path.join(userDir, "templates"));
+        return await svc.scanDirectory(path.join(userDir, "Templates"));
       } catch {
         return [];
       }
@@ -463,7 +485,7 @@ export async function executeTool(
       if (templateName.includes("/") || templateName.includes("\\") || templateName.includes("..")) {
         throw new Error("Invalid template name");
       }
-      const templateContent = (await app.notes.readNote(`templates/${templateName}.md`, userId)) as { content: string };
+      const templateContent = (await app.notes.readNote(`Templates/${templateName}.md`, userId)) as { content: string };
       await app.notes.writeNote(args.notePath as string, templateContent.content, userId);
       return { success: true, path: args.notePath };
     }
@@ -480,6 +502,7 @@ export async function executeTool(
       const oldFull = oldPath.endsWith(".md") ? oldPath : oldPath + ".md";
       const newFull = newPath.endsWith(".md") ? newPath : newPath + ".md";
       await svc.renameNote(userDir, oldFull, newFull, userId);
+      await rewriteStarred(app, userId, (p) => (p === oldFull ? newFull : p));
       return { success: true, oldPath: oldFull, newPath: newFull };
     }
     case "append_to_note": {
@@ -508,7 +531,7 @@ export async function executeTool(
       const yyyy = today.getUTCFullYear();
       const mm = String(today.getUTCMonth() + 1).padStart(2, "0");
       const dd = String(today.getUTCDate()).padStart(2, "0");
-      const dailyPath = `daily/${yyyy}-${mm}-${dd}.md`;
+      const dailyPath = `Daily/${yyyy}-${mm}-${dd}.md`;
       await app.notes.writeNote(dailyPath, content, userId);
       return { success: true, path: dailyPath };
     }
@@ -586,7 +609,7 @@ export async function executeTool(
       const svc = new noteSvc.NoteService(app);
       let tree: unknown[];
       try {
-        tree = (await svc.scanDirectory(path.join(userDir, "daily"))) as unknown[];
+        tree = (await svc.scanDirectory(path.join(userDir, "Daily"))) as unknown[];
       } catch {
         return [];
       }
@@ -612,12 +635,17 @@ export async function executeTool(
     case "empty_trash":
       await app.trash.emptyAll(userId);
       return { success: true };
-    case "rename_folder":
-      return app.folders.rename(
-        userId,
-        args.oldPath as string,
-        args.newPath as string,
+    case "rename_folder": {
+      const oldFolder = args.oldPath as string;
+      const newFolder = args.newPath as string;
+      const result = await app.folders.rename(userId, oldFolder, newFolder);
+      const oldPrefix = oldFolder.endsWith("/") ? oldFolder : oldFolder + "/";
+      const newPrefix = newFolder.endsWith("/") ? newFolder : newFolder + "/";
+      await rewriteStarred(app, userId, (p) =>
+        p.startsWith(oldPrefix) ? newPrefix + p.slice(oldPrefix.length) : p,
       );
+      return result;
+    }
     case "delete_folder":
       await app.folders.delete(userId, args.path as string);
       return { success: true };

--- a/packages/server/src/modules/agents/mcp/tools.ts
+++ b/packages/server/src/modules/agents/mcp/tools.ts
@@ -609,7 +609,7 @@ export async function executeTool(
       const svc = new noteSvc.NoteService(app);
       let tree: unknown[];
       try {
-        tree = (await svc.scanDirectory(path.join(userDir, "Daily"))) as unknown[];
+        tree = (await svc.scanDirectory(path.join(userDir, "Daily"), "Daily")) as unknown[];
       } catch {
         return [];
       }


### PR DESCRIPTION
## Summary
- Fixes path-casing bugs in MCP tools: `list_templates`, `create_note_from_template`, `get_daily_note`, `write_daily_note`, and `list_daily_notes` were all looking at lowercase `templates/` / `daily/` while the rest of the app uses `Templates/` and `Daily/` (see `notes/routes/{templates,daily}.routes.ts`). As a result the MCP couldn't see existing templates or daily notes, and `write_daily_note` was creating a parallel `daily/` folder beside `Daily/`.
- Teaches `rename_note` and `rename_folder` to rewrite the user's `settings.starred` list so favorites follow the move instead of orphaning. Note rename does an exact-path swap; folder rename rewrites the prefix.

## How surfaced
Bugs were observed by running every MCP tool end-to-end against the deployed k8s instance:
- `list_templates` returned `[]` despite `Templates/Project.md` + `Templates/Meeting Notes.md` existing
- `create_note_from_template` → `Error: Note not found: templates/Project.md`
- `write_daily_note` created `daily/2026-05-18.md` while `Daily/2026-03-23.md` already lived in `Daily/`
- favoriting `_mcp-test/test-note.md`, renaming, then `remove_favorite` on the new path returned `wasFavorited: false`

## Test plan
- [x] `tsc --noEmit` clean
- [x] New regression suite `packages/server/src/modules/agents/__tests__/mcp-tools.test.ts` covers: `list_templates` reads `Templates/` (and empty case), `create_note_from_template` resolves under `Templates/`, `get_daily_note`/`write_daily_note`/`list_daily_notes` use `Daily/`, `rename_note` retargets the starred entry, unrelated favorites untouched, `rename_folder` prefix rewrite
- [ ] CI green
- [ ] After merge + tag, verify the operator rolls the new server image