### PR TITLE
ci: route amd64 jobs to arc-azrtydxb-amd64 scale sets on novanas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,12 @@ on:
       - '.gitignore'
 
 # Cancel any in-progress run on the same branch when a new push lands.
-# The self-hosted runner pool is small (single 248 box, three runners),
-# and stacking two CI runs from the same PR — the second push and the
-# leftover first push — was hitting vitest worker-spawn timeouts and
-# fastify boot timeouts because the runner was CPU-starved. Cancelling
-# the older run frees the runner for the newest commit.
+# The self-hosted runner pool is finite (amd64 ARC scale set on novanas,
+# max 20 ephemeral pods), and stacking two CI runs from the same PR — the
+# second push and the leftover first push — was hitting vitest
+# worker-spawn timeouts and fastify boot timeouts because the runner was
+# CPU-starved. Cancelling the older run frees the runner for the newest
+# commit.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -51,7 +52,7 @@ env:
 
 jobs:
   typecheck:
-    runs-on: arc-azrtydxb
+    runs-on: arc-azrtydxb-amd64
     container:
       image: node:24
     steps:
@@ -70,7 +71,7 @@ jobs:
         run: chown -R 1001:1001 . || true
 
   lint:
-    runs-on: arc-azrtydxb
+    runs-on: arc-azrtydxb-amd64
     container:
       image: node:24
     steps:
@@ -91,7 +92,7 @@ jobs:
     # exercises the same workspace state the tests left behind and the
     # two share install/build:shared cost. Postgres lives here for the
     # unit-test suite.
-    runs-on: arc-azrtydxb
+    runs-on: arc-azrtydxb-amd64
     container:
       image: node:24
     services:
@@ -149,7 +150,7 @@ jobs:
     # operator/config/crd/bases/. Tolerates missing artifacts during
     # initial bring-up of the parallel workstreams that deliver them;
     # the gate activates retroactively as each surface lands.
-    runs-on: arc-azrtydxb
+    runs-on: arc-azrtydxb-amd64
     container:
       image: node:24
     steps:
@@ -165,7 +166,7 @@ jobs:
           set -euo pipefail
           apt-get update -qq
           apt-get install -y -qq --no-install-recommends curl ca-certificates
-          # arc-azrtydxb is ARM64 — pick the right arch instead of hard-coding amd64.
+          # arc-azrtydxb-amd64 is amd64, arc-azrtydxb is arm64 — pick the right arch instead of hard-coding either.
           case "$(uname -m)" in
             aarch64|arm64) ARCH=arm64 ;;
             x86_64) ARCH=amd64 ;;
@@ -210,7 +211,7 @@ jobs:
     # check is cheap and doesn't depend on the production build, only
     # on build:shared. Postgres is required because route registration
     # opens DB connections during spec extraction.
-    runs-on: arc-azrtydxb
+    runs-on: arc-azrtydxb-amd64
     container:
       image: node:24
     services:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,7 @@ jobs:
 
   build-amd64:
     needs: [typecheck, lint, test, e2e, build]
-    runs-on: arc-azrtydxb-publish
+    runs-on: arc-azrtydxb-amd64-publish
     permissions:
       contents: read
       packages: write
@@ -607,7 +607,7 @@ jobs:
 
   build-operator-amd64:
     needs: [typecheck, lint, test, e2e]
-    runs-on: arc-azrtydxb-publish
+    runs-on: arc-azrtydxb-amd64-publish
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

Routes amd64 jobs to a new ARC scale set running on the novanas k3s cluster (192.168.10.203). arm64 jobs continue to run on the KW ARC fleet (`arc-azrtydxb` / `arc-azrtydxb-publish`) unchanged.

**Changes in this repo:** kryton/ci.yml (5 jobs → arc-azrtydxb-amd64) + kryton/release.yml (build-amd64, build-operator-amd64 → arc-azrtydxb-amd64-publish)

The new scale sets are `arc-azrtydxb-amd64` (general CI) and `arc-azrtydxb-amd64-publish` (image build/push). Pod templates mirror the KW arm64 runners exactly — same DinD sidecar, cluster CA trust at `/etc/docker/certs.d/...`, buildx mTLS material at `/home/runner/.buildkit-certs/{ca.crt,tls.crt,tls.key}`, and the same `$BUILDKIT_AMD64_ENDPOINT` env var. Workflows port over without touching the buildx/docker glue.

amd64 jobs that delegate to remote BuildKit on 192.168.10.253 will keep working as-is. A follow-up cleanup can switch them to the local docker driver to skip the LAN mTLS round-trip (separate PR).

## Test plan

- [ ] CI runs to completion on the new amd64 runners
- [ ] Image builds (where present) produce digests and push to ghcr.io
- [ ] arm64 jobs continue to run on KW