### PR TITLE
chore: add NOTICE, CLA, and CLA Assistant workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,7 +5,6 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
   actions: write
   contents: write
@@ -21,11 +20,8 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/azrtydxb/kryton/blob/master/CLA.md'
+          path-to-document: 'https://github.com/${{ github.repository }}/blob/HEAD/CLA.md'
           branch: 'cla-signatures'
           allowlist: piwi3910,dependabot[bot],github-actions[bot]
-          remote-organization-name: azrtydxb
-          remote-repository-name: cla-signatures

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,31 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/azrtydxb/kryton/blob/master/CLA.md'
+          branch: 'cla-signatures'
+          allowlist: piwi3910,dependabot[bot],github-actions[bot]
+          remote-organization-name: azrtydxb
+          remote-repository-name: cla-signatures

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,79 @@
+# Kryton Contributor License Agreement
+
+Thank you for your interest in contributing to Kryton (the "Project") maintained
+by Pascal Watteel ("Maintainer"). This Contributor License Agreement ("CLA")
+clarifies the intellectual property license granted with Contributions from any
+person or entity.
+
+By signing this CLA, you accept and agree to the following terms and conditions
+for Your present and future Contributions submitted to the Project.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner, or the legal entity authorized by
+the copyright owner, that is making this Agreement with the Maintainer.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to the Maintainer for inclusion in, or documentation of, the Project.
+
+## 2. Grant of Copyright License
+
+You hereby grant to the Maintainer and to recipients of software distributed by
+the Maintainer a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare derivative works of,
+publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works.
+
+You also grant to the Maintainer the right to **re-license** Your Contributions
+under any other license, including proprietary licenses, at the Maintainer's
+sole discretion. This includes (but is not limited to) the ability for the
+Maintainer to release the Project — and Your Contributions within it — under a
+commercial license in addition to the current Apache License 2.0.
+
+## 3. Grant of Patent License
+
+You hereby grant to the Maintainer and to recipients of software distributed by
+the Maintainer a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer Your
+Contributions, where such license applies only to those patent claims
+licensable by You that are necessarily infringed by Your Contributions alone or
+by combination of Your Contributions with the Project to which such
+Contributions were submitted.
+
+## 4. You Represent That
+
+- You are legally entitled to grant the above licenses.
+- Each of Your Contributions is Your original creation.
+- Your Contribution submissions include complete details of any third-party
+  license or other restriction (including, but not limited to, related patents
+  and trademarks) of which You are personally aware and which are associated
+  with any part of Your Contributions.
+- If Your employer(s) has rights to intellectual property that You create that
+  includes Your Contributions, You represent that You have received permission
+  to make Contributions on behalf of that employer, or that Your employer has
+  waived such rights for Your Contributions to the Project.
+
+## 5. Support
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all.
+
+## 6. No Warranty
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+## Signing
+
+By making a contribution to this project, you certify that you agree to the
+terms above. Sign by commenting on your first pull request with:
+
+    I have read the CLA Document and I hereby sign the CLA
+
+The CLA Assistant bot will record your signature.

--- a/CLA.md
+++ b/CLA.md
@@ -1,73 +1,114 @@
-# Kryton Contributor License Agreement
+# Individual Contributor License Agreement
 
 Thank you for your interest in contributing to Kryton (the "Project") maintained
-by Pascal Watteel ("Maintainer"). This Contributor License Agreement ("CLA")
-clarifies the intellectual property license granted with Contributions from any
-person or entity.
+by Pascal Watteel ("Maintainer"). In order to clarify the intellectual property
+license granted with Contributions from any person or entity, Maintainer must
+have a Contributor License Agreement ("CLA") on file that has been agreed to by
+each Contributor, indicating agreement to the license terms below.
 
-By signing this CLA, you accept and agree to the following terms and conditions
-for Your present and future Contributions submitted to the Project.
+This license is for Your protection as a Contributor as well as the protection
+of Maintainer and the users of the Project; it does not change Your rights to
+use Your own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your present and
+future Contributions submitted to Maintainer. Except for the license granted
+herein to Maintainer and recipients of software distributed by Maintainer, You
+reserve all right, title, and interest in and to Your Contributions.
 
 ## 1. Definitions
 
-**"You"** (or **"Your"**) means the copyright owner, or the legal entity authorized by
-the copyright owner, that is making this Agreement with the Maintainer.
+**"You"** (or **"Your"**) shall mean the copyright owner or legal entity
+authorized by the copyright owner that is making this Agreement with
+Maintainer. For legal entities, the entity making a Contribution and all other
+entities that control, are controlled by, or are under common control with that
+entity are considered to be a single Contributor. For the purposes of this
+definition, "control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or otherwise, or
+(ii) ownership of fifty percent (50%) or more of the outstanding shares, or
+(iii) beneficial ownership of such entity.
 
-**"Contribution"** means any original work of authorship, including any
+**"Contribution"** shall mean any original work of authorship, including any
 modifications or additions to an existing work, that is intentionally submitted
