### PR TITLE
fix(release): publish prerelease SDK under 'next' dist-tag

### DIFF
--- a/scripts/__tests__/release-sdk-publish.test.ts
+++ b/scripts/__tests__/release-sdk-publish.test.ts
@@ -1,15 +1,24 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import { publishSdk } from "../release-sdk.js";
 
+// publishSdk chooses the dist-tag from the SDK's own version: prereleases
+// (a `-pre.N` suffix) publish under `next`, stable versions under `latest`.
+// Mirror that here so the test stays correct as the SDK version changes.
+const sdkVersion: string = JSON.parse(
+  readFileSync(new URL("../../packages/sdk/package.json", import.meta.url), "utf8"),
+).version;
+const tag = sdkVersion.includes("-") ? "next" : "latest";
+
 describe("release SDK publish step", () => {
-  it("invokes npm publish with --access public for @azrtydxb/sdk", async () => {
+  it("publishes @azrtydxb/sdk with --access public and the right dist-tag", async () => {
     const calls: string[] = [];
     const fakeExec = (cmd: string) => {
       calls.push(cmd);
       return "";
     };
     await publishSdk({ exec: fakeExec, dryRun: false });
-    expect(calls).toContain("npm publish --access public --workspace=packages/sdk");
+    expect(calls).toContain(`npm publish --access public --tag ${tag} --workspace=packages/sdk`);
   });
 
   it("uses --dry-run when dryRun is true", async () => {
@@ -19,6 +28,8 @@ describe("release SDK publish step", () => {
       return "";
     };
     await publishSdk({ exec: fakeExec, dryRun: true });
-    expect(calls).toContain("npm publish --access public --dry-run --workspace=packages/sdk");
+    expect(calls).toContain(
+      `npm publish --access public --tag ${tag} --dry-run --workspace=packages/sdk`,
+    );
   });
 });

--- a/scripts/release-sdk.js
+++ b/scripts/release-sdk.js
@@ -1,8 +1,15 @@
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 /**
  * Publish @azrtydxb/sdk to public npm.
  * Called by scripts/release.js after the tag is created.
+ *
+ * npm refuses to publish a prerelease version (one with a `-pre.N` suffix)
+ * without an explicit `--tag`, since it must not move the default `latest`
+ * dist-tag. So prereleases publish under `next` and stable versions under
+ * `latest`. The version is read from the SDK's package.json (which the release
+ * flow keeps in sync with the git tag).
  *
  * @param {object} [opts]
  * @param {(cmd: string) => string} [opts.exec]
@@ -12,7 +19,10 @@ export async function publishSdk({
   exec = (cmd) => execSync(cmd, { stdio: "inherit" }),
   dryRun = false,
 } = {}) {
-  const flags = dryRun ? "--access public --dry-run" : "--access public";
+  const pkgUrl = new URL("../packages/sdk/package.json", import.meta.url);
+  const { version } = JSON.parse(readFileSync(pkgUrl, "utf8"));
+  const distTag = version.includes("-") ? "next" : "latest";
+  const flags = `--access public --tag ${distTag}${dryRun ? " --dry-run" : ""}`;
   exec(`npm publish ${flags} --workspace=packages/sdk`);
 }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -34,6 +34,9 @@ const packageFiles = [
   "packages/core/package.json",
   "packages/core-react/package.json",
   "packages/ui/package.json",
+  // The SDK is published to npm by the release step below, so its version must
+  // track the release tag (otherwise it would publish a stale version).
+  "packages/sdk/package.json",
 ].filter((f) => existsSync(resolve(f)));
 
 const bumpedPackageFiles = [];
@@ -50,6 +53,29 @@ for (const file of packageFiles) {
   writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
   bumpedPackageFiles.push(file);
   console.log(`bumped ${file} → ${newVersion}`);
+}
+
+// Workspace consumers pin `@azrtydxb/sdk` to an exact version. Now that the SDK
+// is bumped above, sync those pins to the new version so the `npm install` below
+// resolves to the local workspace SDK instead of fetching the old one.
+const sdkConsumerFiles = ["packages/client/package.json", "packages/server/package.json"].filter((f) =>
+  existsSync(resolve(f)),
+);
+for (const file of sdkConsumerFiles) {
+  const path = resolve(file);
+  const pkg = JSON.parse(readFileSync(path, "utf8"));
+  let changed = false;
+  for (const field of ["dependencies", "devDependencies"]) {
+    if (pkg[field]?.["@azrtydxb/sdk"] && pkg[field]["@azrtydxb/sdk"] !== newVersion) {
+      pkg[field]["@azrtydxb/sdk"] = newVersion;
+      changed = true;
+    }
+  }
+  if (changed) {
+    writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
+    bumpedPackageFiles.push(file);
+    console.log(`synced ${file} @azrtydxb/sdk → ${newVersion}`);
+  }
 }
 
 const sourceConstantUpdates = [


### PR DESCRIPTION
## Problem
The `publish-sdk` job in `release.yml` fails on every prerelease tag (`v*-pre.N`):

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

`scripts/release-sdk.js` ran `npm publish --access public` with no `--tag`; npm refuses this for prerelease versions so it won't move the `latest` dist-tag.

## Fix
Read the SDK version from `packages/sdk/package.json` and publish prereleases under `next`, stable versions under `latest`. Verified with `node scripts/release-sdk.js --dry-run` → "Publishing … with tag next and public access (dry-run)".

Surfaced while shipping v4.6.5-pre.15 (server session fix); that release otherwise fully succeeded — only this SDK-publish step failed.
