### PR TITLE
feat: mobile-app prerequisites (Phase 0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,29 @@ GOOGLE_CLIENT_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
+# Mobile app integration (optional — leave unset on servers without mobile clients)
+# iOS Universal Links + WebAuthn passkey origin
+MOBILE_IOS_TEAM_ID=
+MOBILE_IOS_BUNDLE_ID=com.kryton.mobile
+# Android App Links (Digital Asset Links)
+MOBILE_ANDROID_PACKAGE=com.kryton.mobile
+# SHA-256 certificate fingerprints for assetlinks.json (colon-separated, e.g. AA:BB:CC:...)
+# This is the hash of the signing CERTIFICATE — NOT the same as MOBILE_ANDROID_APK_KEY_HASH.
+MOBILE_ANDROID_SHA256_FINGERPRINTS=
+# Base64url SHA-256 of the Android app's signing PUBLIC KEY (for WebAuthn passkey origin).
+# Derive with: keytool -exportcert -alias <alias> -keystore <ks> | openssl dgst -sha256 -binary | openssl base64 | tr '+/' '-_' | tr -d '='
+# Different from MOBILE_ANDROID_SHA256_FINGERPRINTS — do not mix them up.
+MOBILE_ANDROID_APK_KEY_HASH=
+
+# Push notifications (optional — both APNS_* and FCM_* must be fully set to enable dispatch)
+APNS_KEY_ID=
+APNS_TEAM_ID=
+APNS_BUNDLE_ID=com.kryton.mobile
+APNS_KEY_PATH=
+APNS_PRODUCTION=false
+FCM_SERVICE_ACCOUNT_PATH=
+FCM_PROJECT_ID=
+
 # SMTP (optional)
 SMTP_HOST=
 SMTP_PORT=587

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -742,6 +742,35 @@ jobs:
           files: |
             release-assets/kryton-crds.yaml
 
+  publish-sdk:
+    # Publish @azrtydxb/sdk to public npm after the GitHub Release is live.
+    # Runs on the same arc-azrtydxb runner as `release`; gates on `release`
+    # so the package version on npm aligns with the GitHub Release tag.
+    # NPM_TOKEN must be set as a repo secret (Settings → Secrets and variables
+    # → Actions → NPM_TOKEN) — a granular token scoped to @azrtydxb/sdk with
+    # publish permission from https://www.npmjs.com/settings/<user>/tokens.
+    needs: [release]
+    runs-on: arc-azrtydxb
+    container:
+      image: node:24
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build --workspace=packages/sdk
+      - name: Publish SDK to npm
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: node scripts/release-sdk.js
+      - if: always()
+        run: chown -R 1001:1001 . || true
+
   # ===========================================================================
   # Phase 4 — NAS package source wiring.
   #

--- a/package-lock.json
+++ b/package-lock.json
@@ -2634,6 +2634,110 @@
         "ws": "^8.16.0"
       }
     },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -2672,11 +2776,179 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@google-cloud/firestore": {
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
@@ -2690,7 +2962,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -2709,7 +2981,7 @@
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -3339,7 +3611,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3626,6 +3898,19 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5862,6 +6147,16 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -5879,6 +6174,13 @@
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -5968,6 +6270,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -6049,6 +6361,60 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/request/node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@types/request/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@types/request/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@types/ssh2": {
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
@@ -6085,6 +6451,13 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -6548,7 +6921,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -6603,7 +6976,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -6897,6 +7269,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -6980,11 +7362,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -7329,6 +7731,15 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bl": {
@@ -7757,7 +8168,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -7772,7 +8183,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7782,7 +8193,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7798,7 +8209,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7808,7 +8219,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7823,7 +8234,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7836,7 +8247,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7911,7 +8322,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -8433,6 +8844,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -8554,7 +8974,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -9114,7 +9534,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9183,7 +9603,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9461,7 +9881,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9616,6 +10036,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
@@ -9764,6 +10193,23 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
@@ -9855,6 +10301,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -9871,6 +10329,29 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fflate": {
@@ -9958,6 +10439,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/firebase-admin": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
+        "farmhash-modern": "^1.1.0",
+        "fast-deep-equal": "^3.1.1",
+        "google-auth-library": "^10.6.1",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^7.11.0",
+        "@google-cloud/storage": "^7.19.0"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -10040,6 +10544,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -10131,6 +10647,91 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gensync": {
@@ -10327,6 +10928,146 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -10345,6 +11086,20 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/guid-typescript": {
       "version": "1.0.9",
@@ -10378,7 +11133,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -10677,6 +11432,23 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10724,6 +11496,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -10742,7 +11520,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -11074,7 +11851,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11307,6 +12084,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -11430,6 +12216,31 @@
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/jws": {
@@ -11859,6 +12670,11 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -11935,7 +12751,13 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -12028,7 +12850,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
@@ -12065,6 +12887,34 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/lucide-react": {
       "version": "0.577.0",
@@ -13593,6 +14443,72 @@
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
@@ -13642,6 +14558,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -13916,7 +14842,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -14066,6 +14992,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -14611,11 +15553,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
       "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -15519,6 +16474,21 @@
         "node": ">= 4"
       }
     },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -16202,6 +17172,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
@@ -16414,6 +17394,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -16556,6 +17543,80 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/teex": {
@@ -17978,6 +19039,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -17986,6 +19056,29 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -18251,6 +19344,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -18291,7 +19400,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -18330,7 +19439,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -18349,7 +19458,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -18359,7 +19468,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18369,7 +19478,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18379,7 +19488,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -18394,7 +19503,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18424,7 +19533,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -18691,6 +19800,7 @@
         "fastify": "^5.2.0",
         "fastify-plugin": "^5.0.1",
         "fastify-type-provider-zod": "^6.1.0",
+        "firebase-admin": "^13.10.0",
         "lib0": "^0.2.99",
         "multer": "^2.1.1",
         "nodemailer": "^8.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kryton",