-by You to the Maintainer for inclusion in, or documentation of, the Project.
+by You to Maintainer for inclusion in, or documentation of, any of the products
+owned or managed by Maintainer (the "Work"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to Maintainer or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of,
+Maintainer for the purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in writing
+by You as "Not a Contribution."
 
 ## 2. Grant of Copyright License
 
-You hereby grant to the Maintainer and to recipients of software distributed by
-the Maintainer a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable copyright license to reproduce, prepare derivative works of,
-publicly display, publicly perform, sublicense, and distribute Your
-Contributions and such derivative works.
-
-You also grant to the Maintainer the right to **re-license** Your Contributions
-under any other license, including proprietary licenses, at the Maintainer's
-sole discretion. This includes (but is not limited to) the ability for the
-Maintainer to release the Project — and Your Contributions within it — under a
-commercial license in addition to the current Apache License 2.0.
+Subject to the terms and conditions of this Agreement, You hereby grant to
+Maintainer and to recipients of software distributed by Maintainer a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, and distribute Your Contributions and such derivative
+works.
 
 ## 3. Grant of Patent License
 
-You hereby grant to the Maintainer and to recipients of software distributed by
-the Maintainer a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable (except as stated in this section) patent license to make, have
-made, use, offer to sell, sell, import, and otherwise transfer Your
-Contributions, where such license applies only to those patent claims
-licensable by You that are necessarily infringed by Your Contributions alone or
-by combination of Your Contributions with the Project to which such
-Contributions were submitted.
+Subject to the terms and conditions of this Agreement, You hereby grant to
+Maintainer and to recipients of software distributed by Maintainer a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Work, where such license applies only
+to those patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work
+to which such Contribution(s) was submitted. If any entity institutes patent
+litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that Your Contribution, or the Work to
+which You have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+Agreement for that Contribution or Work shall terminate as of the date such
+litigation is filed.
 
-## 4. You Represent That
+## 4. Representations
 
-- You are legally entitled to grant the above licenses.
-- Each of Your Contributions is Your original creation.
-- Your Contribution submissions include complete details of any third-party
-  license or other restriction (including, but not limited to, related patents
-  and trademarks) of which You are personally aware and which are associated
-  with any part of Your Contributions.
-- If Your employer(s) has rights to intellectual property that You create that
-  includes Your Contributions, You represent that You have received permission
-  to make Contributions on behalf of that employer, or that Your employer has
-  waived such rights for Your Contributions to the Project.
+You represent that you are legally entitled to grant the above license. If
+Your employer(s) has rights to intellectual property that You create that
+includes Your Contributions, You represent that You have received permission to
+make Contributions on behalf of that employer, that Your employer has waived
+such rights for Your Contributions to Maintainer, or that Your employer has
+executed a separate Corporate CLA with Maintainer.
+
+You represent that each of Your Contributions is Your original creation (see
+section 7 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license or
+other restriction (including, but not limited to, related patents and
+trademarks) of which You are personally aware and which are associated with any
+part of Your Contributions.
 
 ## 5. Support
 
 You are not expected to provide support for Your Contributions, except to the
 extent You desire to provide support. You may provide support for free, for a
-fee, or not at all.
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
 
-## 6. No Warranty
+## 6. Notifications
 
-Unless required by applicable law or agreed to in writing, You provide Your
-Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied, including, without limitation, any warranties
-or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE.
+Should You wish to submit work that is not Your original creation, You may
+submit it to Maintainer separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+## 7. Notice
+
+You agree to notify Maintainer of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any respect.
+
+---
+
+This Agreement is adapted from the
+[Apache Software Foundation Individual Contributor License Agreement v2.0](https://www.apache.org/licenses/icla.pdf).
 
 ## Signing
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+Kryton
+Copyright 2026 Pascal Watteel
+
+This product includes software developed by Pascal Watteel and contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -453,3 +453,19 @@ npm test             # Run all tests
 
 Apache License 2.0 — see [LICENSE](LICENSE) for details.
 
+
+## Trademark
+
+**"Kryton"** and the Kryton logo are trademarks of Pascal Watteel. The Apache
+2.0 license grants rights to use the software, but it does **not** grant
+permission to use these trademarks. You may not use the "Kryton" name or logo
+in a way that suggests endorsement of, or affiliation with, your fork or
+derivative product. Forks distributed publicly must be renamed.
+
+## Contributing
+
+Contributions are welcome. Before your first pull request, please read and
+sign the [Contributor License Agreement](CLA.md). The CLA Assistant bot will
+prompt you on your first PR — sign by commenting:
+
+> I have read the CLA Document and I hereby sign the CLA


### PR DESCRIPTION
Adds:
- `NOTICE` (Apache 2.0 attribution)
- `CLA.md` (Contributor License Agreement with explicit relicensing grant)
- `.github/workflows/cla.yml` (CLA Assistant — uses built-in GITHUB_TOKEN, no PAT needed)
- README: Trademark + Contributing sections

Signatures stored in a `cla-signatures` branch of this repo (created automatically on first signature).

**No manual setup required after merge.** Bot will be active on the next PR.