### PR TITLE
fix(operator): make scaffolded manifests deployable out of the box

### DIFF
--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -28,12 +28,13 @@ resources:
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 
-# Uncomment the patches line if you enable Metrics
-patches:
-# [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
-# More info: https://book.kubebuilder.io/reference/metrics
-- path: manager_metrics_patch.yaml
-  target:
-    kind: Deployment
+# [METRICS] Re-add this patch once cmd/manager/main.go supports the
+# --metrics-secure / --metrics-require-rbac / --metrics-bind-address=:8443
+# flags. The current scaffold patches crashed the manager because the
+# binary only wires the default --metrics-bind-address=:8080.
+# patches:
+# - path: manager_metrics_patch.yaml
+#   target:
+#     kind: Deployment
 
 

--- a/operator/config/default/manager_metrics_patch.yaml
+++ b/operator/config/default/manager_metrics_patch.yaml
@@ -1,12 +1,7 @@
-# This patch adds the args to allow exposing the metrics endpoint using HTTPS
-- op: add
-  path: /spec/template/spec/containers/0/args/0
-  value: --metrics-bind-address=:8443
-# This patch adds the args to allow securing the metrics endpoint
-- op: add
-  path: /spec/template/spec/containers/0/args/0
-  value: --metrics-secure
-# This patch adds the args to allow RBAC-based authn/authz the metrics endpoint
-- op: add
-  path: /spec/template/spec/containers/0/args/0
-  value: --metrics-require-rbac
+# The operator-sdk scaffolded patches assumed --metrics-secure /
+# --metrics-require-rbac / --metrics-bind-address=:8443 flags that
+# cmd/manager/main.go does not (yet) wire up. Until the manager binary
+# grows HTTPS + RBAC for its metrics endpoint, leave the default
+# :8080 plain-HTTP bind in place. Re-enable HTTPS by extending main.go
+# first and then restoring the flags here.
+[]

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -60,7 +60,10 @@ spec:
       containers:
       - args:
           - --leader-elect
-          - --leader-election-id=kryton-operator
+          # cmd/manager/main.go hard-codes LeaderElectionID to
+          # "kryton-operator.azrtydxb.io" and does not yet expose a
+          # --leader-election-id flag. Re-add the override once main.go
+          # grows the flag.
           - --health-probe-bind-address=:8081
         image: controller:latest
         name: manager

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -57,6 +57,14 @@ rules:
   - "apps"
   resources:
   - "deployments"
+  - "statefulsets"
+# The bitnami postgresql subchart renders a PodDisruptionBudget.
+- apiGroups:
+  - "policy"
+  resources:
+  - "poddisruptionbudgets"
+  verbs:
+  - "*"
 
 ##
 ## Rules for operator-only fields (backup, plugins, snapshot).
@@ -118,6 +126,21 @@ rules:
   resources:
   - roles
   - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+# The bitnami postgresql subchart renders a NetworkPolicy; without this
+# grant the helm upgrade fails with a forbidden error from the resource
+# diff step that the helm action client runs before applying.
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
   verbs:
   - get
   - list


### PR DESCRIPTION
## Summary
The operator-sdk scaffold shipped with three latent bugs that prevented `make install && make deploy` from producing a working controller. All three surfaced when I deployed the operator to the kw cluster to verify the v4.6.5-pre.5 MCP fixes from #147.

1. **manager metrics patch crash-looped the controller.** `config/default/manager_metrics_patch.yaml` injected `--metrics-secure`, `--metrics-require-rbac`, and `--metrics-bind-address=:8443` args, but `cmd/manager/main.go` only wires the default `--metrics-bind-address=:8080`. The manager crash-looped with `flag provided but not defined: -metrics-require-rbac`. Patch disabled (with a TODO) until `main.go` grows HTTPS + RBAC for `/metrics`.
2. **`--leader-election-id=kryton-operator` arg was rejected for the same reason.** `main.go` hard-codes `LeaderElectionID` (`kryton-operator.azrtydxb.io`) and does not expose a flag. Removed the arg; the hard-coded value still produces the correct Lease.
3. **RBAC missed three subchart resources.** The bitnami postgresql subchart that the kryton helm chart pulls in renders `NetworkPolicy`, `PodDisruptionBudget`, and `StatefulSet`. Without these grants the helm action client inside the reconciler fails its pre-apply diff with `forbidden`, and the helm release stays at the previous revision indefinitely. Added `networkpolicies` (networking.k8s.io), `poddisruptionbudgets` (policy), and `statefulsets` (apps) to the manager ClusterRole.

## Verification
- `make install` + `make deploy IMG=ghcr.io/azrtydxb/kryton/kryton-operator:4.6.5-pre.5` against the kw cluster
- Applied a `Kryton` CR named `kryton` in `watteel-kryton` with `spec.version: "4.6.5-pre.5"` and the live release's values
- Operator reconciled to `helm release upgraded` with chart `kryton-4.6.5-pre.5`
- Re-tested the four MCP bugs from #147 against the resulting pod — all four fixed

## Test plan
- [x] manager pod reaches `Ready` (no crash loop)
- [x] CR reconciles without RBAC errors
- [x] Operator-managed helm release rolls a new server image
- [ ] CI green