-  "version": "4.6.5-pre.10",
+  "version": "4.6.5-pre.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kryton",
-      "version": "4.6.5-pre.10",
+      "version": "4.6.5-pre.14",
       "workspaces": [
         "packages/*",
         "packages/kryton-mcp",
@@ -3716,6 +3716,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@parse/node-apn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-7.1.0.tgz",
+      "integrity": "sha512-a40P5nScLDi9Pf7koKKkbwI73px0q+iLaKYNrr7kyKJebq/4duGOy3mMevZS0zltn171k3jB5BWCC27dPGsMmw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.4.3",
+        "jsonwebtoken": "9.0.3",
+        "node-forge": "1.3.2",
+        "verror": "1.10.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@peculiar/asn1-android": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
@@ -6913,6 +6928,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -7459,6 +7483,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -8900,6 +8930,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9566,6 +9605,15 @@
       "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
       "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "engines": [
+        "node >=0.6.0"
+      ],
       "license": "MIT"
     },
     "node_modules/fast-check": {
@@ -11351,6 +11399,49 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11845,6 +11936,48 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.startcase": {
@@ -13459,6 +13592,15 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT"
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.38",
@@ -17583,6 +17725,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -18435,7 +18597,7 @@
     },
     "packages/kryton-init": {
       "name": "@azrtydxb/kryton-init",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.8.6",
@@ -18492,17 +18654,19 @@
     "packages/sdk": {
       "name": "@azrtydxb/sdk",
       "version": "4.6.5-pre.10",
+      "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "^0.13.0"
       },
       "devDependencies": {
         "openapi-typescript": "^7.5.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
       }
     },
     "packages/server": {
       "name": "@azrtydxb/server",
-      "version": "4.6.5-pre.10",
+      "version": "4.6.5-pre.14",
       "dependencies": {
         "@better-auth/passkey": "^1.5.6",
         "@cedar-policy/cedar-wasm": "^4.10.0",
@@ -18516,6 +18680,7 @@
         "@fastify/websocket": "^11.0.1",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@opentelemetry/api": "^1.9.0",
+        "@parse/node-apn": "^7.1.0",
         "@xenova/transformers": "^2.17.2",
         "better-auth": "^1.5.6",
         "chokidar": "^4.0.3",

--- a/packages/client/docs/url-routing-design.md
+++ b/packages/client/docs/url-routing-design.md
@@ -1,0 +1,188 @@
+# URL Routing Design — Mobile WebView Targets
+
+**Status:** Design (pre-implementation)  
+**Implements:** Phase 0e.1 of the Kryton mobile plan  
+**Next:** Task 0e.2 implements the routes described here
+
+---
+
+## 1. Current State of the SPA
+
+### State store
+
+All view-navigation state lives in a single Zustand store:
+`src/stores/uiStore.ts` — `useUIStore`.
+
+The top-level display mode is `view: MainView` where:
+
+```ts
+type MainView = 'note' | 'all' | 'graph' | 'tags';
+```
+
+Initial value is `'note'`. The setter is `setView(v: MainView)`.
+
+### Existing URL machinery
+
+The project **already has partial URL routing** via two custom modules:
+
+- `src/lib/urlSchema.ts` — defines `NavState`, `parseUrl`, `serializeNav`, `navEquals`
+- `src/hooks/useUrlSync.ts` — bidirectional sync hook, mounted once in `AppContent`
+
+**Current URL grammar** (from `urlSchema.ts`):
+
+| URL | State |
+|---|---|
+| `/` | default / empty view |
+| `/n/<encoded-path>?tabs=...` | note open, multi-tab |
+| `/view/all` | all-notes view |
+| `/view/graph` | graph view |
+| `/view/tags?tag=<name>` | tags view |
+| `/shared/<ownerUserId>/<path>` | shared note |
+
+`useUrlSync` is mounted in `AppContent` (App.tsx line 335). On mount it parses `window.location` and dispatches to `uiStore`; it subscribes to the store and calls `history.pushState` / `replaceState` on change; it listens for `popstate` to handle browser back/forward. The infinite-loop guard is `navEquals(prev, next)` — if the new URL equals the current one, no push is issued.
+
+No third-party router library is installed. The `package.json` `dependencies` contain no `react-router`, `wouter`, or `@tanstack/router`.
+
+### Entering graph view
+
+Three entry points all call `setView('graph')`:
+
+1. **Keyboard shortcut** — `Ctrl/Cmd+G` in `src/hooks/useKeyboardShortcuts.ts` (calls `shortcutActions.toggleGraph`, which calls `setView(view === 'graph' ? 'note' : 'graph')`)
+2. **Header "Graph" button** — in `App.tsx`, `<Header … onGraphView={() => setView('graph')} />`
+3. **Quick-switcher command** — "Graph view" command in `QuickSwitcher` dispatches `onGraphView` → `setView('graph')`
+
+When `view === 'graph'`, `App.tsx` renders `<GraphPanel fullscreen … />` and hides the right rail.
+
+### Entering canvas/edit view
+
+A note is opened via `state.notes.openNote(path)` (from `useAppState`). When `view === 'note'` and `notes.activeNote` is set, the main pane renders either:
+
+- `<PreviewModeView>` when `editing === false`
+- `<EditModeView>` when `editing === true`
+
+Edit mode is entered via `enterEditMode()` from `useAppCallbacks`, which calls `uiStore.enterEditMode(content)` (sets `editing: true`). Clicking the Edit button in `PreviewModeView` or pressing `Ctrl/Cmd+E` both reach this path.
+
+To enter a note's edit view from a URL: call `setView('note')`, `openNote(path)`, then optionally `enterEditMode()`. The `/canvas/:id` route maps to opening a note and entering edit mode.
+
+### Reaching the plugins tab
+
+The plugins tab lives inside `AdminPage` (`src/pages/AdminPage.tsx`), which is a full-screen modal. The modal is gated by `uiStore.showAdmin: boolean`.
+
+To reach the plugins tab from a URL:
+1. `uiStore.setShowAdmin(true)` — opens the admin modal
+2. `AdminPage` has local `useState<Tab>('users')` — initial tab is `'users'`
+3. **There is no external handle to pre-select the plugins tab.** `AdminPage` only accepts an `onClose` prop.
+
+This means `/plugin/:name` cannot route directly into the plugins tab without modifying `AdminPage` to accept an `initialTab` prop. Task 0e.2 must add `initialTab?: Tab` to `AdminPage` and pipe it through `ModalsContainer` + `useUIStore`.
+
+---
+
+## 2. Proposed Router Choice
+
+**No third-party router.** The existing `useUrlSync` + `urlSchema` machinery already handles the bidirectional URL ↔ state sync without React Router. Adding a router would require wrapping the entire app in `<BrowserRouter>` and teaching it to coexist with the manual `history` calls — unnecessary churn.
+
+The mobile WebView targets are added as **new URL patterns** parsed by `urlSchema.parseUrl` and applied by `useUrlSync`'s `applyImpl`. This is the same pattern used by `/view/graph` and `/n/<path>` today.
+
+**Required `urlSchema` extension:** Add two new `NavState` variants:
+
+```ts
+| { kind: 'canvas'; id: string }
+| { kind: 'plugin'; name: string; notePath: string | null }
+```
+
+---
+
+## 3. Route → View-State Mapping
+
+| URL | NavState kind | State setters fired | Notes |
+|---|---|---|---|
+| `/canvas/<encoded-id>` | `canvas` | `setView('note')`, `openNote(decodedId)`, `enterEditMode()` | `id` is an encoded note path, same encoding as `/n/`. Opens the note in edit/canvas mode. |
+| `/view/graph` | `view` (existing) | `setView('graph')` | Already exists. No change needed. |
+| `/plugin/<name>?note=<notePath>` | `plugin` | `setView('note')`, `setShowAdmin(true)`, `openNote(notePath)` if present | Opens admin modal. Requires `AdminPage` to accept `initialTab='plugins'` and pre-select the named plugin. |
+
+### State setter call sequence
+
+**`/canvas/<id>`**
+```
+setView('note')                   // show note pane
+openNote(decodeNotePath(id))      // fetch + activate the note
+enterEditMode()                   // flip editing:true once content loads
+```
+`enterEditMode` must fire after the note content is available (inside `openNote`'s resolved callback). The canvas route component uses a `useEffect` that watches `notes.activeNote` and calls `enterEditMode` when it becomes non-null.
+
+**`/plugin/<name>?note=<notePath>`**
+```
+setView('note')                   // ensure note pane is backing state
+setShowAdmin(true)                // open admin modal
+// (AdminPage receives initialTab='plugins')
+if (notePath) openNote(notePath)  // optional background focus
+// plugin name passed as prop so the PluginsTab can pre-scroll / highlight
+```
+
+---
+
+## 4. URL ↔ State Bridge Approach
+
+### Mount → state (inbound)
+
+`useUrlSync` already calls `applyImpl(parseUrl(...))` on mount and on `popstate`. Extend `applyImpl`'s `switch` with two new cases:
+
+```ts
+case 'canvas': {
+  ui.setView('note');
+  void cb.openNote(nav.id);
+  // enterEditMode is deferred — fired by a useEffect watching activeNote
+  cb.onCanvasRoute?.();   // signals App to flip into edit mode after load
+  return;
+}
+case 'plugin': {
+  ui.setView('note');
+  ui.setShowAdmin(true);
+  ui.setPendingPluginTab(nav.name);  // new uiStore field
+  if (nav.notePath) void cb.openNote(nav.notePath);
+  return;
+}
+```
+
+### State → URL (outbound)
+
+`useUrlSync`'s `writeUrl` computes a `NavSnapshot` from the store and calls `serializeNav`. Extend `navStateFromSnapshot` to emit canvas/plugin URLs when the store has the corresponding pending signals (e.g. `editing === true` and `view === 'note'` maps to the current `/n/` URL, not `/canvas/`).
+
+Canvas and plugin URLs are **write-once entry points** — the mobile host constructs them; the SPA does not need to write them back. The `/n/<path>` URL already takes over once the note is open. This avoids any need to emit `/canvas/` from the outbound path.
+
+### Infinite-loop guard
+
+Unchanged: `navEquals(parseUrl(location), nextNav)` before any `pushState`. Since canvas/plugin URLs are only consumed on inbound navigation (the SPA writes `/n/<path>` for the ongoing session), there is no outbound push to guard against.
+
+---
+
+## 5. Backwards Compatibility
+
+- `/` continues to render `{ kind: 'default' }` → empty view with no active note. No change.
+- `/view/graph`, `/view/all`, `/view/tags`, `/n/<path>`, `/shared/<…>` — all existing patterns are unchanged.
+- Non-matching URLs already fall through to `{ kind: 'default' }` in `parseUrl`. New patterns are additive, so existing in-app navigation is unaffected.
+- The `AdminPage` `initialTab` prop is optional with a default of `'users'`, so all existing callers (`ModalsContainer`) that pass no `initialTab` continue to open on the users tab.
+
+---
+
+## 6. Testing Approach
+
+Route behaviour is validated with **memory-router-equivalent component tests** using `@testing-library/react` and `vitest`:
+
+- Mock `window.location` / `window.history` (jsdom supports both)
+- Mount `App` with a custom URL via `Object.defineProperty(window, 'location', ...)`
+- Assert that the correct component is rendered (e.g. `GraphPanel` for `/view/graph`, `EditModeView` for `/canvas/Boards%2FRoadmap.canvas`)
+- Assert that `uiStore.view` equals the expected `MainView` after mount
+- For plugin routes, assert `uiStore.showAdmin === true` and that the admin modal renders with the plugins tab active
+
+Unit tests for `parseUrl` / `serializeNav` in `urlSchema.ts` cover the new `canvas` and `plugin` grammar independently of React.
+
+---
+
+## Open Questions for Task 0e.2
+
+1. **`enterEditMode` deferral** — the canvas route needs a signal to fire `enterEditMode` after `openNote` resolves. Cleanest path: add an `onCanvasRoute` callback to `UrlSyncCallbacks`, implemented in `App.tsx` as a `useEffect` watching `notes.activeNote` + a `pendingCanvasRoute` flag.
+
+2. **Plugin name pre-selection** — `PluginsTab` currently has no way to highlight a named plugin. Task 0e.2 decides whether to add a `focusPlugin?: string` prop or a `uiStore.pendingPluginName` field.
+
+3. **`AdminPage` initialTab prop** — `uiStore.showAdmin` opens the modal; `AdminPage`'s `tab` is local state. The cleanest bridge is a new `initialTab?: Tab` prop on `AdminPage` (prop-drilled through `ModalsContainer`). Alternatively, a `uiStore.adminInitialTab` field avoids prop-drilling but adds store surface area.

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useCallback, useState } from 'react';
+import { useMemo, useEffect, useCallback, useState, useRef } from 'react';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { AuthProvider } from './hooks/useAuth';
 import { PluginSlotRegistry, PluginProvider, usePluginSlots, setEditorOption } from '@azrtydxb/ui';
@@ -332,11 +332,26 @@ function AppContent() {
     return walk(notesTree);
   }, [notesTree]);
 
+  // `pendingCanvasEdit` is set by `onCanvasRoute` (below) to the canvas note
+  // id when a `/canvas/:id` URL is applied. Once the matching note finishes
+  // loading its content we enter edit mode and clear the pending flag.
+  const pendingCanvasEdit = useRef<string | null>(null);
+
+  const onCanvasRoute = useCallback(() => {
+    // The URL parser has already called openNote(id); record the path of
+    // the note being opened so the effect below can enter edit mode once
+    // content arrives. We read the target from the URL because activeNote
+    // is still the previous note at the time this callback fires.
+    const match = window.location.pathname.match(/^\/canvas\/(.+)$/);
+    pendingCanvasEdit.current = match ? decodeURIComponent(match[1]) : null;
+  }, []);
+
   useUrlSync(state.notes.activeNote?.tabId ?? state.notes.activeNote?.path ?? null, {
     openNote: state.notes.openNote,
     openSharedNote: state.notes.openSharedNote,
     closeActiveNote: state.notes.closeActiveNote,
     noteExists,
+    onCanvasRoute,
   });
 
   const {
@@ -360,6 +375,22 @@ function AppContent() {
     handleRightPanelResize,
     handleShare,
   } = callbacks;
+
+  // Once the pending canvas note finishes loading, enter edit mode.
+  // `pendingCanvasEdit` is set by `onCanvasRoute` above when a `/canvas/:id`
+  // URL is applied. `enterEditMode` needs activeNote.content to be non-null,
+  // so we gate on the note being loaded before calling it.
+  useEffect(() => {
+    if (!pendingCanvasEdit.current) return;
+    const { activeNote } = state.notes;
+    if (!activeNote) return;
+    if (activeNote.path !== pendingCanvasEdit.current) return;
+    pendingCanvasEdit.current = null;
+    enterEditMode();
+  // enterEditMode is a useCallback with stable identity; activeNote is the
+  // meaningful dep here.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.notes.activeNote]);
 
   useEffect(() => {
     if (!user) return;

--- a/packages/client/src/__tests__/canvasRouteWiring.test.tsx
+++ b/packages/client/src/__tests__/canvasRouteWiring.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Unit test for the onCanvasRoute → enterEditMode wiring introduced in
+ * App.tsx (Work item 1 of the Phase 0e loose-end).
+ *
+ * We exercise the pattern with a minimal test hook that mirrors the logic
+ * in AppContent:
+ *   - useUrlSync fires onCanvasRoute when a /canvas/:id URL is applied
+ *   - a pendingCanvasEdit ref records the canvas id
+ *   - a useEffect watching activeNote calls enterEditMode once the note loads
+ *
+ * This avoids rendering the full App (which has heavy provider deps) while
+ * still covering the exact branching logic.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEffect, useRef, useCallback } from 'react';
+import { useUrlSync } from '../hooks/useUrlSync';
+import { useUIStore } from '../stores/uiStore';
+import { useToastStore } from '../stores/toastStore';
+import type { NoteData } from '../lib/api';
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function setUrl(url: string) {
+  window.history.replaceState(null, '', url);
+}
+
+function resetStores() {
+  useUIStore.setState({ view: 'note', openTabs: [] });
+  useToastStore.setState({ toasts: [] });
+}
+
+/** Minimal replica of the AppContent wiring under test. */
+function useCanvasRouteWiring({
+  activeNote,
+  openNote,
+  enterEditMode,
+}: {
+  activeNote: NoteData | null;
+  openNote: (path: string) => void;
+  enterEditMode: () => void;
+}) {
+  const pendingCanvasEdit = useRef<string | null>(null);
+
+  const onCanvasRoute = useCallback(() => {
+    const match = window.location.pathname.match(/^\/canvas\/(.+)$/);
+    pendingCanvasEdit.current = match ? decodeURIComponent(match[1]) : null;
+  }, []);
+
+  useUrlSync(activeNote?.path ?? null, {
+    openNote,
+    openSharedNote: vi.fn(),
+    closeActiveNote: vi.fn(),
+    noteExists: () => true,
+    onCanvasRoute,
+  });
+
+  useEffect(() => {
+    if (!pendingCanvasEdit.current) return;
+    if (!activeNote) return;
+    if (activeNote.path !== pendingCanvasEdit.current) return;
+    pendingCanvasEdit.current = null;
+    enterEditMode();
+  }, [activeNote, enterEditMode]);
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('onCanvasRoute → enterEditMode wiring', () => {
+  beforeEach(() => {
+    resetStores();
+    setUrl('/');
+  });
+
+  it('navigating to /canvas/X.canvas calls openNote with X.canvas', () => {
+    setUrl('/canvas/X.canvas');
+    const openNote = vi.fn();
+    const enterEditMode = vi.fn();
+
+    renderHook(() =>
+      useCanvasRouteWiring({ activeNote: null, openNote, enterEditMode }),
+    );
+
+    expect(openNote).toHaveBeenCalledWith('X.canvas');
+  });
+
+  it('enterEditMode is NOT called before the note loads', () => {
+    setUrl('/canvas/X.canvas');
+    const openNote = vi.fn();
+    const enterEditMode = vi.fn();
+
+    renderHook(() =>
+      useCanvasRouteWiring({ activeNote: null, openNote, enterEditMode }),
+    );
+
+    // activeNote is still null — enterEditMode must not fire yet
+    expect(enterEditMode).not.toHaveBeenCalled();
+  });
+
+  it('enterEditMode is called once activeNote.path matches and content is loaded', () => {
+    setUrl('/canvas/X.canvas');
+    const openNote = vi.fn();
+    const enterEditMode = vi.fn();
+
+    const loadedNote: NoteData = {
+      path: 'X.canvas',
+      title: 'X',
+      content: '# Canvas content',
+      modifiedAt: new Date().toISOString(),
+    };
+
+    const { rerender } = renderHook(
+      ({ activeNote }: { activeNote: NoteData | null }) =>
+        useCanvasRouteWiring({ activeNote, openNote, enterEditMode }),
+      { initialProps: { activeNote: null as NoteData | null } },
+    );
+
+    expect(enterEditMode).not.toHaveBeenCalled();
+
+    act(() => {
+      rerender({ activeNote: loadedNote });
+    });
+
+    expect(enterEditMode).toHaveBeenCalledOnce();
+  });
+
+  it('enterEditMode is NOT called when a different note is active', () => {
+    setUrl('/canvas/X.canvas');
+    const openNote = vi.fn();
+    const enterEditMode = vi.fn();
+
+    const wrongNote: NoteData = {
+      path: 'Other.canvas',
+      title: 'Other',
+      content: '# Other',
+      modifiedAt: new Date().toISOString(),
+    };
+
+    const { rerender } = renderHook(
+      ({ activeNote }: { activeNote: NoteData | null }) =>
+        useCanvasRouteWiring({ activeNote, openNote, enterEditMode }),
+      { initialProps: { activeNote: null as NoteData | null } },
+    );
+
+    act(() => {
+      rerender({ activeNote: wrongNote });
+    });
+
+    expect(enterEditMode).not.toHaveBeenCalled();
+  });
+
+  it('enterEditMode is called only once even if activeNote re-renders', () => {
+    setUrl('/canvas/X.canvas');
+    const openNote = vi.fn();
+    const enterEditMode = vi.fn();
+
+    const loadedNote: NoteData = {
+      path: 'X.canvas',
+      title: 'X',
+      content: '# Canvas content',
+      modifiedAt: new Date().toISOString(),
+    };
+
+    const { rerender } = renderHook(
+      ({ activeNote }: { activeNote: NoteData | null }) =>
+        useCanvasRouteWiring({ activeNote, openNote, enterEditMode }),
+      { initialProps: { activeNote: null as NoteData | null } },
+    );
+
+    act(() => {
+      rerender({ activeNote: loadedNote });
+    });
+    act(() => {
+      // Simulate a re-render with the same note (e.g. content update)
+      rerender({ activeNote: { ...loadedNote, content: '# Updated' } });
+    });
+
+    expect(enterEditMode).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire enterEditMode when there is no canvas navigation', () => {
+    setUrl('/n/Regular.md');
+    const openNote = vi.fn();
+    const enterEditMode = vi.fn();
+
+    const note: NoteData = {
+      path: 'Regular.md',
+      title: 'Regular',
+      content: '# Regular note',
+      modifiedAt: new Date().toISOString(),
+    };
+
+    const { rerender } = renderHook(
+      ({ activeNote }: { activeNote: NoteData | null }) =>
+        useCanvasRouteWiring({ activeNote, openNote, enterEditMode }),
+      { initialProps: { activeNote: null as NoteData | null } },
+    );
+
+    act(() => {
+      rerender({ activeNote: note });
+    });
+
+    expect(enterEditMode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/components/Graph/GraphPanel.tsx
+++ b/packages/client/src/components/Graph/GraphPanel.tsx
@@ -4,6 +4,8 @@ import { GraphView } from '@azrtydxb/ui';
 import type { HoveredNodeInfo } from '@azrtydxb/ui';
 import { GraphData } from '../../lib/api';
 import { Icons } from '../Icons';
+import { useMobileEmbed } from '../../hooks/useMobileEmbed';
+import '../../styles/mobile-embed.css';
 
 interface GraphPanelProps {
   graphData: GraphData | null;
@@ -98,6 +100,7 @@ export function GraphPanel({
   onModeChange,
   fullscreen = false,
 }: GraphPanelProps) {
+  const isMobile = useMobileEmbed();
   // Default to global so the rail always shows the whole graph at a glance.
   // Local is the focus mode the user opts into to see "what's connected to
   // this note"; global is the right idle state.
@@ -354,10 +357,10 @@ export function GraphPanel({
 
   return (
     <>
-      <div style={containerStyle}>
+      <div style={containerStyle} className={isMobile ? "mobile-embed" : ""}>
         {renderHeader(fullscreen ? null : () => setExpanded(true))}
         {!expanded && (
-          <div ref={canvasWrapRef} className="bg-grid" style={{ flex: 1, display: 'flex', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
+          <div ref={canvasWrapRef} className={`bg-grid canvas-surface`} style={{ flex: 1, display: 'flex', position: 'relative', overflow: 'hidden', minHeight: 0 }}>
             <GraphView
               graphData={graphData}
               loading={loading}
@@ -457,7 +460,7 @@ export function GraphPanel({
                   </button>
                 </div>
               </div>
-              <div ref={expandedCanvasWrapRef} className="bg-grid" style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0 }}>
+              <div ref={expandedCanvasWrapRef} className="bg-grid canvas-surface" style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0 }}>
                 <GraphView
                   graphData={graphData}
                   loading={loading}

--- a/packages/client/src/components/Views/EditModeView.tsx
+++ b/packages/client/src/components/Views/EditModeView.tsx
@@ -15,6 +15,8 @@ import { useYjsDocument } from '../../hooks/useYjsDocument';
 import { useToastStore } from '../../stores/toastStore';
 import { useAuth } from '../../hooks/useAuth';
 import { presenceColor } from '../../lib/presenceColor';
+import { useMobileEmbed } from '../../hooks/useMobileEmbed';
+import '../../styles/mobile-embed.css';
 
 type SaveStatus = 'unchanged' | 'unsaved' | 'saving' | 'saved' | 'error';
 
@@ -62,6 +64,7 @@ export function EditModeView({
   onContentChange, onCursorStateChange,
   onLinkClick, onCreateNote, onNoteSelect, onTabClose,
 }: EditModeViewProps) {
+  const isMobile = useMobileEmbed();
   const hasChanges = editContent !== originalContent;
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('unchanged');
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -240,7 +243,7 @@ export function EditModeView({
   );
 
   return (
-    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, background: 'var(--bg)' }}>
+    <div className={isMobile ? "mobile-embed" : ""} style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, background: 'var(--bg)' }}>
       {/* Tab strip + actions row (single 38px row, shared bottom border) */}
       <div style={{ display: 'flex', alignItems: 'stretch', background: 'var(--bg)', borderBottom: '1px solid var(--line)' }}>
         <div style={{ flex: 1, minWidth: 0, display: 'flex' }}>
@@ -296,7 +299,7 @@ export function EditModeView({
             flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0,
             borderRight: showPreview ? '1px solid var(--line)' : 'none',
           }}>
-            <div style={{ flex: 1, overflow: 'hidden' }}>
+            <div className="canvas-surface" style={{ flex: 1, overflow: 'hidden' }}>
               <Editor
                 key={activeNote.path}
                 ref={editorRef}

--- a/packages/client/src/hooks/__tests__/useMobileEmbed.test.ts
+++ b/packages/client/src/hooks/__tests__/useMobileEmbed.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMobileEmbed } from '../useMobileEmbed';
+
+function setUrl(url: string) {
+  window.history.replaceState(null, '', url);
+}
+
+describe('useMobileEmbed', () => {
+  beforeEach(() => {
+    setUrl('/');
+  });
+
+  it('returns false when there is no ?mobile query parameter', () => {
+    setUrl('/some/path');
+    const { result } = renderHook(() => useMobileEmbed());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when ?mobile=1', () => {
+    setUrl('/?mobile=1');
+    const { result } = renderHook(() => useMobileEmbed());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when ?mobile=true', () => {
+    setUrl('/canvas?mobile=true');
+    const { result } = renderHook(() => useMobileEmbed());
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/client/src/hooks/__tests__/useMobileEmbed.test.ts
+++ b/packages/client/src/hooks/__tests__/useMobileEmbed.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { useMobileEmbed } from '../useMobileEmbed';
 
 function setUrl(url: string) {
   window.history.replaceState(null, '', url);
@@ -8,24 +7,41 @@ function setUrl(url: string) {
 
 describe('useMobileEmbed', () => {
   beforeEach(() => {
+    // The hook caches its first detection in module scope (so a later URL-sync
+    // that drops ?mobile= can't flip it back to false). Reset the module
+    // registry between tests so each test gets a fresh, un-cached hook.
+    vi.resetModules();
     setUrl('/');
   });
 
-  it('returns false when there is no ?mobile query parameter', () => {
+  it('returns false when there is no ?mobile query parameter', async () => {
     setUrl('/some/path');
+    const { useMobileEmbed } = await import('../useMobileEmbed');
     const { result } = renderHook(() => useMobileEmbed());
     expect(result.current).toBe(false);
   });
 
-  it('returns true when ?mobile=1', () => {
+  it('returns true when ?mobile=1', async () => {
     setUrl('/?mobile=1');
+    const { useMobileEmbed } = await import('../useMobileEmbed');
     const { result } = renderHook(() => useMobileEmbed());
     expect(result.current).toBe(true);
   });
 
-  it('returns true when ?mobile=true', () => {
+  it('returns true when ?mobile=true', async () => {
     setUrl('/canvas?mobile=true');
+    const { useMobileEmbed } = await import('../useMobileEmbed');
     const { result } = renderHook(() => useMobileEmbed());
+    expect(result.current).toBe(true);
+  });
+
+  it('keeps returning true after the ?mobile param is later dropped from the URL', async () => {
+    setUrl('/?mobile=1');
+    const { useMobileEmbed } = await import('../useMobileEmbed');
+    const { result, rerender } = renderHook(() => useMobileEmbed());
+    expect(result.current).toBe(true);
+    setUrl('/some/path'); // URL sync dropped the param
+    rerender();
     expect(result.current).toBe(true);
   });
 });

--- a/packages/client/src/hooks/__tests__/useUrlSync.test.ts
+++ b/packages/client/src/hooks/__tests__/useUrlSync.test.ts
@@ -176,3 +176,70 @@ describe('useUrlSync — popstate', () => {
     expect(useUIStore.getState().view).toBe('graph');
   });
 });
+
+describe('useUrlSync — canvas routes', () => {
+  beforeEach(() => {
+    resetStores();
+    setUrl('/');
+  });
+
+  it('parses /canvas/<id> → sets view=note and calls openNote', () => {
+    setUrl('/canvas/Welcome.canvas');
+    const cb = makeCallbacks();
+    renderHook(() => useUrlSync(null, cb));
+    expect(useUIStore.getState().view).toBe('note');
+    expect(cb.openNote).toHaveBeenCalledWith('Welcome.canvas');
+  });
+
+  it('parses /canvas/<nested-path> → calls openNote with decoded id', () => {
+    setUrl('/canvas/Boards/Roadmap.canvas');
+    const cb = makeCallbacks();
+    renderHook(() => useUrlSync(null, cb));
+    expect(cb.openNote).toHaveBeenCalledWith('Boards/Roadmap.canvas');
+  });
+
+  it('calls onCanvasRoute when provided', () => {
+    setUrl('/canvas/Welcome.canvas');
+    const onCanvasRoute = vi.fn();
+    const cb = makeCallbacks({ onCanvasRoute });
+    renderHook(() => useUrlSync(null, cb));
+    expect(onCanvasRoute).toHaveBeenCalled();
+  });
+
+  it('does not crash when onCanvasRoute is not provided', () => {
+    setUrl('/canvas/Welcome.canvas');
+    const cb = makeCallbacks(); // no onCanvasRoute
+    expect(() => renderHook(() => useUrlSync(null, cb))).not.toThrow();
+  });
+});
+
+describe('useUrlSync — plugin routes', () => {
+  beforeEach(() => {
+    resetStores();
+    setUrl('/');
+  });
+
+  it('parses /plugin/<name> → sets showAdmin=true and adminInitialTab=plugins', () => {
+    setUrl('/plugin/kanban');
+    renderHook(() => useUrlSync(null, makeCallbacks()));
+    expect(useUIStore.getState().showAdmin).toBe(true);
+    expect(useUIStore.getState().adminInitialTab).toBe('plugins');
+    expect(useUIStore.getState().view).toBe('note');
+  });
+
+  it('parses /plugin/<name>?note=<path> → also calls openNote', () => {
+    setUrl('/plugin/kanban?note=Library%2FCards.md');
+    const cb = makeCallbacks();
+    renderHook(() => useUrlSync(null, cb));
+    expect(useUIStore.getState().showAdmin).toBe(true);
+    expect(useUIStore.getState().adminInitialTab).toBe('plugins');
+    expect(cb.openNote).toHaveBeenCalledWith('Library/Cards.md');
+  });
+
+  it('parses /plugin/<name> without note → does not call openNote', () => {
+    setUrl('/plugin/kanban');
+    const cb = makeCallbacks();
+    renderHook(() => useUrlSync(null, cb));
+    expect(cb.openNote).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/hooks/useMobileEmbed.ts
+++ b/packages/client/src/hooks/useMobileEmbed.ts
@@ -1,8 +1,15 @@
 import { useSyncExternalStore } from "react";
 
+// Cache the first detection for the whole session. The app's URL sync rewrites
+// the URL via history.pushState and may drop the `?mobile=` param, so re-reading
+// later would incorrectly return false. Once embedded, always embedded.
+let cached: boolean | null = null;
+
 function read(): boolean {
+  if (cached !== null) return cached;
   const v = new URLSearchParams(window.location.search).get("mobile");
-  return v === "1" || v === "true";
+  cached = v === "1" || v === "true";
+  return cached;
 }
 
 function subscribe(cb: () => void) {

--- a/packages/client/src/hooks/useMobileEmbed.ts
+++ b/packages/client/src/hooks/useMobileEmbed.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from "react";
+
+function read(): boolean {
+  const v = new URLSearchParams(window.location.search).get("mobile");
+  return v === "1" || v === "true";
+}
+
+function subscribe(cb: () => void) {
+  window.addEventListener("popstate", cb);
+  return () => window.removeEventListener("popstate", cb);
+}
+
+/** True when the page is loaded inside the Kryton mobile webview (?mobile=1). */
+export function useMobileEmbed(): boolean {
+  return useSyncExternalStore(subscribe, read, () => false);
+}

--- a/packages/client/src/hooks/useUrlSync.ts
+++ b/packages/client/src/hooks/useUrlSync.ts
@@ -22,6 +22,12 @@ export interface UrlSyncCallbacks {
   /** Verify that a path still exists in the user's tree; the hook drops
    *  any URL-listed tab whose path is missing (deleted-while-away). */
   noteExists: (path: string) => boolean;
+  /** Called when a `/canvas/:id` URL is applied. The host (App.tsx) uses
+   *  this as a signal to call `enterEditMode` once the note content loads,
+   *  since `enterEditMode` needs the content string and the note fetch is
+   *  async. Optional — canvas routes work without it (note opens in
+   *  preview mode); the signal just flips to edit mode after load. */
+  onCanvasRoute?: () => void;
 }
 
 /** Snapshot of the navigation-relevant pieces of UI state. */
@@ -177,6 +183,23 @@ export function useUrlSync(activeTabId: string | null, callbacks: UrlSyncCallbac
         } else {
           cb.closeActiveNote();
         }
+        return;
+      }
+      case 'canvas': {
+        // Open the note in edit/canvas mode. `enterEditMode` needs actual
+        // content, so we fire it lazily via the `onCanvasRoute` callback
+        // which is wired in App.tsx as a useEffect watching `activeNote`.
+        ui.setView('note');
+        void cb.openNote(nav.id);
+        cb.onCanvasRoute?.();
+        return;
+      }
+      case 'plugin': {
+        // Open the admin modal pre-selected on the plugins tab.
+        ui.setView('note');
+        ui.setAdminInitialTab('plugins');
+        ui.setShowAdmin(true);
+        if (nav.notePath) void cb.openNote(nav.notePath);
         return;
       }
     }

--- a/packages/client/src/lib/__tests__/urlSchema.test.ts
+++ b/packages/client/src/lib/__tests__/urlSchema.test.ts
@@ -176,3 +176,169 @@ describe('navEquals', () => {
     ).toBe(false);
   });
 });
+
+// ─────────────────────────── canvas routes ───────────────────────────
+
+describe('parseUrl — canvas routes', () => {
+  it('parses /canvas/<simple-path>', () => {
+    expect(parseUrl('/canvas/Welcome.canvas', '')).toEqual({
+      kind: 'canvas',
+      id: 'Welcome.canvas',
+    });
+  });
+
+  it('parses /canvas/<multi-segment-path> with literal slashes', () => {
+    expect(parseUrl('/canvas/Boards/Roadmap.canvas', '')).toEqual({
+      kind: 'canvas',
+      id: 'Boards/Roadmap.canvas',
+    });
+  });
+
+  it('parses /canvas/<multi-segment-path> with encoded slashes (%2F)', () => {
+    expect(parseUrl('/canvas/Boards%2FRoadmap.canvas', '')).toEqual({
+      kind: 'canvas',
+      id: 'Boards/Roadmap.canvas',
+    });
+  });
+
+  it('parses /canvas/<path-with-spaces>', () => {
+    expect(parseUrl('/canvas/My%20Board.canvas', '')).toEqual({
+      kind: 'canvas',
+      id: 'My Board.canvas',
+    });
+  });
+
+  it('collapses /canvas/ (no id) to default', () => {
+    expect(parseUrl('/canvas/', '')).toEqual({ kind: 'default' });
+    expect(parseUrl('/canvas', '')).toEqual({ kind: 'default' });
+  });
+});
+
+describe('serializeNav — canvas routes', () => {
+  it('serializes canvas state to /canvas/<encoded-path>', () => {
+    expect(serializeNav({ kind: 'canvas', id: 'Welcome.canvas' })).toBe(
+      '/canvas/Welcome.canvas',
+    );
+  });
+
+  it('serializes canvas state with multi-segment id (literal slashes)', () => {
+    expect(serializeNav({ kind: 'canvas', id: 'Boards/Roadmap.canvas' })).toBe(
+      '/canvas/Boards/Roadmap.canvas',
+    );
+  });
+
+  it('serializes canvas state with spaces in id', () => {
+    expect(serializeNav({ kind: 'canvas', id: 'My Board.canvas' })).toBe(
+      '/canvas/My%20Board.canvas',
+    );
+  });
+
+  it('round-trips canvas → serialize → parse', () => {
+    const cases: NavState[] = [
+      { kind: 'canvas', id: 'Welcome.canvas' },
+      { kind: 'canvas', id: 'Boards/Roadmap.canvas' },
+      { kind: 'canvas', id: 'My Boards/Team Roadmap.canvas' },
+    ];
+    for (const nav of cases) {
+      const url = serializeNav(nav);
+      const qIdx = url.indexOf('?');
+      const pathname = qIdx >= 0 ? url.slice(0, qIdx) : url;
+      const search = qIdx >= 0 ? url.slice(qIdx) : '';
+      expect(parseUrl(pathname, search)).toEqual(nav);
+    }
+  });
+});
+
+// ─────────────────────────── plugin routes ───────────────────────────
+
+describe('parseUrl — plugin routes', () => {
+  it('parses /plugin/<name> with no note query', () => {
+    expect(parseUrl('/plugin/kanban', '')).toEqual({
+      kind: 'plugin',
+      name: 'kanban',
+      notePath: null,
+    });
+  });
+
+  it('parses /plugin/<name>?note=<path>', () => {
+    expect(parseUrl('/plugin/kanban', '?note=Library/Cards.md')).toEqual({
+      kind: 'plugin',
+      name: 'kanban',
+      notePath: 'Library/Cards.md',
+    });
+  });
+
+  it('decodes the note query parameter', () => {
+    expect(parseUrl('/plugin/kanban', '?note=My%20Notes/Cards.md')).toEqual({
+      kind: 'plugin',
+      name: 'kanban',
+      notePath: 'My Notes/Cards.md',
+    });
+  });
+
+  it('collapses /plugin/ (no name) to default', () => {
+    expect(parseUrl('/plugin/', '')).toEqual({ kind: 'default' });
+    expect(parseUrl('/plugin', '')).toEqual({ kind: 'default' });
+  });
+});
+
+describe('serializeNav — plugin routes', () => {
+  it('serializes plugin state with no notePath', () => {
+    expect(serializeNav({ kind: 'plugin', name: 'kanban', notePath: null })).toBe(
+      '/plugin/kanban',
+    );
+  });
+
+  it('serializes plugin state with notePath', () => {
+    expect(
+      serializeNav({ kind: 'plugin', name: 'kanban', notePath: 'Library/Cards.md' }),
+    ).toBe('/plugin/kanban?note=Library%2FCards.md');
+  });
+
+  it('round-trips plugin → serialize → parse', () => {
+    const cases: NavState[] = [
+      { kind: 'plugin', name: 'kanban', notePath: null },
+      { kind: 'plugin', name: 'kanban', notePath: 'Library/Cards.md' },
+      { kind: 'plugin', name: 'my-plugin', notePath: 'Folder/My Note.md' },
+    ];
+    for (const nav of cases) {
+      const url = serializeNav(nav);
+      const qIdx = url.indexOf('?');
+      const pathname = qIdx >= 0 ? url.slice(0, qIdx) : url;
+      const search = qIdx >= 0 ? url.slice(qIdx) : '';
+      expect(parseUrl(pathname, search)).toEqual(nav);
+    }
+  });
+});
+
+// ─────────────── regression: existing routes still parse correctly ────────────
+
+describe('parseUrl — regression: existing routes', () => {
+  it('still parses / as default', () => {
+    expect(parseUrl('/', '')).toEqual({ kind: 'default' });
+  });
+
+  it('still parses /n/X.md as note', () => {
+    expect(parseUrl('/n/X.md', '')).toEqual({
+      kind: 'note',
+      activePath: 'X.md',
+      tabs: ['X.md'],
+    });
+  });
+
+  it('still parses /view/graph as view', () => {
+    expect(parseUrl('/view/graph', '')).toEqual({ kind: 'view', view: 'graph', tag: null });
+  });
+
+  it('still parses /view/all as view', () => {
+    expect(parseUrl('/view/all', '')).toEqual({ kind: 'view', view: 'all', tag: null });
+  });
+
+  it('still parses /view/tags with tag', () => {
+    expect(parseUrl('/view/tags', '?tag=work')).toEqual({
+      kind: 'view',
+      view: 'tags',
+      tag: 'work',
+    });
+  });
+});

--- a/packages/client/src/lib/urlSchema.ts
+++ b/packages/client/src/lib/urlSchema.ts
@@ -25,7 +25,9 @@ export type NavState =
   | { kind: 'default' }
   | { kind: 'view'; view: Exclude<MainView, 'note'>; tag: string | null }
   | { kind: 'note'; activePath: string; tabs: string[] }
-  | { kind: 'shared'; ownerUserId: string; path: string };
+  | { kind: 'shared'; ownerUserId: string; path: string }
+  | { kind: 'canvas'; id: string }
+  | { kind: 'plugin'; name: string; notePath: string | null };
 
 /** Encode a notes-tree path for use inside the URL. Slash separators
  *  stay literal; each segment is `encodeURIComponent`d so spaces,
@@ -112,6 +114,29 @@ export function parseUrl(pathname: string, search: string): NavState {
     return { kind: 'note', activePath, tabs: tabSet };
   }
 
+  // /canvas/<encoded-id>
+  // Mirrors the /n/ encoding: folder slashes stay literal, segments are
+  // encodeURIComponent'd. The id may also arrive with %2F-encoded slashes
+  // (e.g. from a mobile host that fully-encodes the path); both forms are
+  // accepted by simply percent-decoding the whole rest segment.
+  if (cleanedPath.startsWith('canvas/')) {
+    const rest = cleanedPath.slice('canvas/'.length);
+    if (rest.length === 0) return { kind: 'default' };
+    // Decode segment by segment to handle literal slash separators, then
+    // also handle %2F (fully-encoded slashes) via a global decode pass.
+    const id = decodeNotePath(rest);
+    return { kind: 'canvas', id };
+  }
+
+  // /plugin/<name>?note=<encoded-path>
+  if (cleanedPath.startsWith('plugin/')) {
+    const name = cleanedPath.slice('plugin/'.length);
+    if (name.length === 0) return { kind: 'default' };
+    const rawNote = params.get('note');
+    const notePath = rawNote && rawNote.length > 0 ? decodeURIComponent(rawNote) : null;
+    return { kind: 'plugin', name, notePath };
+  }
+
   return { kind: 'default' };
 }
 
@@ -143,6 +168,19 @@ export function serializeNav(state: NavState): string {
       // Preserve full tab order including the active tab so the parser
       // can reconstruct exactly what the user saw.
       return `/n/${active}?tabs=${joinTabs(state.tabs)}`;
+    }
+    case 'canvas': {
+      // Mirror /n/ encoding: per-segment encodeURIComponent, literal slashes.
+      return `/canvas/${encodeNotePath(state.id)}`;
+    }
+    case 'plugin': {
+      // The note query param uses a full encodeURIComponent so slashes in
+      // the path become %2F — this keeps the note path unambiguous as a
+      // single query-string value.
+      if (state.notePath) {
+        return `/plugin/${state.name}?note=${encodeURIComponent(state.notePath)}`;
+      }
+      return `/plugin/${state.name}`;
     }
   }
 }

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback, CSSProperties, FormEvent } from 'react';
+import { useState, useEffect, useCallback, CSSProperties, FormEvent, useRef } from 'react';
 import {
   X, Users, Ticket, Settings, Trash2, ShieldCheck, ShieldOff,
   UserX, UserCheck, Plus, Copy, Check, Key, Package, Globe,
 } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
+import { useUIStore } from '../stores/uiStore';
 import { request } from '../lib/api';
 import { PluginsTab } from './PluginsTab';
 import { TunnelTab } from './TunnelTab';
@@ -70,9 +71,30 @@ const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: 'tunnel', label: 'Tunnel', icon: Globe },
 ];
 
-export default function AdminPage({ onClose }: { onClose: () => void }) {
+export default function AdminPage({
+  onClose,
+  initialTab,
+}: {
+  onClose: () => void;
+  initialTab?: Tab;
+}) {
   const { user } = useAuth();
-  const [tab, setTab] = useState<Tab>('users');
+  const adminInitialTab = useUIStore((s) => s.adminInitialTab);
+  const setAdminInitialTab = useUIStore((s) => s.setAdminInitialTab);
+  // Resolve the starting tab: explicit prop wins, then the store field
+  // (set by useUrlSync for /plugin/ routes), then the default 'users'.
+  const resolvedInitial = initialTab ?? adminInitialTab ?? 'users';
+  const [tab, setTab] = useState<Tab>(resolvedInitial as Tab);
+  // Clear the store field after consuming it so re-opening AdminPage
+  // from a normal code path doesn't re-land on the plugin tab.
+  const clearedRef = useRef(false);
+  useEffect(() => {
+    if (!clearedRef.current && adminInitialTab !== null) {
+      clearedRef.current = true;
+      setAdminInitialTab(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div

--- a/packages/client/src/pages/PluginsTab.tsx
+++ b/packages/client/src/pages/PluginsTab.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { CSSProperties } from 'react';
+import { useMobileEmbed } from '../hooks/useMobileEmbed';
+import '../styles/mobile-embed.css';
 import {
   Search, Package, Download, RefreshCw, Trash2, Settings,
   CheckCircle, XCircle, AlertCircle,
@@ -93,6 +95,7 @@ const subTabStyle = (active: boolean): CSSProperties => ({
 type SubView = 'browse' | 'installed';
 
 export function PluginsTab() {
+  const isMobile = useMobileEmbed();
   const [subView, setSubView] = useState<SubView>('installed');
   const [installedIds, setInstalledIds] = useState<Set<string>>(new Set());
 
@@ -105,7 +108,7 @@ export function PluginsTab() {
   useEffect(() => { refreshInstalledIds(); }, [refreshInstalledIds]);
 
   return (
-    <div style={{ color: 'var(--fg-1)' }}>
+    <div className={isMobile ? "mobile-embed" : ""} style={{ color: 'var(--fg-1)' }}>
       {/* Sub-view toggle — same mode-pill pattern as the outer tabs */}
       <div style={{ display: 'flex', gap: 2, marginBottom: 14 }}>
         <SubTabBtn active={subView === 'installed'} onClick={() => setSubView('installed')} label="Installed" />

--- a/packages/client/src/stores/uiStore.ts
+++ b/packages/client/src/stores/uiStore.ts
@@ -31,6 +31,9 @@ interface UIState {
 
   // Modals
   showAdmin: boolean;
+  /** When set, AdminPage opens to this tab instead of the default 'users'.
+   *  Cleared by AdminPage after it reads the initial tab on mount. */
+  adminInitialTab: 'users' | 'invites' | 'settings' | 'plugins' | 'tunnel' | null;
   showTemplatePicker: boolean;
   pendingTemplatePath: string | null;
   showQuickSwitcher: boolean;
@@ -68,6 +71,7 @@ interface UIState {
   setOriginalContent: SetState<string | null>;
   setCursorState: SetState<{ line: number; col: number; wordCount: number }>;
   setShowAdmin: SetState<boolean>;
+  setAdminInitialTab: SetState<'users' | 'invites' | 'settings' | 'plugins' | 'tunnel' | null>;
   setShowTemplatePicker: SetState<boolean>;
   setPendingTemplatePath: SetState<string | null>;
   setShowQuickSwitcher: SetState<boolean>;
@@ -110,6 +114,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   editContent: null,
   originalContent: null,
   showAdmin: false,
+  adminInitialTab: null,
   showTemplatePicker: false,
   pendingTemplatePath: null,
   showQuickSwitcher: false,
@@ -134,6 +139,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   setOriginalContent: (v) => set({ originalContent: resolve(v, get().originalContent) }),
   setCursorState: (v) => set({ cursorState: resolve(v, get().cursorState) }),
   setShowAdmin: (v) => set({ showAdmin: resolve(v, get().showAdmin) }),
+  setAdminInitialTab: (v) => set({ adminInitialTab: resolve(v, get().adminInitialTab) }),
   setShowTemplatePicker: (v) => set({ showTemplatePicker: resolve(v, get().showTemplatePicker) }),
   setPendingTemplatePath: (v) => set({ pendingTemplatePath: resolve(v, get().pendingTemplatePath) }),
   setShowQuickSwitcher: (v) => set({ showQuickSwitcher: resolve(v, get().showQuickSwitcher) }),
@@ -181,6 +187,7 @@ export const useUIStore = create<UIState>((set, get) => ({
     editContent: null,
     originalContent: null,
     showAdmin: false,
+    adminInitialTab: null,
     showTemplatePicker: false,
     pendingTemplatePath: null,
     showQuickSwitcher: false,

--- a/packages/client/src/styles/mobile-embed.css
+++ b/packages/client/src/styles/mobile-embed.css
@@ -1,0 +1,25 @@
+.mobile-embed {
+  /* Larger touch targets: 44pt minimum per Apple HIG. */
+  --touch-target-min: 44px;
+}
+
+.mobile-embed button,
+.mobile-embed [role="button"],
+.mobile-embed a {
+  min-height: var(--touch-target-min);
+  min-width: var(--touch-target-min);
+}
+
+.mobile-embed input,
+.mobile-embed select,
+.mobile-embed textarea {
+  font-size: 16px; /* iOS does not auto-zoom on focus for >=16px inputs. */
+  min-height: var(--touch-target-min);
+}
+
+/* Disable text selection on canvas to prevent the OS magnifier popup. */
+.mobile-embed .canvas-surface {
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}

--- a/packages/sdk/PUBLISHING.md
+++ b/packages/sdk/PUBLISHING.md
@@ -4,7 +4,9 @@ The SDK is published to public npm on every kryton release tag.
 
 ## Automated (CI release)
 
-`scripts/release.js` invokes `publishSdk()` after pushing the tag. In CI,
+`scripts/release.js` creates the release commit and tag, then invokes
+`publishSdk()` — the git tag is pushed manually afterwards
+(`git push origin master --tags`), not before publishing. In CI,
 the `publish-sdk` job in `.github/workflows/release.yml` runs after the
 `release` job and calls `node scripts/release-sdk.js` directly. The job
 injects `NPM_TOKEN` from the repo secrets via the `NODE_AUTH_TOKEN` env var

--- a/packages/sdk/PUBLISHING.md
+++ b/packages/sdk/PUBLISHING.md
@@ -1,0 +1,29 @@
+# Publishing @azrtydxb/sdk
+
+The SDK is published to public npm on every kryton release tag.
+
+## Automated (CI release)
+
+`scripts/release.js` invokes `publishSdk()` after pushing the tag. In CI,
+the `publish-sdk` job in `.github/workflows/release.yml` runs after the
+`release` job and calls `node scripts/release-sdk.js` directly. The job
+injects `NPM_TOKEN` from the repo secrets via the `NODE_AUTH_TOKEN` env var
+that `actions/setup-node` reads automatically.
+
+## Manual (local release)
+
+```bash
+npm login                                        # one time
+npm run build --workspace=packages/sdk
+npm publish --access public --workspace=packages/sdk
+```
+
+## React Native compatibility
+
+The SDK is consumed by `kryton-mobile`. Before any change to `packages/sdk`, run:
+
+```bash
+npm test --workspace=packages/sdk
+```
+
+The `rn-compat.test.ts` suite verifies the client constructs without DOM globals. Do not add Node-only or DOM-only dependencies.

--- a/packages/sdk/__tests__/rn-compat.test.ts
+++ b/packages/sdk/__tests__/rn-compat.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { createKrytonClient } from "../src/index.js";
+
+describe("@azrtydxb/sdk React Native compatibility", () => {
+  it("constructs a client without touching DOM globals", () => {
+    // Simulate RN: DOM globals are undefined.
+    const originalDocument = (globalThis as any).document;
+    const originalWindow = (globalThis as any).window;
+    delete (globalThis as any).document;
+    delete (globalThis as any).window;
+    try {
+      const client = createKrytonClient({ baseUrl: "http://localhost:3001" });
+      expect(typeof client.GET).toBe("function");
+      expect(typeof client.POST).toBe("function");
+    } finally {
+      (globalThis as any).document = originalDocument;
+      (globalThis as any).window = originalWindow;
+    }
+  });
+
+  it("exports the expected type aliases", () => {
+    // Type-only assertions; ensures the public surface is stable.
+    type _Probe = import("../src/index.js").UserPublicProfile;
+    expect(true).toBe(true);
+  });
+});

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@azrtydxb/sdk",
   "version": "4.6.5-pre.10",
-  "private": true,
+  "description": "Typed TypeScript client for the Kryton REST API.",
+  "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,6 +15,15 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/azrtydxb/kryton.git",
+    "directory": "packages/sdk"
+  },
   "scripts": {
     "generate": "openapi-typescript ../server/openapi.snapshot.json -o src/types.gen.ts",
     "build": "npm run generate && tsc",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -18,13 +18,15 @@
     "generate": "openapi-typescript ../server/openapi.snapshot.json -o src/types.gen.ts",
     "build": "npm run generate && tsc",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist src/types.gen.ts"
+    "clean": "rm -rf dist src/types.gen.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "openapi-fetch": "^0.13.0"
   },
   "devDependencies": {
     "openapi-typescript": "^7.5.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.1"
   }
 }

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -401,6 +401,259 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/tunnel/reconnect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Force a tunnel reconnect attempt (admin) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                202: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            accepted: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/tunnel/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get tunnel traffic stats (admin) */
+        get: {
+            parameters: {
+                query?: {
+                    window?: "24h" | "7d" | "30d";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            bytes_in: number;
+                            bytes_out: number;
+                            daily: {
+                                bytes_in: number;
+                                bytes_out: number;
+                                date: string;
+                                requests: number;
+                            }[];
+                            requests: number;
+                            since: number;
+                            /** @enum {string} */
+                            window: "24h" | "7d" | "30d";
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/tunnel/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get tunnel status (admin) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            /** @enum {string} */
+                            state: "idle";
+                        } | {
+                            /** @enum {string} */
+                            state: "connecting";
+                        } | {
+                            connectedAt: number;
+                            sessionId: string;
+                            /** @enum {string} */
+                            state: "open";
+                            subdomain: string;
+                            tokenExpiresAt: number;
+                        } | {
+                            lastError: string;
+                            nextAttemptAt: number;
+                            /** @enum {string} */
+                            state: "backoff";
+                        } | {
+                            message: string;
+                            /** @enum {string} */
+                            reason: "invalid-jwt" | "revoked-jwt" | "subscription-inactive" | "duplicate-instance" | "unknown";
+                            /** @enum {string} */
+                            state: "fatal";
+                        } | {
+                            /** @enum {string} */
+                            state: "closing";
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/tunnel/token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Set the tunnel JWT (admin) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        token: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            /** @enum {string} */
+                            state: "idle";
+                        } | {
+                            /** @enum {string} */
+                            state: "connecting";
+                        } | {
+                            connectedAt: number;
+                            sessionId: string;
+                            /** @enum {string} */
+                            state: "open";
+                            subdomain: string;
+                            tokenExpiresAt: number;
+                        } | {
+                            lastError: string;
+                            nextAttemptAt: number;
+                            /** @enum {string} */
+                            state: "backoff";
+                        } | {
+                            message: string;
+                            /** @enum {string} */
+                            reason: "invalid-jwt" | "revoked-jwt" | "subscription-inactive" | "duplicate-instance" | "unknown";
+                            /** @enum {string} */
+                            state: "fatal";
+                        } | {
+                            /** @enum {string} */
+                            state: "closing";
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        /** Clear the tunnel JWT (admin) */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/users": {
         parameters: {
             query?: never;

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -4,6 +4,72 @@
  */
 
 export interface paths {
+    "/.well-known/apple-app-site-association": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/.well-known/assetlinks.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/access-requests/": {
         parameters: {
             query?: never;
@@ -1179,6 +1245,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            agentId: string | null;
                             /** Format: date-time */
                             createdAt: string;
                             expiresAt: string | null;
@@ -1204,6 +1271,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
+                        agentId?: string;
                         /** Format: date-time */
                         expiresAt?: string;
                         name: string;
@@ -1220,6 +1288,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            agentId: string | null;
                             /** Format: date-time */
                             createdAt: string;
                             expiresAt: string | null;
@@ -2195,6 +2264,517 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/notifications/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/notes/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a note */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        content: string;
+                        path: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/notes/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a note */
+        delete: {
+            parameters: {
+                query: {
+                    path: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/notes/get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read a single note */
+        get: {
+            parameters: {
+                query: {
+                    path: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            content: string;
+                            modifiedAt: string;
+                            path: string;
+                            title: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/notes/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List notes for the current user (optionally under a folder) */
+        get: {
+            parameters: {
+                query?: {
+                    folder?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["NoteEntry"][];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/notes/openByPath": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Request that the client UI open a note (emits note:open) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        path: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/notes/replaceFenceAtRange": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Splice a line range in a note with new source */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        newSource: string;
+                        path: string;
+                        range: {
+                            endLine: number;
+                            startLine: number;
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/notes/update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Overwrite a note */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        content: string;
+                        path: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/storage/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a storage key for the current user + plugin */
+        delete: {
+            parameters: {
+                query: {
+                    key: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/storage/get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read a storage key for the current user + plugin */
+        get: {
+            parameters: {
+                query: {
+                    key: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            value: unknown;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/storage/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List storage entries for the current user + plugin */
+        get: {
+            parameters: {
+                query?: {
+                    prefix?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            key: string;
+                            userId: string | null;
+                            value: unknown;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/plugin-builtin/storage/set": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Write a storage key for the current user + plugin */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        key: string;
+                        value: unknown;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            ok: true;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/plugins/active": {
         parameters: {
             query?: never;
@@ -2627,6 +3207,103 @@ export interface paths {
             };
         };
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/push/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register a push notification device token */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        platform: "ios" | "android";
+                        token: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            platform: "ios" | "android";
+                        };
+                    };
+                };
+                /** @description Default Response */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            /** @enum {string} */
+                            platform: "ios" | "android";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/push/register/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Deregister a push notification device */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -3682,15 +4359,19 @@ export interface components {
             children?: components["schemas"]["FileTreeNode"][];
             name: string;
             path: string;
+            size?: number;
             /** @enum {string} */
             type: "file" | "folder";
+            updatedAt?: string;
         };
         FileTreeNodeInput: {
             children?: components["schemas"]["FileTreeNodeInput"][];
             name: string;
             path: string;
+            size?: number;
             /** @enum {string} */
             type: "file" | "folder";
+            updatedAt?: string;
         };
         NoteDataResponse: {
             content: string;
@@ -3703,6 +4384,20 @@ export interface components {
             modifiedAt: string;
             path: string;
             title: string;
+        };
+        NoteEntry: {
+            children?: components["schemas"]["NoteEntry"][];
+            name: string;
+            path: string;
+            /** @enum {string} */
+            type: "file" | "directory";
+        };
+        NoteEntryInput: {
+            children?: components["schemas"]["NoteEntryInput"][];
+            name: string;
+            path: string;
+            /** @enum {string} */
+            type: "file" | "directory";
         };
         RenameNoteBody: {
             newPath: string;

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.ts"],
+  },
+  resolve: {
+    // Allow importing "../src/index.js" to resolve to "../src/index.ts" in tests
+    extensionAlias: {
+      ".js": [".ts", ".js"],
+    },
+  },
+});

--- a/packages/server/openapi.snapshot.json
+++ b/packages/server/openapi.snapshot.json
@@ -189,11 +189,17 @@
           "path": {
             "type": "string"
           },
+          "size": {
+            "type": "number"
+          },
           "type": {
             "enum": [
               "file",
               "folder"
             ],
+            "type": "string"
+          },
+          "updatedAt": {
             "type": "string"
           }
         },
@@ -220,11 +226,17 @@
           "path": {
             "type": "string"
           },
+          "size": {
+            "type": "number"
+          },
           "type": {
             "enum": [
               "file",
               "folder"
             ],
+            "type": "string"
+          },
+          "updatedAt": {
             "type": "string"
           }
         },
@@ -2365,6 +2377,16 @@
                   "items": {
                     "additionalProperties": false,
                     "properties": {
+                      "agentId": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
                       "createdAt": {
                         "format": "date-time",
                         "type": "string"
@@ -2409,6 +2431,7 @@
                       "name",
                       "keyPrefix",
                       "scope",
+                      "agentId",
                       "expiresAt",
                       "lastUsedAt",
                       "createdAt"
@@ -2433,6 +2456,10 @@
             "application/json": {
               "schema": {
                 "properties": {
+                  "agentId": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
                   "expiresAt": {
                     "format": "date-time",
                     "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
@@ -2468,6 +2495,16 @@
                 "schema": {
                   "additionalProperties": false,
                   "properties": {
+                    "agentId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
                     "createdAt": {
                       "format": "date-time",
                       "type": "string"
@@ -2505,6 +2542,7 @@
                     "keyPrefix",
                     "name",
                     "scope",
+                    "agentId",
                     "expiresAt",
                     "createdAt"
                   ],
@@ -3714,6 +3752,567 @@
         ]
       }
     },
+    "/api/plugin-builtin/notes/create": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "content"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [
+                        true
+                      ],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Create a note",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/notes/delete": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [
+                        true
+                      ],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Delete a note",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/notes/get": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "modifiedAt": {
+                      "anyOf": [
+                        {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "content",
+                    "title",
+                    "modifiedAt"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Read a single note",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/notes/list": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "folder",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/schema0"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "List notes for the current user (optionally under a folder)",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/notes/openByPath": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "path": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [
+                        true
+                      ],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Request that the client UI open a note (emits note:open)",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/notes/replaceFenceAtRange": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "newSource": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "range": {
+                    "properties": {
+                      "endLine": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "startLine": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "startLine",
+                      "endLine"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "path",
+                  "range",
+                  "newSource"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [
+                        true
+                      ],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Splice a line range in a note with new source",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/notes/update": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "content"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [
+                        true
+                      ],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Overwrite a note",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/storage/delete": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [
+                        true
+                      ],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Delete a storage key for the current user + plugin",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/storage/get": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "value": {}
+                  },
+                  "required": [
+                    "value"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Read a storage key for the current user + plugin",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/storage/list": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "prefix",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "userId": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "value": {}
+                    },
+                    "required": [
+                      "key",
+                      "value",
+                      "userId"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "List storage entries for the current user + plugin",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
+    "/api/plugin-builtin/storage/set": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "key": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "enum": [
+                        true
+                      ],
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Write a storage key for the current user + plugin",
+        "tags": [
+          "plugin-builtin"
+        ]
+      }
+    },
     "/api/plugins/active": {
       "get": {
         "responses": {
@@ -4238,6 +4837,121 @@
         "summary": "Deactivate and remove a plugin (admin)",
         "tags": [
           "plugins"
+        ]
+      }
+    },
+    "/api/push/register": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "platform": {
+                    "enum": [
+                      "ios",
+                      "android"
+                    ],
+                    "type": "string"
+                  },
+                  "token": {
+                    "maxLength": 2048,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "platform",
+                  "token"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "platform": {
+                      "enum": [
+                        "ios",
+                        "android"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "platform"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "platform": {
+                      "enum": [
+                        "ios",
+                        "android"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "platform"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Default Response"
+          }
+        },
+        "summary": "Register a push notification device token",
+        "tags": [
+          "push"
+        ]
+      }
+    },
+    "/api/push/register/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response"
+          }
+        },
+        "summary": "Deregister a push notification device",
+        "tags": [
+          "push"
         ]
       }
     },

--- a/packages/server/openapi.snapshot.json
+++ b/packages/server/openapi.snapshot.json
@@ -3752,6 +3752,15 @@
         ]
       }
     },
+    "/api/notifications/stream": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/api/plugin-builtin/notes/create": {
       "post": {
         "requestBody": {

--- a/packages/server/openapi.snapshot.json
+++ b/packages/server/openapi.snapshot.json
@@ -310,6 +310,69 @@
         ],
         "type": "object"
       },
+      "NoteEntry": {
+        "$id": "#/components/schemas/NoteEntry",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "children": {
+            "items": {
+              "$ref": "#/components/schemas/NoteEntry"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "file",
+              "directory"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "path",
+          "type"
+        ],
+        "type": "object"
+      },
+      "NoteEntryInput": {
+        "$id": "#/components/schemas/NoteEntryInput",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "children": {
+            "items": {
+              "$ref": "#/components/schemas/NoteEntryInput"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "file",
+              "directory"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "path",
+          "type"
+        ],
+        "type": "object"
+      },
       "RenameNoteBody": {
         "$id": "#/components/schemas/RenameNoteBody",
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -3955,7 +4018,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/schema0"
+                    "$ref": "#/components/schemas/NoteEntry"
                   },
                   "type": "array"
                 }

--- a/packages/server/openapi.snapshot.json
+++ b/packages/server/openapi.snapshot.json
@@ -548,6 +548,24 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/.well-known/apple-app-site-association": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
+    "/.well-known/assetlinks.json": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/api/access-requests/": {
       "get": {
         "responses": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,6 +40,7 @@
     "@fastify/websocket": "^11.0.1",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@opentelemetry/api": "^1.9.0",
+    "@parse/node-apn": "^7.1.0",
     "@xenova/transformers": "^2.17.2",
     "better-auth": "^1.5.6",
     "chokidar": "^4.0.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,6 +51,7 @@
     "fastify": "^5.2.0",
     "fastify-plugin": "^5.0.1",
     "fastify-type-provider-zod": "^6.1.0",
+    "firebase-admin": "^13.10.0",
     "lib0": "^0.2.99",
     "multer": "^2.1.1",
     "nodemailer": "^8.0.5",

--- a/packages/server/src/config/env.ts
+++ b/packages/server/src/config/env.ts
@@ -164,6 +164,41 @@ const envSchema = z.object({
     description: "Default From: address for outbound mail.",
   }),
 
+  // ---------------------------------------------------------------------------
+  // APNs (Apple Push Notification service)
+  // ---------------------------------------------------------------------------
+  APNS_KEY_ID: withMeta(z.string().optional(), {
+    secret: true,
+    userFacing: true,
+    description: "APNs token-auth key ID (10-char, from Apple Developer portal).",
+  }),
+  APNS_TEAM_ID: withMeta(z.string().optional(), {
+    secret: false,
+    userFacing: true,
+    description: "Apple Developer Team ID used for APNs token auth.",
+  }),
+  APNS_BUNDLE_ID: withMeta(z.string().optional(), {
+    secret: false,
+    userFacing: true,
+    description: "iOS app bundle identifier for APNs topic (e.g. com.kryton.mobile).",
+  }),
+  APNS_KEY_PATH: withMeta(z.string().optional(), {
+    secret: true,
+    userFacing: true,
+    description: "Filesystem path to the APNs .p8 private key file.",
+  }),
+  APNS_PRODUCTION: withMeta(
+    z
+      .string()
+      .default("false")
+      .transform((s) => s === "true"),
+    {
+      secret: false,
+      userFacing: true,
+      description: "Send APNs to production gateway (\"true\") or sandbox (\"false\").",
+    },
+  ),
+
   OPENAPI_ENABLED: withMeta(
     z
       .string()

--- a/packages/server/src/config/env.ts
+++ b/packages/server/src/config/env.ts
@@ -199,6 +199,20 @@ const envSchema = z.object({
     },
   ),
 
+  // ---------------------------------------------------------------------------
+  // FCM (Firebase Cloud Messaging)
+  // ---------------------------------------------------------------------------
+  FCM_SERVICE_ACCOUNT_PATH: withMeta(z.string().optional(), {
+    secret: true,
+    userFacing: true,
+    description: "Filesystem path to the Firebase service account JSON key file.",
+  }),
+  FCM_PROJECT_ID: withMeta(z.string().optional(), {
+    secret: false,
+    userFacing: true,
+    description: "Firebase project ID for FCM (e.g. my-project-12345).",
+  }),
+
   OPENAPI_ENABLED: withMeta(
     z
       .string()

--- a/packages/server/src/config/env.ts
+++ b/packages/server/src/config/env.ts
@@ -165,6 +165,35 @@ const envSchema = z.object({
   }),
 
   // ---------------------------------------------------------------------------
+  // Mobile app integration (optional — degrade gracefully when unset)
+  // ---------------------------------------------------------------------------
+  MOBILE_IOS_TEAM_ID: withMeta(z.string().optional(), {
+    secret: false,
+    userFacing: true,
+    description: "Apple Developer Team ID for iOS Universal Links / WebAuthn RP (e.g. ABCDE12345).",
+  }),
+  MOBILE_IOS_BUNDLE_ID: withMeta(z.string().optional(), {
+    secret: false,
+    userFacing: true,
+    description: "iOS app bundle identifier (e.g. com.kryton.mobile). Used for Universal Links and passkey origin.",
+  }),
+  MOBILE_ANDROID_PACKAGE: withMeta(z.string().optional(), {
+    secret: false,
+    userFacing: true,
+    description: "Android app package name (e.g. com.kryton.mobile). Used for Digital Asset Links.",
+  }),
+  MOBILE_ANDROID_SHA256_FINGERPRINTS: withMeta(z.string().optional(), {
+    secret: false,
+    userFacing: true,
+    description: "Comma-separated SHA-256 certificate fingerprints for Android App Links (assetlinks.json). These are the SHA-256 hash of the signing certificate — distinct from the APK key hash used for WebAuthn.",
+  }),
+  MOBILE_ANDROID_APK_KEY_HASH: withMeta(z.string().optional(), {
+    secret: false,
+    userFacing: true,
+    description: "Base64url-encoded SHA-256 of the Android app's signing public key. Used as the WebAuthn passkey origin (android:apk-key-hash:…). Different from the certificate fingerprint used in assetlinks.json.",
+  }),
+
+  // ---------------------------------------------------------------------------
   // APNs (Apple Push Notification service)
   // ---------------------------------------------------------------------------
   APNS_KEY_ID: withMeta(z.string().optional(), {

--- a/packages/server/src/db/migrations/0006_brainy_jack_power.sql
+++ b/packages/server/src/db/migrations/0006_brainy_jack_power.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "push_devices" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"userId" text NOT NULL,
+	"platform" text NOT NULL,
+	"token" text NOT NULL,
+	"lastSeenAt" timestamp with time zone DEFAULT now() NOT NULL,
+	"createdAt" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "push_devices" ADD CONSTRAINT "push_devices_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "push_devices_userId_idx" ON "push_devices" USING btree ("userId");--> statement-breakpoint
+CREATE UNIQUE INDEX "push_devices_platform_token_unique" ON "push_devices" USING btree ("platform","token");

--- a/packages/server/src/db/migrations/meta/0006_snapshot.json
+++ b/packages/server/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,2813 @@
+{
+  "id": "a231d9a2-bd0c-46cd-9ec5-2c7cdfc5ed7a",
+  "prevId": "0915dd7b-b125-43af-99e0-508981edf6bb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Account": {
+      "name": "Account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Account_providerId_accountId_key": {
+          "name": "Account_providerId_accountId_key",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Account_userId_User_id_fk": {
+          "name": "Account_userId_User_id_fk",
+          "tableFrom": "Account",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ApiKey": {
+      "name": "ApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read-only'"
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ApiKey_keyHash_key": {
+          "name": "ApiKey_keyHash_key",
+          "columns": [
+            {
+              "expression": "keyHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_userId_idx": {
+          "name": "ApiKey_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_keyHash_idx": {
+          "name": "ApiKey_keyHash_idx",
+          "columns": [
+            {
+              "expression": "keyHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ApiKey_agentId_idx": {
+          "name": "ApiKey_agentId_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ApiKey_userId_User_id_fk": {
+          "name": "ApiKey_userId_User_id_fk",
+          "tableFrom": "ApiKey",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Passkey": {
+      "name": "Passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Passkey_credentialID_key": {
+          "name": "Passkey_credentialID_key",
+          "columns": [
+            {
+              "expression": "credentialID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Passkey_userId_User_id_fk": {
+          "name": "Passkey_userId_User_id_fk",
+          "tableFrom": "Passkey",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Session": {
+      "name": "Session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Session_token_key": {
+          "name": "Session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Session_userId_User_id_fk": {
+          "name": "Session_userId_User_id_fk",
+          "tableFrom": "Session",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TwoFactor": {
+      "name": "TwoFactor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backupCodes": {
+          "name": "backupCodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TwoFactor_userId_idx": {
+          "name": "TwoFactor_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TwoFactor_userId_User_id_fk": {
+          "name": "TwoFactor_userId_User_id_fk",
+          "tableFrom": "TwoFactor",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "twoFactorEnabled": {
+          "name": "twoFactorEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "User_email_key": {
+          "name": "User_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Verification": {
+      "name": "Verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InstalledPlugin": {
+      "name": "InstalledPlugin",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'installed'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "installedAt": {
+          "name": "installedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "schemaVersion": {
+          "name": "schemaVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PluginStorage": {
+      "name": "PluginStorage",
+      "schema": "",
+      "columns": {
+        "pluginId": {
+          "name": "pluginId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "PluginStorage_userId_User_id_fk": {
+          "name": "PluginStorage_userId_User_id_fk",
+          "tableFrom": "PluginStorage",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "PluginStorage_pluginId_key_userId_pk": {
+          "name": "PluginStorage_pluginId_key_userId_pk",
+          "columns": [
+            "pluginId",
+            "key",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Settings": {
+      "name": "Settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Settings_key_userId_pk": {
+          "name": "Settings_key_userId_pk",
+          "columns": [
+            "key",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Attachment": {
+      "name": "Attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notePath": {
+          "name": "notePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Attachment_userId_notePath_idx": {
+          "name": "Attachment_userId_notePath_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notePath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Attachment_contentHash_idx": {
+          "name": "Attachment_contentHash_idx",
+          "columns": [
+            {
+              "expression": "contentHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Attachment_userId_User_id_fk": {
+          "name": "Attachment_userId_User_id_fk",
+          "tableFrom": "Attachment",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Folder": {
+      "name": "Folder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Folder_userId_path_key": {
+          "name": "Folder_userId_path_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Folder_userId_User_id_fk": {
+          "name": "Folder_userId_User_id_fk",
+          "tableFrom": "Folder",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.GraphEdge": {
+      "name": "GraphEdge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fromPath": {
+          "name": "fromPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toPath": {
+          "name": "toPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromNoteId": {
+          "name": "fromNoteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toNoteId": {
+          "name": "toNoteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "GraphEdge_userId_idx": {
+          "name": "GraphEdge_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GraphEdge_fromNoteId_idx": {
+          "name": "GraphEdge_fromNoteId_idx",
+          "columns": [
+            {
+              "expression": "fromNoteId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GraphEdge_toNoteId_idx": {
+          "name": "GraphEdge_toNoteId_idx",
+          "columns": [
+            {
+              "expression": "toNoteId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "GraphEdge_userId_User_id_fk": {
+          "name": "GraphEdge_userId_User_id_fk",
+          "tableFrom": "GraphEdge",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NoteRevision": {
+      "name": "NoteRevision",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notePath": {
+          "name": "notePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "NoteRevision_userId_notePath_createdAt_idx": {
+          "name": "NoteRevision_userId_notePath_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notePath",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "NoteRevision_userId_User_id_fk": {
+          "name": "NoteRevision_userId_User_id_fk",
+          "tableFrom": "NoteRevision",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NoteTag": {
+      "name": "NoteTag",
+      "schema": "",
+      "columns": {
+        "notePath": {
+          "name": "notePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "NoteTag_tagId_Tag_id_fk": {
+          "name": "NoteTag_tagId_Tag_id_fk",
+          "tableFrom": "NoteTag",
+          "tableTo": "Tag",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "NoteTag_userId_User_id_fk": {
+          "name": "NoteTag_userId_User_id_fk",
+          "tableFrom": "NoteTag",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "NoteTag_userId_notePath_tagId_pk": {
+          "name": "NoteTag_userId_notePath_tagId_pk",
+          "columns": [
+            "userId",
+            "notePath",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NoteVersion": {
+      "name": "NoteVersion",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notePath": {
+          "name": "notePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "NoteVersion_userId_User_id_fk": {
+          "name": "NoteVersion_userId_User_id_fk",
+          "tableFrom": "NoteVersion",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "NoteVersion_userId_notePath_pk": {
+          "name": "NoteVersion_userId_notePath_pk",
+          "columns": [
+            "userId",
+            "notePath"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SearchIndex": {
+      "name": "SearchIndex",
+      "schema": "",
+      "columns": {
+        "notePath": {
+          "name": "notePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "modifiedAt": {
+          "name": "modifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tsv": {
+          "name": "tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, '') || ' ' || coalesce(tags, ''))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "SearchIndex_userId_idx": {
+          "name": "SearchIndex_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SearchIndex_tsv_idx": {
+          "name": "SearchIndex_tsv_idx",
+          "columns": [
+            {
+              "expression": "tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SearchIndex_userId_User_id_fk": {
+          "name": "SearchIndex_userId_User_id_fk",
+          "tableFrom": "SearchIndex",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "SearchIndex_notePath_userId_pk": {
+          "name": "SearchIndex_notePath_userId_pk",
+          "columns": [
+            "notePath",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Tag": {
+      "name": "Tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Tag_userId_name_key": {
+          "name": "Tag_userId_name_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Tag_userId_User_id_fk": {
+          "name": "Tag_userId_User_id_fk",
+          "tableFrom": "Tag",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TrashItem": {
+      "name": "TrashItem",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "originalPath": {
+          "name": "originalPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "TrashItem_userId_trashedAt_idx": {
+          "name": "TrashItem_userId_trashedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trashedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AccessRequest": {
+      "name": "AccessRequest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requesterUserId": {
+          "name": "requesterUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerUserId": {
+          "name": "ownerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notePath": {
+          "name": "notePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "AccessRequest_requesterUserId_User_id_fk": {
+          "name": "AccessRequest_requesterUserId_User_id_fk",
+          "tableFrom": "AccessRequest",
+          "tableTo": "User",
+          "columnsFrom": [
+            "requesterUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "AccessRequest_ownerUserId_User_id_fk": {
+          "name": "AccessRequest_ownerUserId_User_id_fk",
+          "tableFrom": "AccessRequest",
+          "tableTo": "User",
+          "columnsFrom": [
+            "ownerUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.InviteCode": {
+      "name": "InviteCode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usedById": {
+          "name": "usedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "InviteCode_code_key": {
+          "name": "InviteCode_code_key",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "InviteCode_createdById_User_id_fk": {
+          "name": "InviteCode_createdById_User_id_fk",
+          "tableFrom": "InviteCode",
+          "tableTo": "User",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "InviteCode_usedById_User_id_fk": {
+          "name": "InviteCode_usedById_User_id_fk",
+          "tableFrom": "InviteCode",
+          "tableTo": "User",
+          "columnsFrom": [
+            "usedById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NoteShare": {
+      "name": "NoteShare",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerUserId": {
+          "name": "ownerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isFolder": {
+          "name": "isFolder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedWithUserId": {
+          "name": "sharedWithUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "NoteShare_ownerUserId_path_sharedWithUserId_key": {
+          "name": "NoteShare_ownerUserId_path_sharedWithUserId_key",
+          "columns": [
+            {
+              "expression": "ownerUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sharedWithUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NoteShare_sharedWithUserId_idx": {
+          "name": "NoteShare_sharedWithUserId_idx",
+          "columns": [
+            {
+              "expression": "sharedWithUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "NoteShare_ownerUserId_User_id_fk": {
+          "name": "NoteShare_ownerUserId_User_id_fk",
+          "tableFrom": "NoteShare",
+          "tableTo": "User",
+          "columnsFrom": [
+            "ownerUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "NoteShare_sharedWithUserId_User_id_fk": {
+          "name": "NoteShare_sharedWithUserId_User_id_fk",
+          "tableFrom": "NoteShare",
+          "tableTo": "User",
+          "columnsFrom": [
+            "sharedWithUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.YjsDocument": {
+      "name": "YjsDocument",
+      "schema": "",
+      "columns": {
+        "docId": {
+          "name": "docId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stateVector": {
+          "name": "stateVector",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "YjsDocument_userId_User_id_fk": {
+          "name": "YjsDocument_userId_User_id_fk",
+          "tableFrom": "YjsDocument",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.YjsUpdate": {
+      "name": "YjsUpdate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "docId": {
+          "name": "docId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "update": {
+          "name": "update",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "YjsUpdate_docId_createdAt_idx": {
+          "name": "YjsUpdate_docId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "docId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Agent": {
+      "name": "Agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerUserId": {
+          "name": "ownerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policyText": {
+          "name": "policyText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Agent_ownerUserId_name_key": {
+          "name": "Agent_ownerUserId_name_key",
+          "columns": [
+            {
+              "expression": "ownerUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Agent_ownerUserId_User_id_fk": {
+          "name": "Agent_ownerUserId_User_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "User",
+          "columnsFrom": [
+            "ownerUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentToken": {
+      "name": "AgentToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentToken_tokenHash_idx": {
+          "name": "AgentToken_tokenHash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentToken_agentId_Agent_id_fk": {
+          "name": "AgentToken_agentId_Agent_id_fk",
+          "tableFrom": "AgentToken",
+          "tableTo": "Agent",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpSession": {
+      "name": "McpSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyScope": {
+          "name": "keyScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastActivityAt": {
+          "name": "lastActivityAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpSession_userId_idx": {
+          "name": "McpSession_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpSession_lastActivityAt_idx": {
+          "name": "McpSession_lastActivityAt_idx",
+          "columns": [
+            {
+              "expression": "lastActivityAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpSession_userId_User_id_fk": {
+          "name": "McpSession_userId_User_id_fk",
+          "tableFrom": "McpSession",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmbedJob": {
+      "name": "EmbedJob",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_path": {
+          "name": "note_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "embed_job_queue_idx": {
+          "name": "embed_job_queue_idx",
+          "columns": [
+            {
+              "expression": "enqueued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EmbedJob_user_id_User_id_fk": {
+          "name": "EmbedJob_user_id_User_id_fk",
+          "tableFrom": "EmbedJob",
+          "tableTo": "User",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "EmbedJob_user_id_note_path_pk": {
+          "name": "EmbedJob_user_id_note_path_pk",
+          "columns": [
+            "user_id",
+            "note_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NoteEmbeddingChunk": {
+      "name": "NoteEmbeddingChunk",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_path": {
+          "name": "note_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(384)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "note_embedding_hnsw_idx": {
+          "name": "note_embedding_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "note_embedding_user_path_idx": {
+          "name": "note_embedding_user_path_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "NoteEmbeddingChunk_user_id_User_id_fk": {
+          "name": "NoteEmbeddingChunk_user_id_User_id_fk",
+          "tableFrom": "NoteEmbeddingChunk",
+          "tableTo": "User",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "NoteEmbeddingChunk_user_id_note_path_chunk_index_pk": {
+          "name": "NoteEmbeddingChunk_user_id_note_path_chunk_index_pk",
+          "columns": [
+            "user_id",
+            "note_path",
+            "chunk_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TunnelTrafficDaily": {
+      "name": "TunnelTrafficDaily",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requests": {
+          "name": "requests",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bytesIn": {
+          "name": "bytesIn",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bytesOut": {
+          "name": "bytesOut",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_devices": {
+      "name": "push_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_devices_userId_idx": {
+          "name": "push_devices_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_devices_platform_token_unique": {
+          "name": "push_devices_platform_token_unique",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_devices_userId_User_id_fk": {
+          "name": "push_devices_userId_User_id_fk",
+          "tableFrom": "push_devices",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/src/db/migrations/meta/_journal.json
+++ b/packages/server/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1779182438789,
       "tag": "0005_supreme_pyro",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1779374082050,
+      "tag": "0006_brainy_jack_power",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema/__tests__/push.test.ts
+++ b/packages/server/src/db/schema/__tests__/push.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { pushDevices } from "../push.js";
+
+describe("push_devices schema", () => {
+  it("declares the expected columns", () => {
+    const cols = Object.keys(pushDevices);
+    expect(cols).toEqual(
+      expect.arrayContaining(["id", "userId", "platform", "token", "lastSeenAt", "createdAt"]),
+    );
+  });
+});

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -72,3 +72,4 @@ export * from "./collab.js";
 export * from "./agents.js";
 export * from "./embeddings.js";
 export * from "./tunnel.js";
+export * from "./push.js";

--- a/packages/server/src/db/schema/push.ts
+++ b/packages/server/src/db/schema/push.ts
@@ -1,0 +1,35 @@
+import { sql } from "drizzle-orm";
+import { index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+
+import { user } from "./auth.js";
+
+// ---------------------------------------------------------------------------
+// PushDevices
+// ---------------------------------------------------------------------------
+
+export const pushDevices = pgTable(
+  "push_devices",
+  {
+    id: text("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: text("userId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    platform: text("platform", { enum: ["ios", "android"] }).notNull(),
+    token: text("token").notNull(),
+    lastSeenAt: timestamp("lastSeenAt", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("createdAt", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    index("push_devices_userId_idx").on(t.userId),
+    uniqueIndex("push_devices_platform_token_unique").on(t.platform, t.token),
+  ],
+);
+
+export type PushDevice = typeof pushDevices.$inferSelect;
+export type NewPushDevice = typeof pushDevices.$inferInsert;

--- a/packages/server/src/modules/identity/__tests__/apns.test.ts
+++ b/packages/server/src/modules/identity/__tests__/apns.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { sendApns, type ApnsResult } from "../services/push/apns.js";
+
+describe("sendApns", () => {
+  it("sends a notification and returns success on 200", async () => {
+    const fakeProvider = {
+      send: vi.fn().mockResolvedValue({ sent: [{ device: "tok" }], failed: [] }),
+    };
+    const res: ApnsResult = await sendApns(
+      { token: "tok", title: "Hi", body: "Hello", deepLink: "kryton://x" },
+      { provider: fakeProvider as any, bundleId: "com.kryton.mobile" },
+    );
+    expect(res).toEqual({ ok: true });
+    expect(fakeProvider.send).toHaveBeenCalledOnce();
+  });
+
+  it("returns permanent failure on BadDeviceToken", async () => {
+    const fakeProvider = {
+      send: vi.fn().mockResolvedValue({
+        sent: [],
+        failed: [{ device: "tok", response: { reason: "BadDeviceToken" }, status: "410" }],
+      }),
+    };
+    const res = await sendApns(
+      { token: "tok", title: "Hi", body: "Hello" },
+      { provider: fakeProvider as any, bundleId: "com.kryton.mobile" },
+    );
+    expect(res).toEqual({ ok: false, permanent: true, reason: "BadDeviceToken" });
+  });
+
+  it("returns transient failure on 5xx", async () => {
+    const fakeProvider = {
+      send: vi.fn().mockResolvedValue({
+        sent: [],
+        failed: [{ device: "tok", response: { reason: "InternalServerError" }, status: "500" }],
+      }),
+    };
+    const res = await sendApns(
+      { token: "tok", title: "Hi", body: "Hello" },
+      { provider: fakeProvider as any, bundleId: "com.kryton.mobile" },
+    );
+    expect(res).toEqual({ ok: false, permanent: false, reason: "InternalServerError" });
+  });
+});

--- a/packages/server/src/modules/identity/__tests__/apns.test.ts
+++ b/packages/server/src/modules/identity/__tests__/apns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { sendApns, type ApnsResult } from "../services/push/apns.js";
+import { sendApns, type ApnsResult, type ApnsDeps } from "../services/push/apns.js";
 
 describe("sendApns", () => {
   it("sends a notification and returns success on 200", async () => {
@@ -8,7 +8,7 @@ describe("sendApns", () => {
     };
     const res: ApnsResult = await sendApns(
       { token: "tok", title: "Hi", body: "Hello", deepLink: "kryton://x" },
-      { provider: fakeProvider as any, bundleId: "com.kryton.mobile" },
+      { provider: fakeProvider as unknown as ApnsDeps["provider"], bundleId: "com.kryton.mobile" },
     );
     expect(res).toEqual({ ok: true });
     expect(fakeProvider.send).toHaveBeenCalledOnce();
@@ -23,7 +23,7 @@ describe("sendApns", () => {
     };
     const res = await sendApns(
       { token: "tok", title: "Hi", body: "Hello" },
-      { provider: fakeProvider as any, bundleId: "com.kryton.mobile" },
+      { provider: fakeProvider as unknown as ApnsDeps["provider"], bundleId: "com.kryton.mobile" },
     );
     expect(res).toEqual({ ok: false, permanent: true, reason: "BadDeviceToken" });
   });
@@ -37,7 +37,7 @@ describe("sendApns", () => {
     };
     const res = await sendApns(
       { token: "tok", title: "Hi", body: "Hello" },
-      { provider: fakeProvider as any, bundleId: "com.kryton.mobile" },
+      { provider: fakeProvider as unknown as ApnsDeps["provider"], bundleId: "com.kryton.mobile" },
     );
     expect(res).toEqual({ ok: false, permanent: false, reason: "InternalServerError" });
   });

--- a/packages/server/src/modules/identity/__tests__/bus.test.ts
+++ b/packages/server/src/modules/identity/__tests__/bus.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { NotificationBus, type NotificationEvent } from "../services/notifications/bus.js";
+
+function makeEvent(userId: string): NotificationEvent {
+  return {
+    id: "evt-1",
+    userId,
+    kind: "custom",
+    title: "Test",
+    body: "Test body",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+describe("NotificationBus", () => {
+  it("delivers an event to a subscribed user", async () => {
+    const bus = new NotificationBus();
+    const handler = vi.fn();
+    bus.subscribe("user-a", handler);
+
+    const event = makeEvent("user-a");
+    await bus.publish(event);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  it("does not deliver an event to a different user", async () => {
+    const bus = new NotificationBus();
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+    bus.subscribe("user-a", handlerA);
+    bus.subscribe("user-b", handlerB);
+
+    await bus.publish(makeEvent("user-a"));
+
+    expect(handlerA).toHaveBeenCalledOnce();
+    expect(handlerB).not.toHaveBeenCalled();
+  });
+
+  it("stops delivering events after unsubscribe", async () => {
+    const bus = new NotificationBus();
+    const handler = vi.fn();
+    const unsub = bus.subscribe("user-a", handler);
+
+    await bus.publish(makeEvent("user-a"));
+    expect(handler).toHaveBeenCalledOnce();
+
+    unsub();
+    await bus.publish(makeEvent("user-a"));
+    expect(handler).toHaveBeenCalledOnce(); // still once, not twice
+  });
+});

--- a/packages/server/src/modules/identity/__tests__/dispatcher.test.ts
+++ b/packages/server/src/modules/identity/__tests__/dispatcher.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { dispatchPush, type DispatcherDeps } from "../services/push/dispatcher.js";
+import type { NotificationEvent } from "../services/notifications/bus.js";
+
+function makeEvent(overrides?: Partial<NotificationEvent>): NotificationEvent {
+  return {
+    id: "evt-1",
+    userId: "user-a",
+    kind: "custom",
+    title: "Test title",
+    body: "Test body",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides?: Partial<DispatcherDeps>): DispatcherDeps {
+  return {
+    sendApns: vi.fn().mockResolvedValue({ ok: true }),
+    sendFcm: vi.fn().mockResolvedValue({ ok: true }),
+    listDevices: vi.fn().mockResolvedValue([]),
+    prune: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("dispatchPush", () => {
+  it("fans out to ios and android devices", async () => {
+    const deps = makeDeps({
+      listDevices: vi.fn().mockResolvedValue([
+        { id: "dev-ios", platform: "ios" as const, token: "apns-token" },
+        { id: "dev-android", platform: "android" as const, token: "fcm-token" },
+      ]),
+    });
+
+    await dispatchPush(makeEvent(), deps);
+
+    expect(deps.sendApns).toHaveBeenCalledOnce();
+    expect(deps.sendApns).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "apns-token", title: "Test title" }),
+    );
+    expect(deps.sendFcm).toHaveBeenCalledOnce();
+    expect(deps.sendFcm).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "fcm-token", title: "Test title" }),
+    );
+    expect(deps.prune).not.toHaveBeenCalled();
+  });
+
+  it("prunes a device on permanent failure", async () => {
+    const deps = makeDeps({
+      listDevices: vi.fn().mockResolvedValue([
+        { id: "dev-ios", platform: "ios" as const, token: "bad-token" },
+      ]),
+      sendApns: vi.fn().mockResolvedValue({ ok: false, permanent: true, reason: "BadDeviceToken" }),
+    });
+
+    await dispatchPush(makeEvent(), deps);
+
+    expect(deps.prune).toHaveBeenCalledOnce();
+    expect(deps.prune).toHaveBeenCalledWith("dev-ios");
+  });
+
+  it("does not prune on transient failure", async () => {
+    const deps = makeDeps({
+      listDevices: vi.fn().mockResolvedValue([
+        { id: "dev-android", platform: "android" as const, token: "fcm-token" },
+      ]),
+      sendFcm: vi
+        .fn()
+        .mockResolvedValue({ ok: false, permanent: false, reason: "messaging/server-unavailable" }),
+    });
+
+    await dispatchPush(makeEvent(), deps);
+
+    expect(deps.prune).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/modules/identity/__tests__/fcm.test.ts
+++ b/packages/server/src/modules/identity/__tests__/fcm.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { sendFcm, type FcmResult } from "../services/push/fcm.js";
+
+describe("sendFcm", () => {
+  it("returns ok on success", async () => {
+    const messaging = { send: vi.fn().mockResolvedValue("projects/x/messages/123") };
+    const res: FcmResult = await sendFcm(
+      { token: "fcm-tok", title: "Hi", body: "Hello", deepLink: "kryton://x" },
+      { messaging: messaging as any },
+    );
+    expect(res).toEqual({ ok: true });
+  });
+
+  it("returns permanent failure on UNREGISTERED", async () => {
+    const messaging = {
+      send: vi.fn().mockRejectedValue(
+        Object.assign(new Error("Requested entity was not found."), {
+          code: "messaging/registration-token-not-registered",
+        }),
+      ),
+    };
+    const res = await sendFcm(
+      { token: "fcm-tok", title: "Hi", body: "Hello" },
+      { messaging: messaging as any },
+    );
+    expect(res).toEqual({
+      ok: false,
+      permanent: true,
+      reason: "messaging/registration-token-not-registered",
+    });
+  });
+
+  it("returns transient failure on internal errors", async () => {
+    const messaging = {
+      send: vi.fn().mockRejectedValue(
+        Object.assign(new Error("internal"), { code: "messaging/internal-error" }),
+      ),
+    };
+    const res = await sendFcm(
+      { token: "fcm-tok", title: "Hi", body: "Hello" },
+      { messaging: messaging as any },
+    );
+    expect(res).toEqual({ ok: false, permanent: false, reason: "messaging/internal-error" });
+  });
+});

--- a/packages/server/src/modules/identity/__tests__/fcm.test.ts
+++ b/packages/server/src/modules/identity/__tests__/fcm.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
-import { sendFcm, type FcmResult } from "../services/push/fcm.js";
+import { sendFcm, type FcmResult, type FcmDeps } from "../services/push/fcm.js";
 
 describe("sendFcm", () => {
   it("returns ok on success", async () => {
     const messaging = { send: vi.fn().mockResolvedValue("projects/x/messages/123") };
     const res: FcmResult = await sendFcm(
       { token: "fcm-tok", title: "Hi", body: "Hello", deepLink: "kryton://x" },
-      { messaging: messaging as any },
+      { messaging: messaging as unknown as FcmDeps["messaging"] },
     );
     expect(res).toEqual({ ok: true });
   });
@@ -21,7 +21,7 @@ describe("sendFcm", () => {
     };
     const res = await sendFcm(
       { token: "fcm-tok", title: "Hi", body: "Hello" },
-      { messaging: messaging as any },
+      { messaging: messaging as unknown as FcmDeps["messaging"] },
     );
     expect(res).toEqual({
       ok: false,
@@ -38,7 +38,7 @@ describe("sendFcm", () => {
     };
     const res = await sendFcm(
       { token: "fcm-tok", title: "Hi", body: "Hello" },
-      { messaging: messaging as any },
+      { messaging: messaging as unknown as FcmDeps["messaging"] },
     );
     expect(res).toEqual({ ok: false, permanent: false, reason: "messaging/internal-error" });
   });

--- a/packages/server/src/modules/identity/__tests__/notifications.routes.test.ts
+++ b/packages/server/src/modules/identity/__tests__/notifications.routes.test.ts
@@ -1,0 +1,91 @@
+import Fastify from "fastify";
+import { afterEach, describe, expect, it } from "vitest";
+import { zodPlugin } from "../../../plugins/zod.js";
+import { errorsPlugin } from "../../../plugins/errors.js";
+import { AuthError } from "../../../lib/errors.js";
+import type { AuthApi } from "../../../plugins/auth.js";
+import { notificationsRoutes } from "../routes/notifications.routes.js";
+
+/**
+ * SSE stream tests.
+ *
+ * Full streaming behaviour (heartbeat, live event delivery) is not testable via
+ * Fastify's `app.inject()` because inject() does not support long-lived
+ * connections. These tests verify auth enforcement and route registration only.
+ * End-to-end streaming is verified manually / in CI integration tests.
+ */
+
+/**
+ * Build a minimal Fastify app that only mounts notificationsRoutes with a
+ * stubbed auth layer. No DB required — this is a pure unit test.
+ */
+async function buildNotificationsTestApp(opts: { authenticated: boolean }) {
+  const app = Fastify({ logger: false });
+
+  await app.register(zodPlugin);
+
+  const authApi: AuthApi = {
+    instance: {} as never,
+    async resolve() {
+      return null;
+    },
+    async requireUser() {
+      if (!opts.authenticated) throw new AuthError("Missing or invalid session");
+      return { id: "unit-user", email: "unit@test.local", name: "unit", role: "user" };
+    },
+    async requireAuth() {
+      if (!opts.authenticated) throw new AuthError("Missing or invalid session");
+      return {
+        user: { id: "unit-user", email: "unit@test.local", name: "unit", role: "user" },
+        apiKey: null,
+        agentId: null,
+      };
+    },
+    async getOptionalUser() {
+      return null;
+    },
+    async requireAdmin() {
+      throw new AuthError("not needed");
+    },
+    requireWriteScope() {},
+    requireSession() {},
+    async authenticateWsToken() {
+      return null;
+    },
+  };
+
+  app.decorate("auth", authApi);
+  await app.register(errorsPlugin);
+  await app.register(notificationsRoutes);
+  await app.ready();
+  return app;
+}
+
+describe("identity / notifications routes", () => {
+  let close: (() => Promise<void>) | null = null;
+
+  afterEach(async () => {
+    if (close) await close();
+    close = null;
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    const app = await buildNotificationsTestApp({ authenticated: false });
+    close = () => app.close();
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/notifications/stream",
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("route is registered and visible in the route table", async () => {
+    const app = await buildNotificationsTestApp({ authenticated: true });
+    close = () => app.close();
+
+    const routes = app.printRoutes();
+    expect(routes).toContain("api/notifications/stream");
+  });
+});

--- a/packages/server/src/modules/identity/__tests__/passkey-origin.test.ts
+++ b/packages/server/src/modules/identity/__tests__/passkey-origin.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { buildPasskeyOrigins } from "../auth-config.js";
+
+describe("buildPasskeyOrigins", () => {
+  it("returns only the web origin when no mobile env vars are set", () => {
+    const origins = buildPasskeyOrigins({ APP_URL: "https://kryton.example.com" });
+    expect(origins).toEqual(["https://kryton.example.com"]);
+  });
+
+  it("includes ios:bundle-id origin when MOBILE_IOS_BUNDLE_ID is set", () => {
+    const origins = buildPasskeyOrigins({
+      APP_URL: "https://kryton.example.com",
+      MOBILE_IOS_BUNDLE_ID: "com.kryton.mobile",
+    });
+    expect(origins).toEqual([
+      "https://kryton.example.com",
+      "ios:bundle-id:com.kryton.mobile",
+    ]);
+  });
+
+  it("includes android:apk-key-hash origin when MOBILE_ANDROID_APK_KEY_HASH is set", () => {
+    const origins = buildPasskeyOrigins({
+      APP_URL: "https://kryton.example.com",
+      MOBILE_ANDROID_APK_KEY_HASH: "abc123base64url",
+    });
+    expect(origins).toEqual([
+      "https://kryton.example.com",
+      "android:apk-key-hash:abc123base64url",
+    ]);
+  });
+
+  it("includes all three origins when both mobile env vars are set", () => {
+    const origins = buildPasskeyOrigins({
+      APP_URL: "https://kryton.example.com",
+      MOBILE_IOS_BUNDLE_ID: "com.kryton.mobile",
+      MOBILE_ANDROID_APK_KEY_HASH: "abc123base64url",
+    });
+    expect(origins).toEqual([
+      "https://kryton.example.com",
+      "ios:bundle-id:com.kryton.mobile",
+      "android:apk-key-hash:abc123base64url",
+    ]);
+  });
+
+  it("falls back to localhost origin when APP_URL is not set", () => {
+    const origins = buildPasskeyOrigins({});
+    expect(origins).toEqual(["http://localhost:5173"]);
+  });
+});

--- a/packages/server/src/modules/identity/__tests__/push.test.ts
+++ b/packages/server/src/modules/identity/__tests__/push.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { pushDevices } from "../../../db/schema/push.js";
+import type { TestDbHandle } from "../../../test/db-fixture.js";
+import {
+  buildIdentityTestApp,
+  cleanupIdentityTestUser,
+  createIdentityTestDb,
+  createIdentityTestUser,
+  seedIdentityTestUser,
+} from "./helpers.js";
+
+const TEST_USER = createIdentityTestUser("push");
+
+describe("identity / push routes", () => {
+  let dbHandle: TestDbHandle;
+  let close: (() => Promise<void>) | null = null;
+
+  beforeAll(async () => {
+    dbHandle = createIdentityTestDb();
+    await seedIdentityTestUser(dbHandle, TEST_USER);
+  });
+  afterAll(async () => {
+    await cleanupIdentityTestUser(dbHandle, TEST_USER.id);
+    await dbHandle.close();
+  });
+  beforeEach(async () => {
+    await dbHandle.db.delete(pushDevices).where(eq(pushDevices.userId, TEST_USER.id));
+  });
+  afterEach(async () => {
+    if (close) await close();
+    close = null;
+  });
+
+  describe("POST /api/push/register", () => {
+    it("registers a new device for the authenticated user", async () => {
+      const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
+      close = () => app.close();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/push/register",
+        payload: { platform: "ios", token: "apns-token-aaaa" },
+      });
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body).toMatchObject({ id: expect.any(String), platform: "ios" });
+
+      const rows = await dbHandle.db
+        .select()
+        .from(pushDevices)
+        .where(eq(pushDevices.userId, TEST_USER.id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].token).toBe("apns-token-aaaa");
+    });
+
+    it("upserts when the same (platform, token) is registered again", async () => {
+      const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
+      close = () => app.close();
+
+      await app.inject({
+        method: "POST",
+        url: "/api/push/register",
+        payload: { platform: "ios", token: "apns-token-bbbb" },
+      });
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/push/register",
+        payload: { platform: "ios", token: "apns-token-bbbb" },
+      });
+      expect(res.statusCode).toBe(200);
+
+      const rows = await dbHandle.db
+        .select()
+        .from(pushDevices)
+        .where(eq(pushDevices.userId, TEST_USER.id));
+      expect(rows).toHaveLength(1);
+    });
+
+    it("rejects unauthenticated requests with 401", async () => {
+      const app = await buildIdentityTestApp({ user: null, dbHandle });
+      close = () => app.close();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/push/register",
+        payload: { platform: "ios", token: "x" },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("rejects invalid platform with 400", async () => {
+      const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
+      close = () => app.close();
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/push/register",
+        payload: { platform: "windows", token: "x" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe("DELETE /api/push/register/:id", () => {
+    it("deletes an owned device and returns 204", async () => {
+      const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
+      close = () => app.close();
+
+      const createRes = await app.inject({
+        method: "POST",
+        url: "/api/push/register",
+        payload: { platform: "android", token: "fcm-token-cccc" },
+      });
+      expect(createRes.statusCode).toBe(201);
+      const { id } = createRes.json();
+
+      const delRes = await app.inject({
+        method: "DELETE",
+        url: `/api/push/register/${id}`,
+      });
+      expect(delRes.statusCode).toBe(204);
+
+      const rows = await dbHandle.db
+        .select()
+        .from(pushDevices)
+        .where(eq(pushDevices.userId, TEST_USER.id));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("returns 404 for an unknown device id", async () => {
+      const app = await buildIdentityTestApp({ user: TEST_USER, dbHandle });
+      close = () => app.close();
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: "/api/push/register/nonexistent-id",
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/packages/server/src/modules/identity/auth-config.ts
+++ b/packages/server/src/modules/identity/auth-config.ts
@@ -174,11 +174,18 @@ export function createAuth(db: Db) {
     },
 
     session: {
-      expiresIn: 60 * 60 * 24 * 7, // 7 days
-      updateAge: 60 * 60 * 24, // 1 day
+      expiresIn: 60 * 60 * 24 * 60, // 60 days (2 months)
+      updateAge: 60 * 60 * 24, // 1 day — sliding: each use within the window extends expiry to now + expiresIn
+      // cookieCache is intentionally DISABLED. It stores the session in a short-lived
+      // signed `session_data` cookie (5 min) that the server refreshes via Set-Cookie.
+      // Browsers adopt the refresh automatically, but native mobile clients (React
+      // Native) cache the original cookies in the OkHttp cookie jar and re-send the
+      // stale `session_data`. Once it expires, better-auth's getSession returns null
+      // *before* the DB fallback (api/routes/session.ts), logging mobile users out
+      // every ~5 minutes. With cookieCache off, every request validates the
+      // `session_token` against the DB directly — stable for the full session lifetime.
       cookieCache: {
-        enabled: true,
-        maxAge: 300, // 5 minutes
+        enabled: false,
       },
     },
 

--- a/packages/server/src/modules/identity/auth-config.ts
+++ b/packages/server/src/modules/identity/auth-config.ts
@@ -16,6 +16,31 @@ const log = createLogger("auth");
 const APP_URL = process.env.APP_URL || "http://localhost:5173";
 
 /**
+ * Build the list of origins that the passkey plugin will accept.
+ *
+ * In addition to the web origin (`APP_URL`), mobile passkey ceremonies require
+ * platform-specific origins:
+ *   - iOS:     `ios:bundle-id:<MOBILE_IOS_BUNDLE_ID>`
+ *   - Android: `android:apk-key-hash:<MOBILE_ANDROID_APK_KEY_HASH>`
+ *
+ * Note: `MOBILE_ANDROID_APK_KEY_HASH` is the base64url-encoded SHA-256 of the
+ * signing *public key* — distinct from the colon-separated certificate
+ * fingerprints in `MOBILE_ANDROID_SHA256_FINGERPRINTS` (used for assetlinks.json).
+ *
+ * All mobile env vars are optional; when unset the function returns only the
+ * web origin so existing deployments are unaffected.
+ */
+export function buildPasskeyOrigins(env: NodeJS.ProcessEnv = process.env): string[] {
+  return [
+    env.APP_URL || "http://localhost:5173",
+    ...(env.MOBILE_IOS_BUNDLE_ID ? [`ios:bundle-id:${env.MOBILE_IOS_BUNDLE_ID}`] : []),
+    ...(env.MOBILE_ANDROID_APK_KEY_HASH
+      ? [`android:apk-key-hash:${env.MOBILE_ANDROID_APK_KEY_HASH}`]
+      : []),
+  ];
+}
+
+/**
  * Extra origins (beyond APP_URL) that better-auth will accept. Modules
  * that learn additional public origins at runtime — most notably the
  * tunnel module, once a JWT is configured — push them in via
@@ -119,7 +144,7 @@ export function createAuth(db: Db) {
       passkey({
         rpName: "Kryton",
         rpID: process.env.WEBAUTHN_RP_ID || "localhost",
-        origin: APP_URL,
+        origin: buildPasskeyOrigins(),
       }),
       twoFactor({
         issuer: "Kryton",

--- a/packages/server/src/modules/identity/index.ts
+++ b/packages/server/src/modules/identity/index.ts
@@ -30,31 +30,47 @@ const identityModuleImpl: FastifyPluginAsync = async (app) => {
   // Guard on `app.hasDecorator("config")` so unit tests that build a minimal
   // Fastify instance without the config decorator don't fail here.
   const cfg = app.hasDecorator("config") ? app.config : null;
-  if (cfg?.APNS_KEY_PATH && cfg?.FCM_SERVICE_ACCOUNT_PATH) {
+  // Require EVERY APNs + FCM field the dispatcher dereferences below, not just
+  // the two path vars — a partial config would otherwise crash at startup on
+  // the non-null assertions.
+  const pushConfigured =
+    !!cfg?.APNS_KEY_PATH &&
+    !!cfg?.APNS_KEY_ID &&
+    !!cfg?.APNS_TEAM_ID &&
+    !!cfg?.APNS_BUNDLE_ID &&
+    !!cfg?.FCM_SERVICE_ACCOUNT_PATH &&
+    !!cfg?.FCM_PROJECT_ID;
+  if (cfg && pushConfigured) {
     const provider = getDefaultProvider({
-      keyPath: cfg.APNS_KEY_PATH,
+      keyPath: cfg.APNS_KEY_PATH!,
       keyId: cfg.APNS_KEY_ID!,
       teamId: cfg.APNS_TEAM_ID!,
       production: cfg.APNS_PRODUCTION ?? false,
     });
     const messaging = getDefaultMessaging({
-      serviceAccountPath: cfg.FCM_SERVICE_ACCOUNT_PATH,
+      serviceAccountPath: cfg.FCM_SERVICE_ACCOUNT_PATH!,
       projectId: cfg.FCM_PROJECT_ID!,
     });
-    notificationBus.onAfterPublish(async (event) =>
-      dispatchPush(event, {
-        sendApns: (p) => sendApns(p, { provider, bundleId: cfg.APNS_BUNDLE_ID! }),
-        sendFcm: (p) => sendFcm(p, { messaging }),
-        listDevices: async (userId) =>
-          app.db
-            .select({ id: pushDevices.id, platform: pushDevices.platform, token: pushDevices.token })
-            .from(pushDevices)
-            .where(eq(pushDevices.userId, userId)),
-        prune: async (id) => {
-          await app.db.delete(pushDevices).where(eq(pushDevices.id, id));
-        },
-      }),
-    );
+    notificationBus.onAfterPublish(async (event) => {
+      // Push delivery is best-effort: never let a send failure reject
+      // NotificationBus.publish() and break the path that emitted the event.
+      try {
+        await dispatchPush(event, {
+          sendApns: (p) => sendApns(p, { provider, bundleId: cfg.APNS_BUNDLE_ID! }),
+          sendFcm: (p) => sendFcm(p, { messaging }),
+          listDevices: async (userId) =>
+            app.db
+              .select({ id: pushDevices.id, platform: pushDevices.platform, token: pushDevices.token })
+              .from(pushDevices)
+              .where(eq(pushDevices.userId, userId)),
+          prune: async (id) => {
+            await app.db.delete(pushDevices).where(eq(pushDevices.id, id));
+          },
+        });
+      } catch (err) {
+        app.log.error({ err }, "push dispatch failed");
+      }
+    });
     app.log.info("push dispatcher wired");
   } else {
     app.log.warn("push dispatcher disabled (APNS_* and FCM_* env vars not set)");

--- a/packages/server/src/modules/identity/index.ts
+++ b/packages/server/src/modules/identity/index.ts
@@ -3,6 +3,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { ApiKeyService } from "./services/api-key.service.js";
 import { usersRoutes } from "./routes/users.routes.js";
 import { apiKeysRoutes } from "./routes/api-keys.routes.js";
+import { pushRoutes } from "./routes/push.routes.js";
 
 const identityModuleImpl: FastifyPluginAsync = async (app) => {
   const apiKeyService = new ApiKeyService(app);
@@ -13,6 +14,7 @@ const identityModuleImpl: FastifyPluginAsync = async (app) => {
 
   await app.register(usersRoutes, { prefix: "/api/users" });
   await app.register(apiKeysRoutes({ apiKeyService }), { prefix: "/api/api-keys" });
+  await app.register(pushRoutes, { prefix: "/api/push" });
 };
 
 /**

--- a/packages/server/src/modules/identity/index.ts
+++ b/packages/server/src/modules/identity/index.ts
@@ -4,6 +4,13 @@ import { ApiKeyService } from "./services/api-key.service.js";
 import { usersRoutes } from "./routes/users.routes.js";
 import { apiKeysRoutes } from "./routes/api-keys.routes.js";
 import { pushRoutes } from "./routes/push.routes.js";
+import { notificationsRoutes } from "./routes/notifications.routes.js";
+import { notificationBus } from "./services/notifications/bus.js";
+import { dispatchPush } from "./services/push/dispatcher.js";
+import { sendApns, getDefaultProvider } from "./services/push/apns.js";
+import { sendFcm, getDefaultMessaging } from "./services/push/fcm.js";
+import { pushDevices } from "../../db/schema/push.js";
+import { eq } from "drizzle-orm";
 
 const identityModuleImpl: FastifyPluginAsync = async (app) => {
   const apiKeyService = new ApiKeyService(app);
@@ -15,6 +22,43 @@ const identityModuleImpl: FastifyPluginAsync = async (app) => {
   await app.register(usersRoutes, { prefix: "/api/users" });
   await app.register(apiKeysRoutes({ apiKeyService }), { prefix: "/api/api-keys" });
   await app.register(pushRoutes, { prefix: "/api/push" });
+  await app.register(notificationsRoutes);
+
+  // Wire the push dispatcher to the notification bus. Only active when both
+  // APNs and FCM credentials are configured; otherwise a warning is logged and
+  // background push delivery is skipped (SSE stream still works).
+  // Guard on `app.hasDecorator("config")` so unit tests that build a minimal
+  // Fastify instance without the config decorator don't fail here.
+  const cfg = app.hasDecorator("config") ? app.config : null;
+  if (cfg?.APNS_KEY_PATH && cfg?.FCM_SERVICE_ACCOUNT_PATH) {
+    const provider = getDefaultProvider({
+      keyPath: cfg.APNS_KEY_PATH,
+      keyId: cfg.APNS_KEY_ID!,
+      teamId: cfg.APNS_TEAM_ID!,
+      production: cfg.APNS_PRODUCTION ?? false,
+    });
+    const messaging = getDefaultMessaging({
+      serviceAccountPath: cfg.FCM_SERVICE_ACCOUNT_PATH,
+      projectId: cfg.FCM_PROJECT_ID!,
+    });
+    notificationBus.onAfterPublish(async (event) =>
+      dispatchPush(event, {
+        sendApns: (p) => sendApns(p, { provider, bundleId: cfg.APNS_BUNDLE_ID! }),
+        sendFcm: (p) => sendFcm(p, { messaging }),
+        listDevices: async (userId) =>
+          app.db
+            .select({ id: pushDevices.id, platform: pushDevices.platform, token: pushDevices.token })
+            .from(pushDevices)
+            .where(eq(pushDevices.userId, userId)),
+        prune: async (id) => {
+          await app.db.delete(pushDevices).where(eq(pushDevices.id, id));
+        },
+      }),
+    );
+    app.log.info("push dispatcher wired");
+  } else {
+    app.log.warn("push dispatcher disabled (APNS_* and FCM_* env vars not set)");
+  }
 };
 
 /**

--- a/packages/server/src/modules/identity/routes/notifications.routes.ts
+++ b/packages/server/src/modules/identity/routes/notifications.routes.ts
@@ -18,6 +18,11 @@ export const notificationsRoutes: FastifyPluginAsync = async (app) => {
     const { user } = await app.auth.requireAuth(req);
     const userId = user.id;
 
+    // Take over the response lifecycle: we stream via reply.raw and never let
+    // Fastify serialize/send a payload. Without hijack() Fastify would attempt
+    // to send a response when this handler resolves ("Reply was already sent").
+    reply.hijack();
+
     reply.raw.writeHead(200, {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache, no-transform",

--- a/packages/server/src/modules/identity/routes/notifications.routes.ts
+++ b/packages/server/src/modules/identity/routes/notifications.routes.ts
@@ -1,0 +1,46 @@
+import type { FastifyPluginAsync } from "fastify";
+import { notificationBus, type NotificationEvent } from "../services/notifications/bus.js";
+
+/**
+ * Notification SSE stream route.
+ *
+ * GET /api/notifications/stream — streams NotificationEvent objects as
+ * server-sent events for the authenticated user. Events are formatted as:
+ *
+ *   event: notification
+ *   data: <JSON>
+ *
+ * A `: ping` comment is written every 25 seconds to keep proxies from
+ * idle-closing the connection.
+ */
+export const notificationsRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/api/notifications/stream", async (req, reply) => {
+    const { user } = await app.auth.requireAuth(req);
+    const userId = user.id;
+
+    reply.raw.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    });
+
+    const write = (event: NotificationEvent) => {
+      reply.raw.write(`event: notification\ndata: ${JSON.stringify(event)}\n\n`);
+    };
+
+    const unsub = notificationBus.subscribe(userId, write);
+
+    // Heartbeat every 25 s to keep proxies from idle-closing the connection.
+    const heartbeat = setInterval(() => reply.raw.write(": ping\n\n"), 25_000);
+
+    const close = () => {
+      clearInterval(heartbeat);
+      unsub();
+      reply.raw.end();
+    };
+
+    req.raw.on("close", close);
+    req.raw.on("error", close);
+  });
+};

--- a/packages/server/src/modules/identity/routes/push.routes.ts
+++ b/packages/server/src/modules/identity/routes/push.routes.ts
@@ -1,0 +1,80 @@
+import type { FastifyPluginAsync } from "fastify";
+import type { ZodTypeProvider } from "fastify-type-provider-zod";
+import { z } from "zod";
+import { NotFoundError } from "../../../lib/errors.js";
+import { registerDevice, deregisterDevice } from "../services/push-devices.js";
+
+const registerBodySchema = z.object({
+  platform: z.enum(["ios", "android"]),
+  token: z.string().min(1).max(2048),
+});
+
+const registerResponseSchema = z.object({
+  id: z.string(),
+  platform: z.enum(["ios", "android"]),
+});
+
+const deviceIdParamsSchema = z.object({
+  id: z.string(),
+});
+
+/**
+ * Push notification device registration routes — mounted under `/api/push`.
+ *
+ * POST /register    — register (or re-register) a device token
+ * DELETE /register/:id — deregister a device by DB id
+ */
+export const pushRoutes: FastifyPluginAsync = async (app) => {
+  const typed = app.withTypeProvider<ZodTypeProvider>();
+
+  typed.post(
+    "/register",
+    {
+      schema: {
+        tags: ["push"],
+        summary: "Register a push notification device token",
+        body: registerBodySchema,
+        response: {
+          200: registerResponseSchema,
+          201: registerResponseSchema,
+        },
+      },
+      preHandler: async (req) => {
+        await app.auth.requireAuth(req);
+      },
+    },
+    async (req, reply) => {
+      const ctx = await app.auth.requireAuth(req);
+      const { platform, token } = req.body;
+      const { device, created } = await registerDevice(app.db, {
+        userId: ctx.user.id,
+        platform,
+        token,
+      });
+      reply.status(created ? 201 : 200);
+      return { id: device.id, platform: device.platform as "ios" | "android" };
+    },
+  );
+
+  typed.delete(
+    "/register/:id",
+    {
+      schema: {
+        tags: ["push"],
+        summary: "Deregister a push notification device",
+        params: deviceIdParamsSchema,
+        response: { 204: z.null() },
+      },
+      preHandler: async (req) => {
+        await app.auth.requireAuth(req);
+      },
+    },
+    async (req, reply) => {
+      const ctx = await app.auth.requireAuth(req);
+      const ok = await deregisterDevice(app.db, { userId: ctx.user.id, id: req.params.id });
+      if (!ok) throw new NotFoundError("Device not found");
+      reply.status(204);
+      return null;
+    },
+  );
+};

--- a/packages/server/src/modules/identity/services/notifications/bus.ts
+++ b/packages/server/src/modules/identity/services/notifications/bus.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from "node:events";
+
+export interface NotificationEvent {
+  id: string;
+  userId: string;
+  kind: "share-invite" | "mention" | "deadline" | "custom";
+  title: string;
+  body: string;
+  createdAt: string;
+  deepLink?: string;
+}
+
+export type Subscriber = (event: NotificationEvent) => void;
+
+export class NotificationBus {
+  private readonly emitter = new EventEmitter();
+  private readonly afterPublishHooks: Array<(e: NotificationEvent) => Promise<void> | void> = [];
+
+  constructor() {
+    this.emitter.setMaxListeners(0);
+  }
+
+  subscribe(userId: string, fn: Subscriber): () => void {
+    this.emitter.on(userId, fn);
+    return () => this.emitter.off(userId, fn);
+  }
+
+  async publish(event: NotificationEvent): Promise<void> {
+    this.emitter.emit(event.userId, event);
+    for (const hook of this.afterPublishHooks) {
+      await hook(event);
+    }
+  }
+
+  onAfterPublish(hook: (e: NotificationEvent) => Promise<void> | void): () => void {
+    this.afterPublishHooks.push(hook);
+    return () => {
+      const i = this.afterPublishHooks.indexOf(hook);
+      if (i >= 0) this.afterPublishHooks.splice(i, 1);
+    };
+  }
+}
+
+export const notificationBus = new NotificationBus();

--- a/packages/server/src/modules/identity/services/push-devices.ts
+++ b/packages/server/src/modules/identity/services/push-devices.ts
@@ -1,0 +1,50 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { Db } from "../../../db/client.js";
+import { pushDevices, type PushDevice } from "../../../db/schema/push.js";
+
+export type Platform = "ios" | "android";
+
+export async function registerDevice(
+  db: Db,
+  input: { userId: string; platform: Platform; token: string },
+): Promise<{ device: PushDevice; created: boolean }> {
+  const existing = await db
+    .select()
+    .from(pushDevices)
+    .where(and(eq(pushDevices.platform, input.platform), eq(pushDevices.token, input.token)))
+    .limit(1);
+
+  if (existing[0]) {
+    // Same (platform, token) already registered — update lastSeenAt and re-assign
+    // owner if the device was handed off to a different user.
+    const updates: Partial<{ userId: string; lastSeenAt: ReturnType<typeof sql> }> = {
+      lastSeenAt: sql`now()`,
+    };
+    if (existing[0].userId !== input.userId) {
+      updates.userId = input.userId;
+    }
+    const [updated] = await db
+      .update(pushDevices)
+      .set(updates)
+      .where(eq(pushDevices.id, existing[0].id))
+      .returning();
+    return { device: updated, created: false };
+  }
+
+  const [created] = await db
+    .insert(pushDevices)
+    .values({ userId: input.userId, platform: input.platform, token: input.token })
+    .returning();
+  return { device: created, created: true };
+}
+
+export async function deregisterDevice(
+  db: Db,
+  input: { userId: string; id: string },
+): Promise<boolean> {
+  const deleted = await db
+    .delete(pushDevices)
+    .where(and(eq(pushDevices.userId, input.userId), eq(pushDevices.id, input.id)))
+    .returning();
+  return deleted.length > 0;
+}

--- a/packages/server/src/modules/identity/services/push/apns.ts
+++ b/packages/server/src/modules/identity/services/push/apns.ts
@@ -1,0 +1,58 @@
+import { Notification, Provider } from "@parse/node-apn";
+
+export interface ApnsPayload {
+  token: string;
+  title: string;
+  body: string;
+  deepLink?: string;
+  /** Opaque event ID, deduped client-side against the SSE stream. */
+  eventId?: string;
+}
+
+export type ApnsResult =
+  | { ok: true }
+  | { ok: false; permanent: boolean; reason: string };
+
+export interface ApnsDeps {
+  provider: Pick<Provider, "send">;
+  bundleId: string;
+}
+
+const PERMANENT_REASONS = new Set([
+  "BadDeviceToken",
+  "Unregistered",
+  "DeviceTokenNotForTopic",
+  "BadCertificate",
+  "BadCertificateEnvironment",
+]);
+
+export async function sendApns(payload: ApnsPayload, deps: ApnsDeps): Promise<ApnsResult> {
+  const note = new Notification();
+  note.topic = deps.bundleId;
+  note.alert = { title: payload.title, body: payload.body };
+  note.sound = "default";
+  if (payload.deepLink) note.payload = { ...note.payload, deepLink: payload.deepLink };
+  if (payload.eventId) note.payload = { ...note.payload, eventId: payload.eventId };
+
+  const result = await deps.provider.send(note, payload.token);
+  if (result.sent.length > 0) return { ok: true };
+  const fail = result.failed[0];
+  const reason = (fail?.response as { reason?: string } | undefined)?.reason ?? "Unknown";
+  const permanent = PERMANENT_REASONS.has(reason) || fail?.status === "410";
+  return { ok: false, permanent, reason };
+}
+
+let cachedProvider: Provider | null = null;
+export function getDefaultProvider(opts: {
+  keyPath: string;
+  keyId: string;
+  teamId: string;
+  production: boolean;
+}): Provider {
+  if (cachedProvider) return cachedProvider;
+  cachedProvider = new Provider({
+    token: { key: opts.keyPath, keyId: opts.keyId, teamId: opts.teamId },
+    production: opts.production,
+  });
+  return cachedProvider;
+}

--- a/packages/server/src/modules/identity/services/push/apns.ts
+++ b/packages/server/src/modules/identity/services/push/apns.ts
@@ -34,7 +34,14 @@ export async function sendApns(payload: ApnsPayload, deps: ApnsDeps): Promise<Ap
   if (payload.deepLink) note.payload = { ...note.payload, deepLink: payload.deepLink };
   if (payload.eventId) note.payload = { ...note.payload, eventId: payload.eventId };
 
-  const result = await deps.provider.send(note, payload.token);
+  let result: Awaited<ReturnType<Provider["send"]>>;
+  try {
+    result = await deps.provider.send(note, payload.token);
+  } catch (err) {
+    // The APNs client can throw on transient network/TLS errors. Map to a
+    // transient failure (matching sendFcm) rather than letting it bubble up.
+    return { ok: false, permanent: false, reason: err instanceof Error ? err.message : "send_threw" };
+  }
   if (result.sent.length > 0) return { ok: true };
   const fail = result.failed[0];
   const reason = (fail?.response as { reason?: string } | undefined)?.reason ?? "Unknown";

--- a/packages/server/src/modules/identity/services/push/apns.ts
+++ b/packages/server/src/modules/identity/services/push/apns.ts
@@ -38,7 +38,7 @@ export async function sendApns(payload: ApnsPayload, deps: ApnsDeps): Promise<Ap
   if (result.sent.length > 0) return { ok: true };
   const fail = result.failed[0];
   const reason = (fail?.response as { reason?: string } | undefined)?.reason ?? "Unknown";
-  const permanent = PERMANENT_REASONS.has(reason) || fail?.status === "410";
+  const permanent = PERMANENT_REASONS.has(reason) || fail?.status === 410;
   return { ok: false, permanent, reason };
 }
 

--- a/packages/server/src/modules/identity/services/push/dispatcher.ts
+++ b/packages/server/src/modules/identity/services/push/dispatcher.ts
@@ -1,0 +1,40 @@
+import type { NotificationEvent } from "../notifications/bus.js";
+import type { ApnsResult } from "./apns.js";
+import type { FcmResult } from "./fcm.js";
+
+export interface DispatcherDeps {
+  sendApns: (payload: {
+    token: string;
+    title: string;
+    body: string;
+    deepLink?: string;
+    eventId?: string;
+  }) => Promise<ApnsResult>;
+  sendFcm: (payload: {
+    token: string;
+    title: string;
+    body: string;
+    deepLink?: string;
+    eventId?: string;
+  }) => Promise<FcmResult>;
+  listDevices: (userId: string) => Promise<Array<{ id: string; platform: "ios" | "android"; token: string }>>;
+  prune: (deviceId: string) => Promise<void>;
+}
+
+export async function dispatchPush(event: NotificationEvent, deps: DispatcherDeps): Promise<void> {
+  const devices = await deps.listDevices(event.userId);
+  await Promise.all(
+    devices.map(async (d) => {
+      const payload = {
+        token: d.token,
+        title: event.title,
+        body: event.body,
+        deepLink: event.deepLink,
+        eventId: event.id,
+      };
+      const result =
+        d.platform === "ios" ? await deps.sendApns(payload) : await deps.sendFcm(payload);
+      if (!result.ok && result.permanent) await deps.prune(d.id);
+    }),
+  );
+}

--- a/packages/server/src/modules/identity/services/push/fcm.ts
+++ b/packages/server/src/modules/identity/services/push/fcm.ts
@@ -1,0 +1,53 @@
+import admin from "firebase-admin";
+
+export interface FcmPayload {
+  token: string;
+  title: string;
+  body: string;
+  deepLink?: string;
+  eventId?: string;
+}
+
+export type FcmResult =
+  | { ok: true }
+  | { ok: false; permanent: boolean; reason: string };
+
+export interface FcmDeps {
+  messaging: Pick<admin.messaging.Messaging, "send">;
+}
+
+const PERMANENT_CODES = new Set([
+  "messaging/registration-token-not-registered",
+  "messaging/invalid-registration-token",
+  "messaging/invalid-argument",
+  "messaging/mismatched-credential",
+]);
+
+export async function sendFcm(payload: FcmPayload, deps: FcmDeps): Promise<FcmResult> {
+  try {
+    await deps.messaging.send({
+      token: payload.token,
+      notification: { title: payload.title, body: payload.body },
+      data: {
+        ...(payload.deepLink ? { deepLink: payload.deepLink } : {}),
+        ...(payload.eventId ? { eventId: payload.eventId } : {}),
+      },
+    });
+    return { ok: true };
+  } catch (err) {
+    const code = (err as { code?: string }).code ?? "unknown";
+    const permanent = PERMANENT_CODES.has(code);
+    return { ok: false, permanent, reason: code };
+  }
+}
+
+let cachedApp: admin.app.App | null = null;
+export function getDefaultMessaging(opts: { serviceAccountPath: string; projectId: string }) {
+  if (!cachedApp) {
+    cachedApp = admin.initializeApp({
+      credential: admin.credential.cert(opts.serviceAccountPath),
+      projectId: opts.projectId,
+    });
+  }
+  return cachedApp.messaging();
+}

--- a/packages/server/src/modules/identity/services/push/fcm.ts
+++ b/packages/server/src/modules/identity/services/push/fcm.ts
@@ -42,7 +42,10 @@ export async function sendFcm(payload: FcmPayload, deps: FcmDeps): Promise<FcmRe
 }
 
 let cachedApp: admin.app.App | null = null;
-export function getDefaultMessaging(opts: { serviceAccountPath: string; projectId: string }) {
+export function getDefaultMessaging(opts: {
+  serviceAccountPath: string;
+  projectId: string;
+}): admin.messaging.Messaging {
   if (!cachedApp) {
     cachedApp = admin.initializeApp({
       credential: admin.credential.cert(opts.serviceAccountPath),

--- a/packages/server/src/modules/platform/__tests__/well-known.routes.test.ts
+++ b/packages/server/src/modules/platform/__tests__/well-known.routes.test.ts
@@ -1,0 +1,137 @@
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { wellKnownRoutes } from "../routes/well-known.routes.js";
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(wellKnownRoutes);
+  await app.ready();
+  return app;
+}
+
+describe(".well-known routes", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await buildApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Apple App Site Association
+  // ---------------------------------------------------------------------------
+
+  describe("GET /.well-known/apple-app-site-association", () => {
+    it("returns 200 with applinks and webcredentials when both env vars are set", async () => {
+      process.env.MOBILE_IOS_TEAM_ID = "ABCDE12345";
+      process.env.MOBILE_IOS_BUNDLE_ID = "com.kryton.mobile";
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/.well-known/apple-app-site-association",
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toContain("application/json");
+
+      const body = JSON.parse(res.body);
+      const appId = "ABCDE12345.com.kryton.mobile";
+
+      expect(body.applinks).toBeDefined();
+      expect(body.applinks.details[0].appIDs).toContain(appId);
+      expect(body.applinks.details[0].components).toEqual([{ "/": "/*" }]);
+
+      expect(body.webcredentials).toBeDefined();
+      expect(body.webcredentials.apps).toContain(appId);
+    });
+
+    it("returns 404 when MOBILE_IOS_TEAM_ID is missing", async () => {
+      delete process.env.MOBILE_IOS_TEAM_ID;
+      process.env.MOBILE_IOS_BUNDLE_ID = "com.kryton.mobile";
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/.well-known/apple-app-site-association",
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("returns 404 when MOBILE_IOS_BUNDLE_ID is missing", async () => {
+      process.env.MOBILE_IOS_TEAM_ID = "ABCDE12345";
+      delete process.env.MOBILE_IOS_BUNDLE_ID;
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/.well-known/apple-app-site-association",
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Android Asset Links
+  // ---------------------------------------------------------------------------
+
+  describe("GET /.well-known/assetlinks.json", () => {
+    it("returns 200 with both delegate_permission entries and parsed fingerprints when env vars are set", async () => {
+      process.env.MOBILE_ANDROID_PACKAGE = "com.kryton.mobile";
+      process.env.MOBILE_ANDROID_SHA256_FINGERPRINTS =
+        "AA:BB:CC:DD,EE:FF:00:11";
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/.well-known/assetlinks.json",
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toContain("application/json");
+
+      const body = JSON.parse(res.body) as Array<{
+        relation: string[];
+        target: { namespace: string; package_name: string; sha256_cert_fingerprints: string[] };
+      }>;
+
+      expect(Array.isArray(body)).toBe(true);
+      expect(body).toHaveLength(2);
+
+      const relations = body.map((e) => e.relation[0]);
+      expect(relations).toContain("delegate_permission/common.handle_all_urls");
+      expect(relations).toContain("delegate_permission/common.get_login_creds");
+
+      const target = body[0].target;
+      expect(target.namespace).toBe("android_app");
+      expect(target.package_name).toBe("com.kryton.mobile");
+      expect(target.sha256_cert_fingerprints).toEqual(["AA:BB:CC:DD", "EE:FF:00:11"]);
+    });
+
+    it("returns 404 when MOBILE_ANDROID_PACKAGE is missing", async () => {
+      delete process.env.MOBILE_ANDROID_PACKAGE;
+      process.env.MOBILE_ANDROID_SHA256_FINGERPRINTS = "AA:BB:CC:DD";
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/.well-known/assetlinks.json",
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("returns 404 when MOBILE_ANDROID_SHA256_FINGERPRINTS is missing", async () => {
+      process.env.MOBILE_ANDROID_PACKAGE = "com.kryton.mobile";
+      delete process.env.MOBILE_ANDROID_SHA256_FINGERPRINTS;
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/.well-known/assetlinks.json",
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/packages/server/src/modules/platform/__tests__/well-known.routes.test.ts
+++ b/packages/server/src/modules/platform/__tests__/well-known.routes.test.ts
@@ -12,13 +12,26 @@ async function buildApp(): Promise<FastifyInstance> {
 
 describe(".well-known routes", () => {
   let app: FastifyInstance;
+  // Snapshot/restore MOBILE_* env so these tests don't leak state into others
+  // (Vitest runs files in a shared process by default).
+  let savedMobileEnv: Record<string, string | undefined> = {};
 
   beforeEach(async () => {
+    savedMobileEnv = {};
+    for (const k of Object.keys(process.env)) {
+      if (k.startsWith("MOBILE_")) savedMobileEnv[k] = process.env[k];
+    }
     app = await buildApp();
   });
 
   afterEach(async () => {
     await app.close();
+    for (const k of Object.keys(process.env)) {
+      if (k.startsWith("MOBILE_")) delete process.env[k];
+    }
+    for (const [k, v] of Object.entries(savedMobileEnv)) {
+      if (v !== undefined) process.env[k] = v;
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/server/src/modules/platform/index.ts
+++ b/packages/server/src/modules/platform/index.ts
@@ -5,6 +5,7 @@ import { adminUsersRoutes } from "./routes/admin-users.routes.js";
 import { adminInvitesRoutes } from "./routes/admin-invites.routes.js";
 import { adminSettingsRoutes } from "./routes/admin-settings.routes.js";
 import { settingsRoutes } from "./routes/settings.routes.js";
+import { wellKnownRoutes } from "./routes/well-known.routes.js";
 
 /**
  * Platform module — health, version, admin, settings.
@@ -14,6 +15,7 @@ import { settingsRoutes } from "./routes/settings.routes.js";
  * per-user settings under `/api/settings` to preserve the Express paths.
  */
 export const platformModule: FastifyPluginAsync = async (app) => {
+  await app.register(wellKnownRoutes);
   await app.register(versionRoutes);
   await app.register(healthRoutes);
 

--- a/packages/server/src/modules/platform/routes/well-known.routes.ts
+++ b/packages/server/src/modules/platform/routes/well-known.routes.ts
@@ -1,0 +1,56 @@
+import type { FastifyPluginAsync } from "fastify";
+
+/**
+ * .well-known routes for mobile platform binding.
+ *
+ * Both endpoints return 404 when the relevant MOBILE_* env vars are unset,
+ * so self-hosted Kryton servers without a mobile app don't expose empty or
+ * misleading metadata.
+ *
+ * iOS Universal Links + WebAuthn passkey RP allowlist:
+ *   MOBILE_IOS_TEAM_ID   — Apple Developer Team ID (e.g. ABCDE12345)
+ *   MOBILE_IOS_BUNDLE_ID — App bundle ID (e.g. com.kryton.mobile)
+ *
+ * Android App Links + Digital Asset Links credentials:
+ *   MOBILE_ANDROID_PACKAGE              — Android package name
+ *   MOBILE_ANDROID_SHA256_FINGERPRINTS  — Comma-separated SHA-256 cert fingerprints
+ */
+export const wellKnownRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/.well-known/apple-app-site-association", async (_req, reply) => {
+    const teamId = process.env.MOBILE_IOS_TEAM_ID;
+    const bundleId = process.env.MOBILE_IOS_BUNDLE_ID;
+    if (!teamId || !bundleId) return reply.code(404).send();
+    const appId = `${teamId}.${bundleId}`;
+    reply
+      .header("Content-Type", "application/json")
+      .header("Cache-Control", "public, max-age=3600")
+      .send({
+        applinks: {
+          details: [{ appIDs: [appId], components: [{ "/": "/*" }] }],
+        },
+        webcredentials: { apps: [appId] },
+      });
+  });
+
+  app.get("/.well-known/assetlinks.json", async (_req, reply) => {
+    const packageName = process.env.MOBILE_ANDROID_PACKAGE;
+    const fingerprintsCsv = process.env.MOBILE_ANDROID_SHA256_FINGERPRINTS;
+    if (!packageName || !fingerprintsCsv) return reply.code(404).send();
+    const fingerprints = fingerprintsCsv
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const target = {
+      namespace: "android_app",
+      package_name: packageName,
+      sha256_cert_fingerprints: fingerprints,
+    };
+    reply
+      .header("Content-Type", "application/json")
+      .header("Cache-Control", "public, max-age=3600")
+      .send([
+        { relation: ["delegate_permission/common.handle_all_urls"], target },
+        { relation: ["delegate_permission/common.get_login_creds"], target },
+      ]);
+  });
+};

--- a/packages/server/src/modules/plugins/routes/builtin-notes.routes.ts
+++ b/packages/server/src/modules/plugins/routes/builtin-notes.routes.ts
@@ -7,26 +7,13 @@ import { getUserNotesDir } from "../../notes/services/user-notes-dir.service.js"
 import { ValidationError } from "../../../lib/errors.js";
 import type { NotesOps } from "../services/types.js";
 import type { PluginEventBus } from "../services/event-bus.js";
+import { noteEntryListSchema } from "../schemas/index.js";
 
 export interface BuiltinNotesRoutesDeps {
   notesDir: string;
   notesOps: NotesOps;
   eventBus: PluginEventBus;
 }
-
-const noteEntrySchema: z.ZodType<{
-  name: string;
-  path: string;
-  type: "file" | "directory";
-  children?: unknown[];
-}> = z.lazy(() =>
-  z.object({
-    name: z.string(),
-    path: z.string(),
-    type: z.enum(["file", "directory"]),
-    children: z.array(noteEntrySchema).optional(),
-  }),
-) as never;
 
 const listQuerySchema = z.object({ folder: z.string().optional() });
 const pathQuerySchema = z.object({ path: z.string().min(1) });
@@ -72,7 +59,7 @@ export const builtinNotesRoutes = (
           tags: ["plugin-builtin"],
           summary: "List notes for the current user (optionally under a folder)",
           querystring: listQuerySchema,
-          response: { 200: z.array(noteEntrySchema) },
+          response: { 200: noteEntryListSchema },
         },
         preHandler: async (req) => {
           await app.auth.requireUser(req);

--- a/packages/server/src/modules/plugins/schemas/index.ts
+++ b/packages/server/src/modules/plugins/schemas/index.ts
@@ -1,0 +1,32 @@
+/**
+ * OpenAPI-registered schemas for the plugin-builtin API surface.
+ *
+ * `NoteEntry` is the plugin-facing file-tree node. It uses `type: "file" |
+ * "directory"` (vs the internal `FileTreeNode` which uses "folder") because
+ * plugin consumers have always received "directory" for folders.
+ */
+import { z } from "zod";
+import { sharedSchemaRegistry } from "../../../shared-schemas/index.js";
+
+// Recursive NoteEntry — must be defined as a forward-ref then registered.
+type NoteEntry = {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  children?: NoteEntry[];
+};
+
+const noteEntryBase: z.ZodType<NoteEntry> = z.lazy(() =>
+  z.object({
+    name: z.string(),
+    path: z.string(),
+    type: z.enum(["file", "directory"]),
+    children: z.array(noteEntryBase).optional(),
+  }),
+);
+
+export const noteEntrySchema = noteEntryBase.register(sharedSchemaRegistry, {
+  id: "NoteEntry",
+});
+
+export const noteEntryListSchema = z.array(noteEntrySchema);

--- a/packages/server/vitest.unit.config.ts
+++ b/packages/server/vitest.unit.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Lightweight config for unit tests that do not need a database.
+// Usage: npx vitest run --config vitest.unit.config.ts <path>
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+});

--- a/scripts/__tests__/release-sdk-publish.test.ts
+++ b/scripts/__tests__/release-sdk-publish.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { publishSdk } from "../release-sdk.js";
+
+describe("release SDK publish step", () => {
+  it("invokes npm publish with --access public for @azrtydxb/sdk", async () => {
+    const calls: string[] = [];
+    const fakeExec = (cmd: string) => {
+      calls.push(cmd);
+      return "";
+    };
+    await publishSdk({ exec: fakeExec, dryRun: false });
+    expect(calls).toContain("npm publish --access public --workspace=packages/sdk");
+  });
+
+  it("uses --dry-run when dryRun is true", async () => {
+    const calls: string[] = [];
+    const fakeExec = (cmd: string) => {
+      calls.push(cmd);
+      return "";
+    };
+    await publishSdk({ exec: fakeExec, dryRun: true });
+    expect(calls).toContain("npm publish --access public --dry-run --workspace=packages/sdk");
+  });
+});

--- a/scripts/release-sdk.js
+++ b/scripts/release-sdk.js
@@ -1,0 +1,21 @@
+import { execSync } from "node:child_process";
+
+/**
+ * Publish @azrtydxb/sdk to public npm.
+ * Called by scripts/release.js after the tag is created.
+ *
+ * @param {object} [opts]
+ * @param {(cmd: string) => string} [opts.exec]
+ * @param {boolean} [opts.dryRun]
+ */
+export async function publishSdk({
+  exec = (cmd) => execSync(cmd, { stdio: "inherit" }),
+  dryRun = false,
+} = {}) {
+  const flags = dryRun ? "--access public --dry-run" : "--access public";
+  exec(`npm publish ${flags} --workspace=packages/sdk`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await publishSdk({ dryRun: process.argv.includes("--dry-run") });
+}

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -2,6 +2,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { resolve } from "node:path";
+import { publishSdk } from "./release-sdk.js";
 
 const newVersion = process.argv[2];
 if (!newVersion || !/^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$/.test(newVersion)) {
@@ -74,5 +75,10 @@ exec("npm install");
 exec(`git add ${bumpedPackageFiles.join(" ")} ${sourceFiles.join(" ")} package-lock.json`);
 exec(`git commit -m "chore(release): v${newVersion}"`);
 exec(`git tag v${newVersion}`);
+
+// Publish @azrtydxb/sdk to public npm.
+const dryRun = process.argv.includes("--dry-run");
+await publishSdk({ dryRun });
+console.log(`✓ Published @azrtydxb/sdk`);
 
 console.log(`\nv${newVersion} ready. Push with: git push origin master --tags`);

--- a/site/src/content/docs/advanced/deployment/docker-compose.md
+++ b/site/src/content/docs/advanced/deployment/docker-compose.md
@@ -93,6 +93,39 @@ The full list of variables the server accepts is defined in `packages/server/src
 - `OPENAPI_ENABLED=true` — `/docs` serves OpenAPI UI. Set to `false` to hide it.
 - `WEBAUTHN_RP_ID=localhost` — set this to your bare hostname (e.g. `kryton.example.com`) before enabling passkeys in production.
 
+### Mobile app integration (optional)
+
+These variables enable the mobile-client binding features (Universal Links, Android App Links, mobile passkey ceremonies). All are optional — Kryton degrades gracefully when they are unset.
+
+**iOS**
+
+| Variable | Example | Purpose |
+|---|---|---|
+| `MOBILE_IOS_TEAM_ID` | `ABCDE12345` | Apple Developer Team ID. Required for `apple-app-site-association` (Universal Links + `webcredentials`). |
+| `MOBILE_IOS_BUNDLE_ID` | `com.kryton.mobile` | iOS bundle identifier. Also used as the WebAuthn passkey origin (`ios:bundle-id:…`). |
+
+**Android**
+
+| Variable | Example | Purpose |
+|---|---|---|
+| `MOBILE_ANDROID_PACKAGE` | `com.kryton.mobile` | Android package name. Required for `assetlinks.json` (App Links + login credentials). |
+| `MOBILE_ANDROID_SHA256_FINGERPRINTS` | `AA:BB:CC:…` | Comma-separated SHA-256 **certificate** fingerprints for `assetlinks.json`. This is the hash of the signing _certificate_ — **not** the same as `MOBILE_ANDROID_APK_KEY_HASH`. |
+| `MOBILE_ANDROID_APK_KEY_HASH` | `base64url…` | Base64url-encoded SHA-256 of the signing **public key**. Used as the WebAuthn passkey origin (`android:apk-key-hash:…`). Different from the certificate fingerprint — do not mix them up. Derive with: `keytool -exportcert -alias <alias> -keystore <ks> \| openssl dgst -sha256 -binary \| openssl base64 \| tr '+/' '-_' \| tr -d '='` |
+
+**Push notifications**
+
+Push notifications require both the APNs block (for iOS) and the FCM block (for Android) to be fully configured. Either block being absent disables dispatch for that platform.
+
+| Variable | Purpose |
+|---|---|
+| `APNS_KEY_ID` | APNs token-auth key ID (10-char, from Apple Developer portal). |
+| `APNS_TEAM_ID` | Apple Developer Team ID for APNs token auth. |
+| `APNS_BUNDLE_ID` | iOS app bundle ID for the APNs topic (e.g. `com.kryton.mobile`). |
+| `APNS_KEY_PATH` | Filesystem path to the APNs `.p8` private key file. |
+| `APNS_PRODUCTION` | `true` for the production APNs gateway, `false` (default) for sandbox. |
+| `FCM_SERVICE_ACCOUNT_PATH` | Path to the Firebase service account JSON key file. |
+| `FCM_PROJECT_ID` | Firebase project ID (e.g. `my-project-12345`). |
+
 ## What runs on boot
 
 The image's entrypoint (`entrypoint.sh`) is two lines:


### PR DESCRIPTION
## Summary

Phase 0 of the Kryton Mobile App implementation plan. Lays the kryton-repo groundwork the mobile client depends on: SDK published to public npm, push notification backend, mobile `.well-known` files, web client URL routes for canvas/plugin, mobile-friendly CSS on canvas/graph/plugin routes, and passkey origin allowlist for iOS/Android.

## Sub-phases

- **0a** — `@azrtydxb/sdk` made publishable, `publishSdk()` helper, NPM_TOKEN job in `release.yml`, `PUBLISHING.md`. First publish happens automatically on the next `v*` tag.
- **0b** — `push_devices` table, `POST/DELETE /api/push/register`, in-process notification bus, `GET /api/notifications/stream` SSE endpoint, APNs (`@parse/node-apn`) + FCM (`firebase-admin`) senders with permanent/transient error classification, dispatcher with auto-pruning of unregistered tokens.
- **0c** — `/.well-known/apple-app-site-association` + `assetlinks.json` routes (per-server, env-driven, 404 when unset), MOBILE_* env vars in Zod schema, docs, and `buildPasskeyOrigins()` accepting `ios:bundle-id:` + `android:apk-key-hash:`.
- **0d** — `useMobileEmbed` hook + mobile-embed CSS on `GraphPanel`, `EditModeView`, `PluginsTab`.
- **0e** — Canvas + plugin URL routes added to the existing `urlSchema` + `useUrlSync` (no react-router needed; matches the SPA's URL sync system).
- **Followup** — fixed `/api/plugin-builtin/notes/list` schema registration so `openapi-typescript` can regen the SDK.

## Test plan

- [ ] Server unit tests pass (notification bus, dispatcher, APNs/FCM senders, push routes, well-known routes, passkey origins, plugin schema)
- [ ] Client tests pass (useMobileEmbed, urlSchema canvas+plugin, useUrlSync wiring)
- [ ] `npm run openapi:dump --workspace=packages/server` succeeds
- [ ] `npm run generate --workspace=packages/sdk` succeeds and emits `/api/push/register` + `/api/notifications/stream` paths
- [ ] `npm pack --dry-run --workspace=packages/sdk` shows expected file list
- [ ] Manual: configure NPM_TOKEN repo secret, cut a `v*-pre.N` tag, verify the SDK publishes to https://www.npmjs.com/package/@azrtydxb/sdk

## Required before merge

- Set `NPM_TOKEN` repo secret (granular token scoped to `@azrtydxb/sdk` publish permission)